### PR TITLE
Docs: portal UI + mDNS discovery

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -232,9 +232,9 @@ Accept: application/json
 }
 ```
 
-## Portal API (Projection UI)
+## Portal UI (Projection Explorer)
 
-The portal UI consumes projection graphs to render plane-scoped views. It can either fetch **all projections** via GraphQL or request a **single plane** via the snapshot endpoint.
+The portal UI is a read-only projection explorer (default path: `/ui`). It uses a single GraphQL query to fetch projections for all devices, then renders the device list, plane picker, projection graph, and node details. The UI auto-refreshes on an interval (default 5s) and exposes manual refresh + pause/resume controls.
 
 ### GraphQL projection query
 
@@ -255,14 +255,14 @@ query PortalProjections {
 
 **Notes**
 
-- `Projection.plane` is the plane label shown in the portal plane picker.
+- `Projection.plane` is the plane label shown in the portal plane picker (ordered with defaults `Service`, `Observability`, `Debug`, `Virtual`, then any device-specific planes).
 - `ProjectionNode.id` is the canonical Service path for the node, so it is stable across planes within a snapshot.
 - `ProjectionNode.path` is the plane-specific path shown in the UI.
 - `ProjectionNode.canonicalPath` is the Service-plane path used to correlate nodes across planes.
 
 ### Projection snapshot endpoint
 
-The gateway exposes a lightweight HTTP endpoint to fetch a single projection graph from the latest schema snapshot (outside GraphQL). The default path is `/snapshot` and can be configured via `-snapshot-path`.
+The gateway exposes a lightweight HTTP endpoint to fetch a single projection graph from the latest schema snapshot (outside GraphQL). The portal UI uses GraphQL; the snapshot endpoint is intended for lightweight or plane-specific clients. The default path is `/snapshot` and can be configured via `-snapshot-path`.
 
 **Request**
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -10,9 +10,23 @@
 - `helianthus-ebusgateway` builds as a Go module and serves:
   - GraphQL queries/mutations: `/graphql`
   - GraphQL subscriptions (SSE/WS): `/graphql/subscriptions`
+  - Projection snapshot endpoint: `/snapshot`
   - MCP endpoint: `/mcp`
-- mDNS advertisement: `_helianthus-graphql._tcp` with TXT `path=/graphql`
+  - Portal UI (read-only projection explorer): `/ui`
+- mDNS advertisement for the GraphQL endpoint (see mDNS Discovery below).
 - `cmd/gateway` can optionally enable a **passive broadcast listener** (separate connection) for energy broadcasts.
+
+## mDNS Discovery
+
+When `-mdns` is enabled (default), the gateway advertises its GraphQL endpoint via DNS-SD:
+
+- **Service type:** `_helianthus-graphql._tcp` (domain `local.`)
+- **Instance name:** `-mdns-instance` (default `helianthus`)
+- **Port:** the HTTP listener port
+- **TXT records:**
+  - `path`: HTTP path for GraphQL (default `-mdns-path` or `-graphql-path`, e.g. `/graphql`)
+  - `version`: discovery schema version (default `1`)
+  - `transport`: endpoint transport (default `http`)
 
 ## Build/Verify (Libraries Only)
 


### PR DESCRIPTION
Fixes #40.

- document portal UI behavior and projection explorer details
- add mDNS discovery section with TXT fields
- note snapshot endpoint vs GraphQL usage

Tests: not run (docs-only)