### PR TITLE
docs: document ebusd-tcp backend usage for gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository documents the current, implemented behavior of the Helianthus eB
 Implementation-neutral references for the eBUS wire protocol and data types live under `protocols/` and `types/`. Helianthus-specific architecture, APIs, and deployment notes live elsewhere in the tree.
 
 For Home Assistant onboarding and GraphQL capability expectations, see `development/ha-integration.md`.
+For ebusd command-backend usage (gateway transport selection + protocol behavior), see `deployment/full-stack.md` and `protocols/ebusd-tcp.md`.
 
 ## Documentation Gate
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -16,6 +16,60 @@
 - mDNS advertisement for the GraphQL endpoint (see mDNS Discovery below).
 - `cmd/gateway` can optionally enable a **passive broadcast listener** (separate connection) for energy broadcasts.
 
+## Gateway Transport Backend Selection
+
+`cmd/gateway` selects the eBUS transport backend via CLI flags:
+
+| Flag | Purpose | Notes |
+|---|---|---|
+| `-transport` | Backend protocol | `enh`, `ens`, or `ebusd-tcp` |
+| `-network` | Dial network | `unix` or `tcp` |
+| `-address` | Socket path or host:port | Example: `/var/run/ebusd/ebusd.socket` or `127.0.0.1:8888` |
+| `-read-timeout` | Read timeout | Default `5s` |
+| `-write-timeout` | Write timeout | Default `5s` |
+| `-dial-timeout` | Connect timeout | Default `5s` |
+
+### Example Transport Configurations
+
+```bash
+# ENH over unix socket (default-style setup)
+go run ./cmd/gateway \
+  -transport enh \
+  -network unix \
+  -address /var/run/ebusd/ebusd.socket
+
+# ENS over TCP adapter
+go run ./cmd/gateway \
+  -transport ens \
+  -network tcp \
+  -address 127.0.0.1:9999
+
+# ebusd command backend over TCP
+go run ./cmd/gateway \
+  -transport ebusd-tcp \
+  -network tcp \
+  -address 127.0.0.1:8888
+```
+
+For ebusd command syntax and response framing details, see `protocols/ebusd-tcp.md`.
+
+## ebusd-tcp Backend Notes (Gateway)
+
+When `-transport ebusd-tcp` is selected, the gateway uses ebusd's text command channel (typically port `8888`) and executes request/response traffic via `hex` commands.
+
+### Limitations
+
+- The ebusd command backend is request/response oriented; it is not a continuous bus sniff stream.
+- Broadcast sends (`DST=0xFE`) may return textual completion (for example `done ...`) with no hex payload.
+- The optional passive broadcast listener (`-broadcast`) expects stream-style frame input; this is generally not useful with ebusd command-mode connections.
+
+### Error Behavior
+
+- `ERR:` lines with timeout/no-answer wording are treated as timeouts.
+- Other `ERR:` lines (or malformed hex/usage responses) are treated as invalid payload errors.
+- If multiple lines are returned, parsers should use the first valid hex payload line and ignore later trailing noise.
+- Empty/no non-empty response lines are treated as timeout conditions.
+
 ## mDNS Discovery
 
 When `-mdns` is enabled (default), the gateway advertises its GraphQL endpoint via DNS-SD:

--- a/protocols/ebusd-tcp.md
+++ b/protocols/ebusd-tcp.md
@@ -2,6 +2,8 @@
 
 This document describes the ASCII command protocol exposed by the `ebusd` daemon over TCP (often on port `8888`). It is intended for tooling that drives eBUS transactions through ebusd rather than talking to an adapter directly.
 
+For gateway transport selection examples using this backend, see `deployment/full-stack.md`.
+
 ## Transport
 
 - Connection: plain TCP.
@@ -90,3 +92,13 @@ address 31: self ...
 Tooling can enumerate slave addresses by:
 - matching lines starting with `address XX:` (hex), and
 - keeping entries that contain `slave` but not `self`.
+
+## Backend Integration Checklist
+
+For deterministic request/response behavior when integrating ebusd TCP:
+
+- Send `hex` requests with `DST PB SB LEN DATA...` (CRC omitted; ebusd computes it).
+- Treat the first valid hex payload line as authoritative if trailing lines are present.
+- Strip the leading eBUS response length byte (`LEN`) before higher-layer payload parsing when applicable.
+- Treat `done...` responses as successful no-payload outcomes (commonly broadcast sends).
+- Treat timeout/no-answer `ERR:` responses as timeout conditions; map other `ERR:` responses to invalid payload or command failure.


### PR DESCRIPTION
## Summary
- add gateway-facing ebusd-tcp backend how-to in `deployment/full-stack.md`
- document transport selection flags and include concrete gateway transport examples (`enh`, `ens`, `ebusd-tcp`)
- document ebusd-tcp limitations and error behavior for gateway users
- extend `protocols/ebusd-tcp.md` with an integration checklist for deterministic parser behavior
- add root README cross-link to the new deployment/protocol guidance

## Acceptance mapping
- [x] Add a how-to section for ebusd-tcp in deployment or protocols docs
- [x] Include example config snippets for gateway transport selection
- [x] Note limitations and error behaviors
- [x] CI green (docs-only checks expected)

Closes #38

@codex review
