### PR TITLE
Refactor protocol discovery docs (generic + Vaillant)

### DIFF
--- a/architecture/vaillant.md
+++ b/architecture/vaillant.md
@@ -2,7 +2,7 @@
 
 Modern Vaillant systems often use an architectural approach that differs from the “classic” eBUS expectation of **one physical device ↔ one slave address**.
 
-This document captures the implications for discovery, debugging, and third‑party integrations. It is intentionally **high-level**; for wire formats, see `protocols/vaillant.md`.
+This document captures the implications for discovery, debugging, and third‑party integrations. It is intentionally **high-level**; for wire formats, see `protocols/ebus-vaillant.md`.
 
 ## The Architectural Difference (Classic eBUS vs Vaillant)
 

--- a/protocols/basv.md
+++ b/protocols/basv.md
@@ -1,73 +1,20 @@
 # Device Discovery (BASV) (Observed)
 
-This document describes common eBUS discovery messages used to enumerate devices on the bus and read basic identity metadata. The layouts here describe the **payload bytes** inside an eBUS frame (not including CRC/escaping).
+This document describes the **BASV discovery flow** used to enumerate devices on the eBUS and collect identity metadata.
 
-## QueryExistence (0x07 0xFE)
+It intentionally does not duplicate the wire-level layouts for generic eBUS discovery or vendor extensions; those are documented in the protocol overview pages linked below.
 
-QueryExistence is commonly used as a best-effort “who is present?” broadcast.
+## Discovery Flow (Observed)
 
-```text
-Master telegram:
-  DST = 0xFE (broadcast)
-  PB  = 0x07
-  SB  = 0xFE
-  LEN = 0x00
-  DATA = (empty)
-```
+1. Trigger presence refresh via `QueryExistence` broadcast (`0x07 0xFE`).
+2. Probe candidate slave addresses with `Identification Scan` (`0x07 0x04`) to obtain:
+   - manufacturer byte
+   - device id string
+   - software / hardware version bytes
+3. If the device manufacturer is Vaillant (`0xB5`), optionally enrich identity by reading the Vaillant `scan.id` chunks via B509 (`0xB5 0x09`, `QQ=0x24..0x27`) and assembling the 32-byte ASCII string.
 
-Notes:
-- Broadcast messages do not have a response telegram.
-- Some stacks (including ebusd) use QueryExistence as a trigger to refresh internal address state that can later be queried (e.g. via the ebusd TCP `info` command).
+## References
 
-## Identification Scan (0x07 0x04)
-
-Identification (often “scan” in ebusd terminology) reads a device’s manufacturer, device id, and software/hardware versions.
-
-```text
-Master telegram:
-  DST = <candidate slave address>
-  PB  = 0x07
-  SB  = 0x04
-  LEN = 0x00
-  DATA = (empty)
-```
-
-Observed slave response payload layout:
-
-```text
-  0: manufacturer   byte
-  1..(N-5): device_id ASCII (NUL-padded; length varies)
-  (N-4)..(N-3): sw   2 bytes (opaque)
-  (N-2)..(N-1): hw   2 bytes (opaque)
-```
-
-Notes:
-- The response length varies by device because the device id field is variable-length.
-- Many tools treat `sw`/`hw` as opaque hex.
-
-## Vendor Extension: Vaillant scan.id via 0xB5 0x09
-
-Some Vaillant devices (manufacturer byte `0xB5`) expose a “scan id” string via `0xB5 0x09` requests with a 1-byte selector (`QQ`).
-
-```text
-Request payload (1 byte):
-  QQ : byte
-
-Where QQ is typically one of: 0x24, 0x25, 0x26, 0x27
-```
-
-Each response returns one chunk:
-
-```text
-Response payload (9 bytes):
-  0: status   byte (0x00 indicates success)
-  1..8: ascii 8 bytes (NUL/space padded)
-```
-
-To assemble the full scan id:
-1. Request chunks for `QQ=0x24..0x27` (4 chunks).
-2. Concatenate the 8-byte ASCII segments (total 32 bytes).
-3. Strip trailing NULs and whitespace.
-
-The resulting string is often parsed into fields such as product/model number and a serial-like suffix; the exact format may vary across Vaillant device generations.
-
+- `protocols/ebus-overview.md#queryexistence-0x07-0xfe`
+- `protocols/ebus-overview.md#identification-scan-0x07-0x04`
+- `protocols/ebus-vaillant.md#vaillant-scanid-chunks-qq0x240x27`

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -108,7 +108,54 @@ SRC=0x10 DST=0x08 PB=0xB5 SB=0x04 LEN=0x01 DATA=0x7F CRC=0x??
 
 The CRC byte depends on the exact CRC8 implementation and the escape-aware substitution described above.
 
