### PR TITLE
Docs: Fix Vaillant B524 response + ebusd TCP hex framing

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -74,7 +74,7 @@ This keeps protocol mechanics (bus arbitration, ACK/NACK, retries) inside the Bu
 
 Similarly, Vaillant `0xB5 0x09` register access uses a selector byte (`0x0D` read / `0x0E` write) plus a 16-bit address, so the original request parameters remain important context for decoding and labeling responses.
 
-Vaillant `0xB5 0x24` extended register access follows the same pattern: requests include a fixed prefix (`0x02`), a read/write selector, a group/instance pair, and a 16-bit address. Responses are commonly interpreted by skipping the echoed 4-byte prefix before decoding the value bytes.
+Vaillant `0xB5 0x24` (“B524”) extended register access follows the same pattern: requests include an opcode family (`0x02`/`0x06`), a read/write selector, a group/instance pair, and a 16-bit register id. Responses do **not** echo the request selector; instead they begin with a 4-byte response header (`TT GG RR_LO RR_HI`) followed by optional value bytes. The instance id is not present in the response, so the original request parameters remain important context for correlating replies.
 
 ### IOKit / IORegistry Parallels (Inspiration)
 

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -92,3 +92,7 @@ SRC=0x10 DST=0x08 PB=0xB5 SB=0x04 LEN=0x01 DATA=0x7F CRC=0x??
 ```
 
 The CRC byte depends on the exact CRC8 implementation and the escape-aware substitution described above.
+
+## See Also
+
+- `protocols/ebusd-tcp.md` – ebusd daemon TCP command protocol (for tooling that sends direct-mode telegrams via ebusd).

--- a/protocols/ebusd-tcp.md
+++ b/protocols/ebusd-tcp.md
@@ -1,0 +1,72 @@
+# ebusd TCP Command Protocol (Observed)
+
+This document describes the ASCII command protocol exposed by the `ebusd` daemon over TCP (often on port `8888`). It is intended for tooling that drives eBUS transactions through ebusd rather than talking to an adapter directly.
+
+## Transport
+
+- Connection: plain TCP.
+- Encoding: ASCII text commands terminated by `\\n` (newline).
+- Responses: one or more newline-terminated text lines. Many versions terminate a response with a blank line.
+- Errors: response lines starting with `ERR:` indicate failures (timeouts, signal issues, parse errors, etc.).
+
+## `hex` Command
+
+`hex` sends a raw eBUS telegram (without CRC) and prints the response as hex.
+
+### Request
+
+```text
+hex <TELEGRAM_HEX>
+hex -s <SRC_HEX> <TELEGRAM_HEX>
+```
+
+Where `<TELEGRAM_HEX>` encodes:
+
+```text
+DST PB SB LEN DATA...
+```
+
+Notes:
+- The CRC byte is not included; ebusd computes it.
+- `LEN` is the number of bytes in `DATA...` (0..255) and must be included.
+- `<SRC_HEX>` overrides the source address for the command (optional; depends on ebusd configuration and permissions).
+
+Example (Vaillant B524 register read payload `02 00 03 00 16 00` to `DST=0x15`):
+
+```text
+hex 15B52406 020003001600
+```
+
+(Whitespace is optional; ebusd accepts plain hex.)
+
+### Response
+
+On success, ebusd typically returns a single hex line representing the **slave response bytes** as:
+
+```text
+LEN DATA...
+```
+
+Where the leading `LEN` is the eBUS response data length (not a B524 field). ebusd does not include the slave CRC byte in this output.
+
+Many B524 responses are easiest to parse by stripping this length prefix:
+
+- If the response bytes are `b0 b1 ... bn` and `b0 == n`, treat `b0` as a length prefix and strip it.
+- Example: response line `09030316004574616a00` parses to bytes:
+  - `0x09` length prefix (9 bytes of remaining data)
+  - B524 payload: `03 03 16 00 45 74 61 6a 00`
+
+Notes:
+- Some replies contain only a 1-byte payload (e.g. `01TT`), which becomes a single `TT` byte after stripping.
+- A response of `00` indicates an empty payload (length 0).
+
+### Errors and Multiline Responses
+
+If the first non-empty response line starts with `ERR:`, the command failed.
+
+Some ebusd versions may emit extra trailing lines after a valid hex payload line (including spurious `ERR:` lines). Tooling should treat the **first hex payload line** as authoritative and ignore any later lines once a valid payload has been parsed.
+
+## `info` Command
+
+`info` is a lightweight health/status command used by tooling to check daemon connectivity. Like `hex`, it may return `ERR:` lines on failure.
+

--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -8,7 +8,7 @@ This document lists Vaillant-family message identifiers and payload layouts that
 0xB5 0x04  GetOperationalData (request parameter op; response is op-dependent)
 0xB5 0x05  SetOperationalData (request parameter op + optional payload; response is op-dependent)
 0xB5 0x09  Register access (read/write selector + 16-bit address)
-0xB5 0x24  Extended register access (prefix + 16-bit address)
+0xB5 0x24  Extended register access (selector + 16-bit register id)
 0xB5 0x16  Energy statistics (selector-encoded request; EXP Wh response)
 0xFE 0x01  System-level broadcast (payload unspecified here)
 ```
