### PR TITLE
Docs: gateway runtime wiring

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -1,12 +1,13 @@
 # Architecture Overview
 
-This repository documents the current, implemented architecture of the Helianthus eBUS ecosystem. As of now, `helianthus-ebusgo` and `helianthus-ebusreg` contain the working transport, protocol, type system, registry, and vendor providers. `helianthus-ebusgateway` contains only package stubs (no GraphQL/MCP/mDNS/Matter behavior yet).
+This repository documents the current, implemented architecture of the Helianthus eBUS ecosystem. As of now, `helianthus-ebusgo` and `helianthus-ebusreg` contain the working transport, protocol, type system, registry, and vendor providers. `helianthus-ebusgateway` now wires transport, bus, registry, and router into a runnable gateway process; GraphQL/MCP/mDNS/Matter remain stubs (no API surface yet).
 
 ## Layered Architecture (Mermaid)
 
 ```mermaid
 flowchart TB
   subgraph Gateway
+    G0[Gateway runtime (wired)]
     G1[GraphQL stub]
     G2[MCP stub]
     G3[mDNS stub]
@@ -31,10 +32,14 @@ flowchart TB
     T3[ENS]
   end
 
-  G1 --> R1
-  G2 --> R1
-  G3 --> R1
-  G4 --> R1
+  G1 --> G0
+  G2 --> G0
+  G3 --> G0
+  G4 --> G0
+
+  G0 --> R1
+  G0 --> R3
+  G0 --> P1
 
   R3 --> P1
   R4 --> P2
@@ -42,6 +47,15 @@ flowchart TB
   T1 --> T2
   T1 --> T3
 ```
+
+## Gateway Runtime (Implemented)
+
+The gateway now provides a runtime wiring layer that instantiates the bus, registry, and router from a single config. It does not expose GraphQL/MCP/mDNS/Matter endpoints yet.
+
+- **Construction**: `New(ctx, cfg)` resolves a transport (provided or dialed), then builds a Bus, DeviceRegistry, and BusEventRouter.
+- **Startup**: `Start(ctx)` runs the Bus loop; cancellation stops the bus.
+- **Shutdown**: `Close()` closes the underlying transport connection (or the provided transport).
+- **Router refresh**: `RefreshRouterPlanes()` extracts `router.Plane` implementations from the registry and updates the router’s subscription table.
 
 ## Plane/Provider Model
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -2,14 +2,38 @@
 
 ## Current Status
 
-There is no runnable full-stack server yet. The gateway packages (`graphql`, `mcp`, `mdns`, `matter`) are stubs, and `cmd/gateway` contains an empty `main()`.
+`cmd/gateway` is runnable and wires transport, bus, registry, and router. The gateway packages (`graphql`, `mcp`, `mdns`, `matter`) remain stubs, so there is still no API surface.
 
 ## What Exists
 
 - `helianthus-ebusgo` and `helianthus-ebusreg` build and include unit tests.
-- `helianthus-ebusgateway` builds as a Go module but does not expose an API surface.
+- `helianthus-ebusgateway` includes a `cmd/gateway` runtime that connects to eBUS transport and runs the bus loop.
 
-## Build/Verify (Libraries Only)
+## Run Gateway (Wired Runtime)
+
+```bash
+# From helianthus-ebusgateway
+go run ./cmd/gateway --transport enh --network unix --address /var/run/ebusd/ebusd.socket
+```
+
+```bash
+# TCP example (ENS transport)
+go run ./cmd/gateway --transport ens --network tcp --address 127.0.0.1:8888
+```
+
+Flags (defaults shown):
+
+- `--transport` (`enh` or `ens`, default `enh`, case-insensitive; unknown value fails on startup)
+- `--network` (default `unix`)
+- `--address` (default `/var/run/ebusd/ebusd.socket`)
+- `--read-timeout` (default `5s`)
+- `--write-timeout` (default `5s`)
+- `--dial-timeout` (default `5s`)
+- `--queue-capacity` (default `0`, uses bus default)
+
+The gateway runs until `SIGINT`/`SIGTERM` and then closes the transport connection.
+
+## Build/Verify
 
 ```bash
 # In each repo root:

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -4,6 +4,32 @@
 
 This repository documents **implemented behavior** only. If a feature is not present in code, it should be described as not implemented rather than speculating.
 
+## Gateway Configuration (Implemented)
+
+The gateway runtime uses a Go config struct and CLI flags (see `deployment/full-stack.md`). There are no environment variables for gateway configuration yet.
+
+### Config Surface
+
+- `Config.Transport`: optional `transport.RawTransport`. If set, transport dialing is skipped and `Close()` calls `Transport.Close()`.
+- `Config.TransportConfig`: transport selection and dialing (`Protocol`, `Network`, `Address`, `ReadTimeout`, `WriteTimeout`, `DialTimeout`, optional `Dial` function).
+- `Config.BusConfig`: zero value uses `protocol.DefaultBusConfig()`.
+- `Config.QueueCapacity`: `0` uses the protocol default queue capacity.
+- `Config.Providers`: `registry.PlaneProvider` list used to populate planes on registry registration.
+
+### Transport Selection
+
+- If `Config.Transport` is provided, it is used directly.
+- Otherwise the gateway dials using `TransportConfig.Network` + `TransportConfig.Address` (both required).
+- `TransportConfig.Protocol` is case-insensitive: `enh` (or empty) selects ENH, `ens` selects ENS; any other value fails at startup.
+- Defaults from `DefaultConfig()`: `enh`, `unix`, `/var/run/ebusd/ebusd.socket`, and 5s timeouts.
+
+### Startup/Shutdown
+
+- `New(ctx, cfg)` resolves transport and constructs Bus, DeviceRegistry, and BusEventRouter.
+- `Start(ctx)` runs the bus loop; cancellation stops the bus.
+- `Close()` closes the underlying transport connection.
+- `RefreshRouterPlanes()` updates router subscriptions from planes registered in the registry.
+
 ## Dual License Model
 
 This documentation is split across two licenses:


### PR DESCRIPTION
## Summary
- Update architecture overview to reflect gateway runtime wiring and lifecycle.
- Add gateway run instructions and flags.
- Document gateway config surface and transport selection.

## Code Reference
- helianthus-ebusgateway commit: 234cb88

## Files Changed
- architecture/overview.md
- deployment/full-stack.md
- development/contributing.md
