### PR TITLE
docs: portal API + UI overview

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -232,7 +232,35 @@ Accept: application/json
 }
 ```
 
-### Projection Snapshot Endpoint
+## Portal API (Projection UI)
+
+The portal UI consumes projection graphs to render plane-scoped views. It can either fetch **all projections** via GraphQL or request a **single plane** via the snapshot endpoint.
+
+### GraphQL projection query
+
+```graphql
+query PortalProjections {
+  devices {
+    address
+    manufacturer
+    deviceId
+    projections {
+      plane
+      nodes { id path canonicalPath }
+      edges { id from to }
+    }
+  }
+}
+```
+
+**Notes**
+
+- `Projection.plane` is the plane label shown in the portal plane picker.
+- `ProjectionNode.id` is the canonical Service path for the node, so it is stable across planes within a snapshot.
+- `ProjectionNode.path` is the plane-specific path shown in the UI.
+- `ProjectionNode.canonicalPath` is the Service-plane path used to correlate nodes across planes.
+
+### Projection snapshot endpoint
 
 The gateway exposes a lightweight HTTP endpoint to fetch a single projection graph from the latest schema snapshot (outside GraphQL). The default path is `/snapshot` and can be configured via `-snapshot-path`.
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -121,6 +121,31 @@ The Helianthus Portal UI renders projection graphs and cross-plane views using a
 - **Identity**: `ProjectionNode.id` is derived from the `Service`-plane canonical path, so the same node ID appears across planes when they represent the same canonical entity.
 - **Display vs. join**: `path` is used for plane-local display; `canonicalPath` is used to align nodes across planes and to compute diffs between snapshots.
 
+### Portal UI (Projection Browser)
+
+The gateway serves a read-only portal UI at `cfg.UIPath` (default `/ui`). The portal polls the GraphQL endpoint for devices and their projection graphs, then renders:
+
+- A device list (address + manufacturer + device ID).
+- A plane selector (canonical planes plus any device-specific planes).
+- A graph view for the current plane, plus a node detail card (ID, plane path, canonical path).
+
+Node identity is derived from the canonical Service path, so the same logical node can be correlated across planes within a snapshot. This is what enables **plane switching** without losing identity when a node exists in multiple plane projections.
+
+#### Plane Switching (Mermaid)
+
+```mermaid
+sequenceDiagram
+  participant UI as Portal UI
+  participant P1 as Projection (Observability)
+  participant P2 as Projection (Service)
+  UI->>P1: select node
+  P1-->>UI: node.id + canonicalPath
+  UI->>P2: switch plane (Service)
+  UI->>P2: find node by canonicalPath
+  P2-->>UI: node or not found
+  UI-->>UI: highlight node or clear selection
+```
+
 ### Vaillant Projection Mapping (System Provider)
 
 The Vaillant system provider in `ebusreg` emits projections for a small set of known device IDs and maps Vaillant-specific operations into standardized projection paths.


### PR DESCRIPTION
## Summary
- document portal projection API (GraphQL + snapshot)
- describe portal UI and plane switching
- add plane-switching mermaid diagram

Closes #44
