### PR TITLE
docs: document B5/04 op=0x00 layouts

### DIFF
--- a/protocols/vaillant.md
+++ b/protocols/vaillant.md
@@ -24,18 +24,29 @@ Request payload (1 byte):
 
 ### op = 0x00 (DateTime)
 
-If present, the response payload can be decoded as:
+Two response layouts are currently observed and supported. The decoder uses `dcfstate`, `time_hour`, `time_minute`, `date_day`, `date_month`, `date_year`, and `temp` in both cases. Seconds (layout A) and weekday (layout A) are present on the wire but currently ignored by the decoder.
 
 ```text
-DateTime (10 bytes):
+DateTime layout A (BTI/BDA + temp2, 10 bytes):
   dcfstate      : byte
-  time_second   : BCD  (BTI[0] on wire, SS,MM,HH)
+  time_second   : BCD  (BTI[0] on wire, SS,MM,HH) [ignored]
   time_minute   : BCD  (BTI[1])
   time_hour     : BCD  (BTI[2])
   date_day      : BCD  (BDA[0] on wire, DD,MM,<weekday>,YY)
   date_month    : BCD  (BDA[1])
-  date_weekday  : byte (BDA[2], typically ignored)
+  date_weekday  : byte (BDA[2]) [ignored]
   date_year     : BCD  (BDA[3])
+  temp          : DATA2b (temp2)
+```
+
+```text
+DateTime layout B (legacy, 8 bytes):
+  dcfstate      : byte
+  time_hour     : BCD
+  time_minute   : BCD
+  date_day      : BCD
+  date_month    : BCD
+  date_year     : BCD
   temp          : DATA2b (temp2)
 ```
 


### PR DESCRIPTION
## Summary
- Document both DateTime response layouts for `0xB5 0x04` op=0x00 (BTI/BDA+temp2 with dcfstate, legacy 8-byte)
- Note seconds/weekday are present on wire but currently ignored by decoder

## References
- ebusreg#53

## Agent State
Status: Ready for review
Branch: docs/vaillant-b5-04-datetime-layouts
Last verified (lint/tests): not run (docs-only)
How to reproduce: Review `protocols/vaillant.md` op=0x00 DateTime section
Next steps: Review and merge
Notes (no secrets, no private infra): none