### PR TITLE
Document projection graph core

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -142,14 +142,14 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Status:** Accepted
 
-**Context:** We need to represent device semantics as a graph that can be viewed through multiple planes (e.g., observability vs. automation) while preserving stable identity across those views.
+**Context:** We need to represent device semantics as a graph that can be viewed through multiple planes (e.g., observability vs. automation) while preserving stable identity across those views within a registration/snapshot.
 
-**Decision:** Introduce a projection-graph core in `ebusreg` where:
+**Decision:** Introduce a projection-graph core in `ebusreg` where, in Helianthus:
 
 - A projection is a plane-scoped graph (nodes + edges).
 - Each node has a plane-specific path and a canonical path in the `Service` plane.
-- Node IDs are stable and derived from the canonical Service-plane path.
+- Node IDs are derived from the canonical Service-plane path and are stable within a registration/snapshot.
 - Path format is `Plane:/segment/...` with `@name` marking location segments; plane and segment names disallow `/` and `:`, and segment names must be non-empty and not start with `@`.
 - Edges are validated to reference existing node IDs and have stable IDs (`Plane:from->to`).
 
-**Consequences:** Planes become explicit projections of the canonical Service graph, enabling deterministic identity across planes, consistent path validation, and safe graph composition for higher-level APIs.
+**Consequences:** Planes become explicit projections of the canonical Service graph (Helianthus-specific), enabling deterministic identity across planes within a snapshot, consistent path validation, and safe graph composition for higher-level APIs.

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -80,13 +80,13 @@ See also: `architecture/vaillant.md` for higher-level notes on how Vaillant’s 
 
 ## Projection Graph Core
 
-The registry also supports **projection graphs** attached to a DeviceEntry. A `PlaneProvider` may additionally implement `ProjectionProvider` to emit one or more `Projection` objects alongside its planes. Each projection is a plane-scoped graph (nodes + edges) that represents a **projection** of the canonical Service plane.
+The registry also supports **projection graphs** attached to a DeviceEntry. A `PlaneProvider` may additionally implement `ProjectionProvider` to emit one or more `Projection` objects alongside its planes. In Helianthus, each projection is a plane-scoped graph (nodes + edges) that represents a **projection** of the canonical Service plane.
 
 ### Planes as Projections
 
-- The **Service** plane is canonical. Every node has a canonical Service-plane path that defines its stable identity.
+- The **Service** plane is canonical. Every node has a canonical Service-plane path that defines its identity.
 - Other planes (e.g., `Observability`, `Automation`) are **projections** of the same nodes into plane-specific paths.
-- Node IDs are **stable** and derived from the canonical Service path, so the same node can be recognized across multiple planes.
+- Node IDs are derived from the canonical Service path and are stable **within a registration/snapshot**, so the same node can be recognized across multiple planes in that snapshot.
 
 ### Path Semantics
 
@@ -110,8 +110,8 @@ This model is inspired by how IOKit organizes devices and drivers in macOS:
 
 - **DeviceRegistry ≈ IORegistry**: a central registry of discovered devices and their properties.
 - **PlaneProvider ≈ driver matching/attachment**: a provider matches a device and attaches logical functionality.
-- **Plane ≈ IOService instance**: a plane is a semantic service view derived from the same hardware device.
-- **Multiple Planes per device ≈ multiple IORegistry planes**: a single device can appear in multiple logical planes (heating, DHW, system) without duplicating the underlying physical identity.
+- **Plane (Helianthus) ≠ IORegistry plane**: Helianthus planes are **global relationship views**; every entry exists in all planes (with different paths), whereas IORegistry planes are separate organizational views over the same registry.
+- **Multiple Planes per device ≈ multiple IORegistry planes (conceptual)**: a single device can appear in multiple logical views without duplicating the underlying physical identity.
 
 The mapping is conceptual (not API-identical), used to keep a clean separation between discovery, matching, and the semantic surface.
 


### PR DESCRIPTION
## Summary
- document projection graph core (planes as projections, path semantics, invariants)
- add ADR-014 for Service-plane canonical paths
- aligns docs with helianthus-ebusreg PR #54

## Testing
- not run (docs-only)