### PR TITLE
docs: Vaillant B5/05 SetOperationalData

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -70,7 +70,7 @@ Each Plane publishes:
 
 This keeps protocol mechanics (bus arbitration, ACK/NACK, retries) inside the Bus, while Planes focus purely on domain semantics.
 
-`DecodeResponse` receives the original `params` because some responses are **param-dependent** and cannot be decoded from the frame alone (e.g., op-coded request/response pairs). In Helianthus, this is commonly exposed as a result map containing the request selectors (e.g., `op`) plus the raw `payload`, with optional higher-level fields decoded for known op values (e.g., `0xB5 0x04` GetOperationalData decodes `op=0x00` as DateTime when present).
+`DecodeResponse` receives the original `params` because some responses are **param-dependent** and cannot be decoded from the frame alone (e.g., op-coded request/response pairs). In Helianthus, this is commonly exposed as a result map containing the request selectors (e.g., `op`) plus the raw `payload`, with optional higher-level fields decoded for known op values (e.g., Vaillant `0xB5 0x04` GetOperationalData and `0xB5 0x05` SetOperationalData use an `op` selector; GetOperationalData decodes `op=0x00` as DateTime when present).
 
 ### IOKit / IORegistry Parallels (Inspiration)
 

--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -6,7 +6,7 @@ This document lists Vaillant-family message identifiers and payload layouts that
 
 ```text
 0xB5 0x04  GetOperationalData (request parameter op; response is op-dependent)
-0xB5 0x05  Set target temperature (context-dependent request payload)
+0xB5 0x05  SetOperationalData (request parameter op + optional payload; response is op-dependent)
 0xB5 0x16  Energy statistics (request parameters: period/source/usage)
 0xFE 0x01  System-level broadcast (payload unspecified here)
 ```
@@ -65,6 +65,18 @@ Solar parameters (3 bytes):
 Simple status (1 byte):
   status : DATA1b
 ```
+
+## SetOperationalData (0xB5 0x05)
+
+The `0xB5 0x05` identifier is used for op-coded writes. The request payload starts with a 1-byte `op` selector, followed by an optional payload.
+
+```text
+Request payload (1+ bytes):
+  op      : byte
+  payload : bytes (optional)
+```
+
+Response payload is device/op-specific and may be empty (ack-only).
 
 ## Energy Statistics
 


### PR DESCRIPTION
Doc gating for helianthus-ebusreg PR #34 (SetOperationalData / B5/05).

- Update `protocols/vaillant.md` with the B5/05 request/response notes as currently implemented.

Source: `helianthus-ebusreg/vaillant/system` + tests in `helianthus-ebusreg/router/vaillant_operational_data_test.go`.