@@ -110,28 +110,108 @@ Response payload layout is device/register-specific. In some cases, a single `0x
 
 ## Extended Register Access (0xB5 0x24)
 
-`0xB5 0x24` is used by Vaillant regulators (e.g., `ctlv2`) as an extended register-like access mechanism. Requests start with a 4-byte prefix and a 16-bit address.
+`0xB5 0x24` (often referred to as “B524”) is used by Vaillant regulators as a selector-based extended register mechanism. The request/response format is multiplexed by the first payload byte (`opcode`).
+
+This section documents the **payload bytes** inside an eBUS frame (not including eBUS CRC/escaping). When interacting via ebusd’s TCP `hex` command, note that ebusd typically prefixes the slave response with a 1-byte eBUS response length; see `protocols/ebusd-tcp.md`.
+
+### Directory Probe (opcode 0x00)
+
+The directory probe is used to enumerate groups (GG). Each request probes one group id and returns a float descriptor.
 
 ```text
-Read request payload (6 bytes):
-  0: 0x02          constant prefix
-  1: 0x00          read selector
-  2: group         byte
-  3: instance      byte
-  4: addr_hi       byte
-  5: addr_lo       byte
+Request payload (3 bytes):
+  0: 0x00          opcode (directory probe)
+  1: GG            group id
+  2: 0x00          padding
 
