### PR TITLE
Document broadcast listener in smoke test

### DIFF
--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -2,12 +2,12 @@
 
 ## Current Status
 
-There is no runnable full-stack server yet. The gateway packages (`graphql`, `mcp`, `mdns`, `matter`) are stubs, and `cmd/gateway` contains an empty `main()`.
+There is no runnable full-stack server yet. The gateway packages (`graphql`, `mcp`, `mdns`, `matter`) exist, but `cmd/gateway` currently only starts the bus stack and does not serve HTTP endpoints.
 
 ## What Exists
 
 - `helianthus-ebusgo` and `helianthus-ebusreg` build and include unit tests.
-- `helianthus-ebusgateway` builds as a Go module but does not expose an API surface.
+- `helianthus-ebusgateway` builds as a Go module; `cmd/gateway` can optionally enable a **passive broadcast listener** (separate connection) for energy broadcasts.
 
 ## Build/Verify (Libraries Only)
 

--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -47,6 +47,8 @@ EBUS_SMOKE=1 go run ./cmd/smoke
 2. Scan the bus with a per-device timeout.
 3. Log discovered devices and compare against `expected_devices`.
 4. Invoke **read-only** methods for each discovered plane.
+5. Start a **passive broadcast listener** on a separate ENH/ENS connection after the scan.
+6. Log **semantic energy totals** as B516 broadcasts arrive (if present on the bus).
 
 Notes:
 


### PR DESCRIPTION
Fixes #19.

## Summary
- Note passive broadcast listener in smoke test behavior.
- Update full-stack status to mention broadcast listener support.
