### PR TITLE
docs: Vaillant projection mapping + B524 discovery profile

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -104,6 +104,31 @@ The registry also supports **projection graphs** attached to a DeviceEntry. A `P
 - Node paths are unique within a projection; node IDs may repeat only when they map to the **same** canonical path.
 - Edge IDs are stable (`Plane:from->to`) and edges must reference existing node IDs.
 
+### Vaillant Projection Mapping (System Provider)
+
+The Vaillant system provider in `ebusreg` emits projections for a small set of known device IDs and maps Vaillant-specific operations into standardized projection paths.
+
+- **Eligible devices:** normalized `DeviceID` values `BASV2`, `BAI00`, `VR71` (case/spacing/`_`/`-` normalized).
+- **Base path:** `Service:/ebus/addr@XX/device@<DeviceID>` where `XX` is the hex bus address; if the device ID is missing, the address is used as the device segment.
+- **Always-emitted planes:** `Service`, `Observability`, `Debug`.
+- **Conditional root planes:** `System`, `Heating`, `DHW`, `Solar` (only if the corresponding plane exists for that device).
+
+Nodes and edges are created as follows:
+
+- **Service plane:** root node + `method@get_operational_data` node, edge `root → method`.
+- **Observability plane:** root node + `method@get_operational_data` node, edge `root → method`.
+- **Debug plane:** root node + `register@b509` and `register@b524` nodes, edges `root → register@b509` and `root → register@b524`.
+  - `register@b509` maps to canonical `Service:/.../method@get_register` (B5/09).
+  - `register@b524` maps to canonical `Service:/.../method@get_ext_register` (B5/24).
+
+Example paths:
+
+```text
+Service:/ebus/addr@10/device@BASV2/method@get_operational_data
+Observability:/ebus/addr@10/device@BASV2/method@get_operational_data
+Debug:/ebus/addr@10/device@BASV2/register@b524
+```
+
 ### IOKit / IORegistry Parallels (Inspiration)
 
 This model is inspired by how IOKit organizes devices and drivers in macOS:

--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -219,6 +219,19 @@ GG   Name                  Descriptor  Instanced  Typical opcode  Notes
 0x0C Unknown               1.0         yes        0x06
 ```
 
+### B524 Discovery Profile (Helianthus)
+
+Helianthus uses a static discovery profile to bound B524 group scans. Each entry specifies the opcode family and the **inclusive** upper limits for instance id and register id when probing a group. The directory probe should still be used to verify group presence; these are defaults based on observed VRC720-class regulators.
+
+```text
+GG   Opcode  InstanceMax  RegisterMax  Notes
+0x02 0x02    0x0A         0x0021       Heating circuits (local)
+0x03 0x02    0x0A         0x002F       Zones (local)
+0x09 0x06    0x0A         0x002F       Room sensors (remote)
+0x0A 0x06    0x0A         0x003F       Room state (remote)
+0x0C 0x06    0x0A         0x003F       Unknown (remote)
+```
+
 ## Energy Statistics (0xB5 0x16)
 
 Energy statistics use primary/secondary `0xB5 0x16` and a selector-encoded payload. This format is reverse engineered from observed traffic (see `john30/ebusd-configuration` issue `#490`).


### PR DESCRIPTION
## Summary
- document Vaillant system provider projection mapping and projection paths
- add B524 discovery profile defaults (groups/opcodes/instance/register limits)

## Testing
- not run (docs-only)

Relates to d3vi1/helianthus-ebusreg#55