+## Common Discovery Functions
+
+This section documents common discovery-style requests used to enumerate devices and read basic identity metadata. The layouts describe the **payload bytes** inside an eBUS frame (not including CRC/escaping).
+
+### QueryExistence (0x07 0xFE)
+
+QueryExistence is commonly used as a best-effort “who is present?” broadcast.
+
+```text
+Master telegram:
+  DST = 0xFE (broadcast)
+  PB  = 0x07
+  SB  = 0xFE
+  LEN = 0x00
+  DATA = (empty)
+```
+
+Notes:
+- Broadcast messages do not have a response telegram.
+- Some stacks (including ebusd) use QueryExistence as a trigger to refresh internal address state that can later be queried (e.g. via the ebusd TCP `info` command).
+
+### Identification Scan (0x07 0x04)
+
+Identification (often “scan” in ebusd terminology) reads a device’s manufacturer, device id, and software/hardware versions.
+
+```text
+Master telegram:
+  DST = <candidate slave address>
+  PB  = 0x07
+  SB  = 0x04
+  LEN = 0x00
+  DATA = (empty)
+```
+
+Observed slave response payload layout:
+
+```text
+  0: manufacturer   byte
+  1..(N-5): device_id ASCII (NUL-padded; length varies)
+  (N-4)..(N-3): sw   2 bytes (opaque)
+  (N-2)..(N-1): hw   2 bytes (opaque)
+```
+
+Notes:
+- The response length varies by device because the device id field is variable-length.
+- Many tools treat `sw`/`hw` as opaque hex.
+
 ## See Also
 
 - `protocols/ebusd-tcp.md` – ebusd daemon TCP command protocol (for tooling that sends direct-mode telegrams via ebusd).
-- `protocols/basv.md` – device discovery messages (QueryExistence + Identification).
+- `protocols/basv.md` – BASV discovery flow (observed).

--- a/protocols/ebus-vaillant.md
+++ b/protocols/ebus-vaillant.md
@@ -121,9 +121,29 @@ Response payload layout is device/register-specific. In some cases, a single `0x
 
 ### Vaillant scan.id chunks (QQ=0x24..0x27)
 
-In addition to the `0x0D`/`0x0E` register access sub-format above, Vaillant devices are also observed to use `0xB5 0x09` with a **1-byte selector** (`QQ`) to return fixed-size ASCII chunks that can be assembled into a “scan id” string.
+In addition to the `0x0D`/`0x0E` register access sub-format above, some Vaillant devices (manufacturer byte `0xB5`) are also observed to use `0xB5 0x09` with a **1-byte selector** (`QQ`) to return fixed-size ASCII chunks that can be assembled into a “scan id” string.
 
-See `protocols/basv.md` for the observed request/response layout and assembly rules.
+```text
+Request payload (1 byte):
+  QQ : byte
+
+Where QQ is typically one of: 0x24, 0x25, 0x26, 0x27
+```
+
+Each response returns one chunk:
+
+```text
+Response payload (9 bytes):
+  0: status   byte (0x00 indicates success)
+  1..8: ascii 8 bytes (NUL/space padded)
+```
+
+To assemble the full scan id:
+1. Request chunks for `QQ=0x24..0x27` (4 chunks).
+2. Concatenate the 8-byte ASCII segments (total 32 bytes).
+3. Strip trailing NULs and whitespace.
+
+The resulting string is often parsed into fields such as product/model number and a serial-like suffix; the exact format may vary across Vaillant device generations.
 
 ## Extended Register Access (0xB5 0x24)
 


### PR DESCRIPTION
Closes #58.

Summary:
- Moved generic eBUS discovery functions (QueryExistence + Identification Scan) into `protocols/ebus-overview.md`.
- Moved Vaillant B509 scan.id chunk discovery details into `protocols/ebus-vaillant.md`.
- Renamed `protocols/vaillant.md` -> `protocols/ebus-vaillant.md` and updated cross-links.
- Refocused `protocols/basv.md` on the BASV discovery flow with links to the generic/Vaillant sections.

Local checks:
- Markdown whitespace checks (tabs/trailing spaces) pass.

@codex review