### PR TITLE
docs: Vaillant B5/16 energy statistics

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -124,6 +124,11 @@ flowchart LR
   R --> P3[Plane C]
 ```
 
+The router routes bus frames to subscribed planes via `Plane.OnBroadcast(frame)`. For frames that can be decoded into structured values, the router also exposes a typed event stream:
+
+- `BusEventRouter.Events()` is a buffered channel of `router.BroadcastEvent`.
+- If a plane implements the optional `router.BroadcastDecoder` interface, `HandleBroadcast(frame)` decodes and publishes a `BroadcastEvent` (non-blocking) alongside calling `OnBroadcast`.
+
 ### Request/Response (plane → bus → plane)
 
 ```mermaid

--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -7,7 +7,7 @@ This document lists Vaillant-family message identifiers and payload layouts that
 ```text
 0xB5 0x04  GetOperationalData (request parameter op; response is op-dependent)
 0xB5 0x05  SetOperationalData (request parameter op + optional payload; response is op-dependent)
-0xB5 0x16  Energy statistics (request parameters: period/source/usage)
+0xB5 0x16  Energy statistics (selector-encoded request; EXP Wh response)
 0xFE 0x01  System-level broadcast (payload unspecified here)
 ```
 
@@ -78,15 +78,57 @@ Request payload (1+ bytes):
 
 Response payload is device/op-specific and may be empty (ack-only).
 
-## Energy Statistics
+## Energy Statistics (0xB5 0x16)
 
-Energy statistics use primary/secondary `0xB5 0x16` and a 3-byte request payload:
+Energy statistics use primary/secondary `0xB5 0x16` and a selector-encoded payload. This format is reverse engineered from observed traffic (see `john30/ebusd-configuration` issue `#490`).
 
 ```text
-Request payload:
-  period : byte
-  source : byte
-  usage  : byte
+Request payload (8 bytes):
+  0: 0x10          constant prefix
+  1: 0x0X          period selector (X in low nibble)
+  2: 0xFF
+  3: 0xFF
+  4: 0x0Y          source selector (Y in low nibble)
+  5: 0x0Z          usage selector (Z in low nibble)
+  6: 0xWV          month/day selector (W high nibble, V low nibble)
+  7: 0x3Q          Q selector (Q in low nibble; high nibble observed as 0x3)
+
+Selectors (observed):
+  period X:
+    0 = all (since installation)
+    1 = day
+    2 = month
+    3 = year
+
+  source Y:
+    1 = solar
+    2 = environmental
+    3 = electricity
+    4 = gas
+    9 = heat_pump (unidentified, seen on some heat pumps)
+
+  usage Z:
+    0 = all
+    3 = heating
+    4 = hot water
+    5 = cooling
 ```
 
-Responses are a single `WORD` (2 bytes, little-endian).
+W/V/Q encoding is device-/regulator-dependent and was reverse engineered for Vaillant `ctlv2`-style regulators. In brief:
+
+- For X=0 (all): W/V/Q are ignored.
+- For X=3 (year): Q selects previous/current; W/V are ignored.
+- For X=2 (month): W selects month; Q selects previous/current year (encoding differs for months 1–7 vs 8–12); V is ignored.
+- For X=1 (day): only the last 16 days are available; W parity selects first/second half of the month; V selects day within that half; Q+W determine year/month.
+
+```text
+Response payload (11 bytes):
+  0: 0x0X          period selector (X in low nibble)
+  1: (unknown)
+  2: (unknown)
+  3: 0x0Y          source selector (Y in low nibble)
+  4: 0x0Z          usage selector (Z in low nibble)
+  5: 0xWV          month/day selector (W high nibble, V low nibble)
+  6: 0x3Q          Q selector (Q in low nibble; high nibble observed as 0x3)
+  7..10: EXP       Wh value (IEEE 754 float32, little-endian)
+```


### PR DESCRIPTION
Doc gating for helianthus-ebusreg#30 (PR #35): B5/16 energy statistics decode + typed broadcast events.

- Update `protocols/vaillant.md` with the selector-encoded request/response layout (reverse engineered; matches current implementation).
- Update `architecture/overview.md` to mention router typed broadcast events (`BusEventRouter.Events()` + optional `BroadcastDecoder`).