### PR TITLE
Docs: GraphQL schema builder

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -2,8 +2,17 @@
 
 ## Current Status
 
-The GraphQL package exists as a stub only. There is no implemented schema, no queries, no mutations, and no subscriptions at this time.
+The GraphQL API surface is still **not** exposed (no server, queries, mutations, or subscriptions). However, a **dynamic schema builder** is now implemented and produces registry-driven schema snapshots.
 
-## Implemented Surface
+## Dynamic Schema Builder (Implemented)
 
-- None.
+The builder assembles a GraphQL-oriented schema model directly from the registry:
+
+- **Registry-driven types**: devices, planes, and methods are enumerated from the registry; each method includes frame primary/secondary bytes and a **response schema** (fields + data types) selected via the schema selector for the device’s address/hardware version.
+- **Rebuild on registry change**: `Start(ctx)` performs an initial build and listens on a `changes` channel; each signal triggers a rebuild. If no channel is provided, callers can trigger rebuilds via `Rebuild()`.
+- **Revisioned snapshots**: each successful rebuild increments a revision counter; `Schema()` returns a deep-copied snapshot to keep callers insulated from concurrent rebuilds.
+
+## Not Yet Implemented
+
+- No GraphQL server or resolvers.
+- No queries, mutations, or subscriptions exposed.

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -1,13 +1,14 @@
 # Architecture Overview
 
-This repository documents the current, implemented architecture of the Helianthus eBUS ecosystem. As of now, `helianthus-ebusgo` and `helianthus-ebusreg` contain the working transport, protocol, type system, registry, and vendor providers. `helianthus-ebusgateway` contains only package stubs (no GraphQL/MCP/mDNS/Matter behavior yet).
+This repository documents the current, implemented architecture of the Helianthus eBUS ecosystem. As of now, `helianthus-ebusgo` and `helianthus-ebusreg` contain the working transport, protocol, type system, registry, and vendor providers. `helianthus-ebusgateway` now wires transport, bus, registry, and router into a runnable gateway process; the GraphQL **schema builder** is implemented (no API surface yet), while MCP/mDNS/Matter remain stubs.
 
 ## Layered Architecture (Mermaid)
 
 ```mermaid
 flowchart TB
   subgraph Gateway
-    G1[GraphQL stub]
+    G0[Gateway runtime (wired)]
+    G1[GraphQL schema builder]
     G2[MCP stub]
     G3[mDNS stub]
     G4[Matter stub]
@@ -31,10 +32,14 @@ flowchart TB
     T3[ENS]
   end
 
-  G1 --> R1
-  G2 --> R1
-  G3 --> R1
-  G4 --> R1
+  G1 --> G0
+  G2 --> G0
+  G3 --> G0
+  G4 --> G0
+
+  G0 --> R1
+  G0 --> R3
+  G0 --> P1
 
   R3 --> P1
   R4 --> P2
@@ -42,6 +47,16 @@ flowchart TB
   T1 --> T2
   T1 --> T3
 ```
+
+## Gateway Runtime (Implemented)
+
+The gateway now provides a runtime wiring layer that instantiates the bus, registry, and router from a single config. It does not expose GraphQL/MCP/mDNS/Matter endpoints yet.
+
+- **Construction**: `New(ctx, cfg)` resolves a transport (provided or dialed), then builds a Bus, DeviceRegistry, and BusEventRouter.
+- **Startup**: `Start(ctx)` runs the Bus loop; cancellation stops the bus.
+- **Shutdown**: `Close()` closes the underlying transport connection (or the provided transport).
+- **Router refresh**: `RefreshRouterPlanes()` extracts `router.Plane` implementations from the registry and updates the router’s subscription table.
+- **GraphQL schema rebuild**: the schema builder consumes registry entries and rebuilds schema snapshots whenever a registry change signal is emitted.
 
 ## Plane/Provider Model
 


### PR DESCRIPTION
Updates docs for ebusgateway commit 6cbad2f (dynamic GraphQL schema builder).

Files:
- architecture/overview.md (gateway runtime + schema rebuild)
- api/graphql.md (builder behavior, snapshots)