### PR TITLE
docs: ENH direct transaction semantics

### DIFF
--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -48,4 +48,9 @@ EBUS_SMOKE=1 go run ./cmd/smoke
 3. Log discovered devices and compare against `expected_devices`.
 4. Invoke **read-only** methods for each discovered plane.
 
+Notes:
+
+- If `expected_devices` is empty/omitted, the harness performs a full scan over the default address range.
+- On a multi-master bus, arbitration collisions can occur during scan. The scan logic retries collided targets in later passes (bounded) instead of aborting the entire scan.
+
 The smoke test never writes to the bus.

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -41,6 +41,36 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 Idle periods may include `SYN` (`0xAA`) bytes on the bus; receivers typically ignore these while waiting for an `ACK`/`NACK`.
 
+## Transaction Flow (Direct Mode)
+
+The eBUS “direct” transaction flow used by ebusd-style implementations is:
+
+```mermaid
+sequenceDiagram
+  participant M as Master
+  participant S as Slave
+
+  Note over M,S: Master telegram (unescaped): SRC DST PB SB LEN DATA... CRC
+  M->>S: Send bytes (each byte is echoed on the bus)
+  S-->>M: ACK (0x00) or NACK (0xFF) after command CRC
+
+  alt Master/Slave + ACK
+    Note over M,S: Slave response: LEN DATA... CRC
+    S-->>M: Response payload
+    M-->>S: ACK (0x00) if CRC ok, else NACK (0xFF)
+  end
+
+  Note over M,S: End-of-message
+  M->>S: SYN (0xAA)
+```
+
+Key points:
+
+- **Per-byte echo**: When a master drives a symbol onto the bus it will also observe the same symbol (“echo”). An echo mismatch indicates arbitration loss or a collision.
+- **ACK/NAK timing**: `ACK`/`NACK` is exchanged **once per command**, after the master sends the command CRC (not after each byte).
+- **Response shape**: In master/slave transactions the slave response begins with a **length byte** and does not repeat source/target addresses.
+- **SYN** (`0xAA`) is used as an **end-of-message** delimiter and may also appear during idle.
+
 ## CRC8 and Escaping
 
 CRC8 is computed over the frame data with special handling for control symbols:
@@ -49,6 +79,11 @@ CRC8 is computed over the frame data with special handling for control symbols:
 - `0xAA` (SYN) is treated as `0xA9 0x01`
 
 This substitution is applied before CRC8 updates so that control symbols do not break framing.
+
+On the wire, the same escape mechanism is used when sending these control bytes:
+
+- Literal `0xA9` is encoded as `0xA9 0x00`
+- Literal `0xAA` is encoded as `0xA9 0x01`
 
 ## Example
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -56,6 +56,14 @@ For bytes `< 0x80`, the enhanced protocol allows receive notifications to be sen
 
 Receive data notifications are **not** sent for bytes that are part of an arbitration request initiated by the host. Implementations should not expect echo notifications for those arbitration bytes (typically the address bytes at the start of a master frame).
 
+## START/STARTED and the Source Byte
+
+When using `START`/`STARTED` to acquire the bus (arbitration), the adapter emits the **master source address** on the physical bus as part of that arbitration sequence.
+
+As a consequence, the first command telegram sent immediately after a successful `STARTED` does not need to re-send the `SRC` byte; it can begin at `DST`.
+
+This matches ebusd-style “direct” operation over ENH and explains why `SRC` echo notifications are typically absent right after arbitration.
+
 ## Example (Hex)
 
 ```text


### PR DESCRIPTION
Doc-gating update for recent Tier-1 changes (ENH/direct bus semantics + scan collision behavior).

- protocols/ebus-overview.md: document direct transaction flow (echo, ACK timing, response shape, SYN end-of-message) + wire escaping.
- protocols/enh.md: clarify START/STARTED arbitration effect on SRC byte.
- development/smoke-test.md: note full scan behavior + collision retry passes.