-Write request payload (6+ bytes):
-  0: 0x02          constant prefix
-  1: 0x01          write selector
-  2: group         byte
-  3: instance      byte
-  4: addr_hi       byte
-  5: addr_lo       byte
-  6..: data        bytes (0+)
+Response payload (4 bytes):
+  0..3: descriptor float32le
 ```
 
-Read responses are commonly observed with the first 4 bytes matching the prefix (`0x02 0x00 group instance`) followed by value bytes (many ebusd CSV definitions use `IGN:4` before decoding the value).
+Notes (observed):
+- The descriptor is an IEEE 754 `float32` (little-endian).
+- `NaN` is used as an end-of-directory marker.
+- `0.0` may appear for “holes” (unassigned group ids).
+
+### Register Read/Write (opcode 0x02 / 0x06)
+
+Register access uses two opcode families that share the same selector layout:
+
+- `0x02`: “local” register space (common for regulator-internal groups)
+- `0x06`: “remote” register space (commonly used for room sensor/remote groups)
+
+```text
+Request payload (read, 6 bytes; RR is little-endian u16):
+  0: opcode        0x02 (local) or 0x06 (remote)
+  1: optype        0x00 (read)
+  2: GG            group id
+  3: II            instance id
+  4: RR_LO         register id low byte
+  5: RR_HI         register id high byte
+
+Request payload (write, 6+ bytes):
+  0: opcode        0x02 (local) or 0x06 (remote)
+  1: optype        0x01 (write)
+  2: GG            group id
+  3: II            instance id
+  4: RR_LO
+  5: RR_HI
+  6..: value bytes
+
+Response payload (read, observed):
+  0: TT            reply kind / status
+  1: GG            group id (echo)
+  2: RR_LO         register id low byte (echo)
+  3: RR_HI         register id high byte (echo)
+  4..: value bytes (optional)
+```
+
+Notes (observed):
+- The response does **not** include `II` (instance) and does **not** echo the request opcode/optype.
+- Some replies are status-only and contain only `TT` (1 byte, no GG/RR/value bytes).
+- `TT` semantics (empirical):
+  - `0x00`: no data / not present / invalid
+  - `0x01`: live / operational value
+  - `0x02`: parameter / limit
+  - `0x03`: parameter / config
+
+### Timer Read/Write (opcode 0x03 / 0x04)
+
+Some Vaillant regulators expose timer schedules via B524 selector opcodes `0x03` and `0x04`.
+
+```text
+Request payload (read timer, 5 bytes):
+  0: 0x03          opcode (timer read)
+  1: SEL1          selector tuple byte 1
+  2: SEL2          selector tuple byte 2
+  3: SEL3          selector tuple byte 3
+  4: WD            weekday (0x00..0x06)
+
+Request payload (write timer, 5+ bytes):
+  0: 0x04          opcode (timer write)
+  1: SEL1
+  2: SEL2
+  3: SEL3
+  4: WD
+  5..: blocks      timer blocks (format device-/model-specific)
+```
+
+### Known Groups (Observed on VRC720-class Regulators)
+
+The directory probe descriptor (`float32le`) appears stable per group and can be used as a coarse group “type”. The table below lists observed groups and typical scan defaults used by Helianthus tooling.
+
+```text
+GG   Name                  Descriptor  Instanced  Typical opcode  Notes
+0x00 Regulator Parameters  3.0         no         0x02           RR extends beyond 0x00FF (seen up to 0x01FF)
+0x01 Hot Water Circuit     3.0         no         0x02
+0x02 Heating Circuits      1.0         yes        0x02
+0x03 Zones                 1.0         yes        0x02
+0x04 Solar Circuit         6.0         no         0x02
+0x05 Hot Water Cylinder    1.0         yes/varies 0x02           (instancing varies by model)
+0x09 Room Sensors          1.0         yes        0x06
+0x0A Room State            1.0         yes        0x06
+0x0C Unknown               1.0         yes        0x06
+```
 
 ## Energy Statistics (0xB5 0x16)
 


### PR DESCRIPTION
Changes:
- Correct Vaillant B524 request/response layouts (RR little-endian; response header is TT+GG+RR; status-only TT replies).
- Document B524 directory probe (0x00) and timer selector families (0x03/0x04).
- Add ebusd TCP command protocol notes for `hex` (telegram framing, response length prefix stripping, broadcast status responses, and parsing `info` output for slave addresses).
- Add discovery doc: BASV QueryExistence (0x07/0xFE), Identification (0x07/0x04), plus Vaillant scan.id chunks via 0xB5/0x09 (QQ=0x24..0x27).
- Update eBUS overview with master-address pattern and CRC8 specifics (poly 0x9B, init 0x00; master vs slave CRC coverage).
- Add ebusd CSV conventions doc (type specs + selector encodings) and expand type docs with encoding notes for DATA2b/DATA2c and BITFIELD.
- Update architecture overview to match observed B524 response shape.

Docs-gate followups opened:
- d3vi1/helianthus-ebusgateway#63
- d3vi1/helianthus-ebusgo#51
- d3vi1/helianthus-ebusreg#53
