### PR TITLE
docs: add projection + IORegistry portal semantics

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -167,3 +167,29 @@ This document records the architectural decisions implemented in the codebase. E
 - `ProjectionNode.id` is derived from the canonical Service path so nodes can be correlated across planes; `path` is used for plane-local display.
 
 **Consequences:** Planes become explicit projections of the canonical Service graph (Helianthus-specific), enabling deterministic identity across planes within a snapshot, consistent path validation, and safe graph composition for higher-level APIs.
+
+## ADR-015: Portal consumes projections as plane-scoped graphs (IORegistry-style semantics)
+
+**Status:** Accepted
+
+**Context:** The portal needs deterministic behavior when switching planes (for example `Service` → `Observability` → `Debug`) without losing canonical node identity. Plane-level rendering and cross-plane correlation must remain explicit for API consumers.
+
+**Decision:**
+
+- Treat projection payloads as a strict mapping of `plane -> {nodes, edges}`.
+- Render only the currently selected plane graph; do not merge edges across planes.
+- Preserve selected node identity via canonical `Service` path (`canonicalPath`) when switching planes.
+- Resolve selection in the target plane by canonical path (or clear selection if no mapped node exists).
+- Keep node IDs canonical-path-derived so the same canonical entity can be joined across planes in one snapshot.
+
+**Examples (canonical paths across planes):**
+
+- `Service:/ebus/addr@10/device@BASV2/method@get_operational_data`
+- `Observability:/ebus/addr@10/device@BASV2/method@get_operational_data`
+- `Debug:/ebus/addr@10/device@BASV2/register@b524` → canonical `Service:/ebus/addr@10/device@BASV2/method@get_ext_register`
+
+**Portal query expectation:**
+
+- `devices { projections { plane nodes { id path canonicalPath } edges { id from to } } }`
+
+**Consequences:** API and UI consumers get a stable, IORegistry-style multi-plane browsing model with canonical identity joins, explicit plane-local edges, and predictable plane-switch behavior.

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -96,6 +96,14 @@ Projections are **multi-dimensional** views of the same canonical graph:
 - **Canonical dimension**: each node carries a `CanonicalPath` in the `Service` plane, and the node ID is derived from that canonical path.
 - **Cross-plane correlation**: nodes in different planes with the same `CanonicalPath` (and thus the same node ID) represent the same canonical entity; edges are plane-local and never connect nodes across planes.
 
+### Canonical Path Examples Across Planes
+
+| Plane | Path | CanonicalPath | Correlation rule |
+|---|---|---|---|
+| `Service` | `Service:/ebus/addr@10/device@BASV2/method@get_operational_data` | `Service:/ebus/addr@10/device@BASV2/method@get_operational_data` | Canonical node definition |
+| `Observability` | `Observability:/ebus/addr@10/device@BASV2/method@get_operational_data` | `Service:/ebus/addr@10/device@BASV2/method@get_operational_data` | Same canonical path ⇒ same node ID as `Service` |
+| `Debug` | `Debug:/ebus/addr@10/device@BASV2/register@b524` | `Service:/ebus/addr@10/device@BASV2/method@get_ext_register` | Debug-specific path mapped to canonical service method |
+
 ### Path Semantics
 
 - Path format: `Plane:/segment/segment/@location`
@@ -118,8 +126,10 @@ Projections are **multi-dimensional** views of the same canonical graph:
 The Helianthus Portal UI renders projection graphs and cross-plane views using a single GraphQL query and expects specific fields to be present and stable:
 
 - **Query shape** (example name: `PortalProjections`): `devices { address manufacturer deviceId projections { plane nodes { id path canonicalPath } edges { id from to } } }`
+- **Plane graph contract**: each `projections[]` entry is one plane-scoped graph where `plane -> nodes/edges`; clients render exactly one selected plane at a time.
 - **Identity**: `ProjectionNode.id` is derived from the `Service`-plane canonical path, so the same node ID appears across planes when they represent the same canonical entity.
-- **Display vs. join**: `path` is used for plane-local display; `canonicalPath` is used to align nodes across planes and to compute diffs between snapshots.
+- **Display vs. join**: `path` is plane-local display data; `canonicalPath` is the join key used for cross-plane correlation and snapshot diffs.
+- **Plane switching**: preserve the selected node’s `canonicalPath`, switch plane, then resolve the target node by canonical path (or clear selection when absent in that plane).
 
 ### Portal UI (Projection Browser)
 
@@ -177,7 +187,7 @@ This model is inspired by how IOKit organizes devices and drivers in macOS:
 
 - **DeviceRegistry ≈ IORegistry**: a central registry of discovered devices and their properties.
 - **PlaneProvider ≈ driver matching/attachment**: a provider matches a device and attaches logical functionality.
-- **Plane (Helianthus) ≠ IORegistry plane**: Helianthus planes are **global relationship views**; every entry exists in all planes (with different paths), whereas IORegistry planes are separate organizational views over the same registry.
+- **Plane (Helianthus) ≈ IORegistry-style view**: each plane is a view over the same canonical entities, but node membership is plane-specific (a node may exist in one plane and be absent in another).
 - **Multiple Planes per device ≈ multiple IORegistry planes (conceptual)**: a single device can appear in multiple logical views without duplicating the underlying physical identity.
 
 The mapping is conceptual (not API-identical), used to keep a clean separation between discovery, matching, and the semantic surface.


### PR DESCRIPTION
## Summary
- update `architecture/overview.md` with sharper multi-dimensional projection semantics
- add canonical path examples across planes (`Service`, `Observability`, `Debug`) with explicit canonical mapping rules
- document portal query expectations as a strict `plane -> {nodes, edges}` contract and required plane-switch behavior (`canonicalPath`-based correlation)
- refine IORegistry-style wording to reflect plane-specific node membership
- add `ADR-015` in `architecture/decisions.md` to capture portal-side projection semantics and canonical identity rules

## Acceptance mapping
- [x] Update `architecture/overview.md` with multi-plane projection semantics
- [x] Update `architecture/decisions.md` with new ADR (`ADR-015`)
- [x] Include examples showing canonical paths across planes
- [x] Document portal query expectations (plane → nodes/edges)
- [x] CI green (docs-only checks expected)

Closes #37

@codex review
