### PR TITLE
docs: Vaillant B5/09 register access

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -72,6 +72,8 @@ This keeps protocol mechanics (bus arbitration, ACK/NACK, retries) inside the Bu
 
 `DecodeResponse` receives the original `params` because some responses are **param-dependent** and cannot be decoded from the frame alone (e.g., op-coded request/response pairs). In Helianthus, this is commonly exposed as a result map containing the request selectors (e.g., `op`) plus the raw `payload`, with optional higher-level fields decoded for known op values (e.g., Vaillant `0xB5 0x04` GetOperationalData and `0xB5 0x05` SetOperationalData use an `op` selector; GetOperationalData decodes `op=0x00` as DateTime when present).
 
+Similarly, Vaillant `0xB5 0x09` register access uses a selector byte (`0x0D` read / `0x0E` write) plus a 16-bit address, so the original request parameters remain important context for decoding and labeling responses.
+
 ### IOKit / IORegistry Parallels (Inspiration)
 
 This model is inspired by how IOKit organizes devices and drivers in macOS:

--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -7,6 +7,7 @@ This document lists Vaillant-family message identifiers and payload layouts that
 ```text
 0xB5 0x04  GetOperationalData (request parameter op; response is op-dependent)
 0xB5 0x05  SetOperationalData (request parameter op + optional payload; response is op-dependent)
+0xB5 0x09  Register access (read/write selector + 16-bit address)
 0xB5 0x16  Energy statistics (selector-encoded request; EXP Wh response)
 0xFE 0x01  System-level broadcast (payload unspecified here)
 ```
@@ -77,6 +78,25 @@ Request payload (1+ bytes):
 ```
 
 Response payload is device/op-specific and may be empty (ack-only).
+
+## Register Access (0xB5 0x09)
+
+`0xB5 0x09` is used for register-like access using a selector byte plus a 16-bit address. The same primary/secondary is used for both reads and writes; the selector byte indicates the operation.
+
+```text
+Read request payload (3 bytes):
+  op      : 0x0D
+  addr_hi : byte
+  addr_lo : byte
+
+Write request payload (3+ bytes):
+  op      : 0x0E
+  addr_hi : byte
+  addr_lo : byte
+  data    : bytes (0+)
+```
+
+Response payload layout is device/register-specific. In some cases, a single `0x00` byte is observed instead of a typed value (commonly reported as “invalid position” by ebusd).
 
 ## Energy Statistics (0xB5 0x16)
 


### PR DESCRIPTION
Doc gating for helianthus-ebusreg#31 (PR #36): add B5/09 register access methods.

- Document wire format for B5/09 read/write selector + 16-bit address in `protocols/vaillant.md`.
- Note param-context importance in `architecture/overview.md`.