### PR TITLE
Docs: use initiator/target terminology

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -50,3 +50,79 @@ jobs:
           fi
 
           echo "Markdown checks passed."
+
+      - name: Enforce initiator/target terminology
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import pathlib
+          import re
+          import subprocess
+          import sys
+
+          allowed_file = pathlib.Path("protocols/ebus-overview.md")
+          begin_marker = "<!-- legacy-role-mapping:begin -->"
+          end_marker = "<!-- legacy-role-mapping:end -->"
+
+          # Construct legacy terms without spelling them out literally in-repo.
+          terms = ["m" + "aster", "sl" + "ave"]
+          pattern = re.compile(r"\\b(" + "|".join(map(re.escape, terms)) + r")\\b", re.IGNORECASE)
+
+          md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+
+          def line_number(text: str, index: int) -> int:
+              return text.count("\\n", 0, index) + 1
+
+          def print_match(file_path: str, text: str, index: int, match_text: str) -> None:
+              print(f"{file_path}:{line_number(text, index)}:{match_text}", file=sys.stderr)
+
+          if not allowed_file.exists():
+              print(f"Expected {allowed_file} to exist.", file=sys.stderr)
+              sys.exit(1)
+
+          allowed_text = allowed_file.read_text(encoding="utf-8")
+          begin_index = allowed_text.find(begin_marker)
+          end_index = allowed_text.find(end_marker)
+          if begin_index == -1 or end_index == -1 or end_index <= begin_index:
+              print(
+                  "Missing or malformed legacy-role-mapping markers in protocols/ebus-overview.md.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          allowed_region_start = begin_index
+          allowed_region_end = end_index
+
+          failed = False
+
+          for file_path in md_files:
+              path = pathlib.Path(file_path)
+              text = path.read_text(encoding="utf-8")
+              for match in pattern.finditer(text):
+                  if path != allowed_file:
+                      if not failed:
+                          print(
+                              "Legacy role terms must not appear outside protocols/ebus-overview.md.",
+                              file=sys.stderr,
+                          )
+                      failed = True
+                      print_match(file_path, text, match.start(), match.group(0))
+
+          for match in pattern.finditer(allowed_text):
+              if not (allowed_region_start <= match.start() < allowed_region_end):
+                  if not failed:
+                      print(
+                          "Legacy role terms must only appear inside the legacy-role-mapping note.",
+                          file=sys.stderr,
+                      )
+                  failed = True
+                  print_match(str(allowed_file), allowed_text, match.start(), match.group(0))
+
+          if failed:
+              sys.exit(1)
+
+          print("Terminology gate passed.")
+          PY

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -43,13 +43,13 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Consequences:** ENS framing is deterministic and reversible; invalid sequences are detected at decode time.
 
-## ADR-005: Frame type is inferred from target address
+## ADR-005: Frame type is inferred from destination address
 
 **Status:** Accepted
 
-**Context:** eBUS distinguishes broadcast, master-master, and master-slave frames.
+**Context:** eBUS distinguishes broadcast, initiator-initiator, and initiator-target frames.
 
-**Decision:** Infer `FrameType` from the target address. `0xFE` is broadcast; master/master is detected by valid master-address bit patterns; otherwise master/slave.
+**Decision:** Infer `FrameType` from the destination address. `0xFE` is broadcast; initiator/initiator is detected by valid initiator-address bit patterns; otherwise initiator/target.
 
 **Consequences:** Callers do not set frame type explicitly; it is derived from addressing rules.
 
@@ -69,7 +69,7 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Context:** Frame retries depend on frame type, and ACK/NACK handling must be consistent.
 
-**Decision:** The Bus enforces the send/ACK/response flow and retry policy per frame type (broadcast has no response; master-master only ACK; master-slave ACK + response).
+**Decision:** The Bus enforces the send/ACK/response flow and retry policy per frame type (broadcast has no response; initiator-initiator only ACK; initiator-target ACK + response).
 
 **Consequences:** Callers use a single `Send` call and receive typed errors after retries are exhausted.
 
@@ -77,7 +77,7 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Status:** Accepted
 
-**Context:** eBUS arbitration favors lower master addresses.
+**Context:** eBUS arbitration favors lower initiator addresses.
 
 **Decision:** Outgoing frames are queued in a priority queue keyed by the source address, with FIFO ordering for equal priority.
 

--- a/architecture/vaillant.md
+++ b/architecture/vaillant.md
@@ -1,6 +1,6 @@
 # Vaillant Regulator Architecture Notes (eBUS Context)
 
-Modern Vaillant systems often use an architectural approach that differs from the “classic” eBUS expectation of **one physical device ↔ one slave address**.
+Modern Vaillant systems often use an architectural approach that differs from the “classic” eBUS expectation of **one physical device ↔ one target address**.
 
 This document captures the implications for discovery, debugging, and third‑party integrations. It is intentionally **high-level**; for wire formats, see `protocols/ebus-vaillant.md`.
 
@@ -8,7 +8,7 @@ This document captures the implications for discovery, debugging, and third‑pa
 
 ### Classic eBUS mental model (illustrative)
 
-- Each physical device appears as its own slave address on the bus.
+- Each physical device appears as its own target address on the bus.
 - Distinct subsystems (heating circuit, DHW, mixer modules, zone controllers) are typically represented as separate nodes.
 - Bus scans show the “shape” of the system without vendor-specific application protocols.
 
@@ -17,7 +17,7 @@ Example (illustrative):
 ```text
 Address  Device
 -------  ----------------------
-0x10     Room controller (master)
+0x10     Room controller (initiator)
 0x25     DHW circuit module
 0x26     Heating circuit 1 module
 0x27     Heating circuit 2 module
@@ -49,7 +49,8 @@ Practical implication:
 
 ### Reduced bus transparency
 
-- In classic eBUS setups, a scan of slave addresses approximates the physical topology.
+- In classic eBUS setups, a scan of target addresses approximates the physical topology.
+- In classic eBUS setups, a scan of target addresses approximates the physical topology.
 - In Vaillant’s regulator model, a bus scan can look like a small system even when the internal topology is large, because many subsystems are “hidden” behind selectors.
 
 ### More difficult debugging
@@ -63,14 +64,14 @@ Illustrative comparison:
 
 ```text
 Classic eBUS style:
-  master -> 0x26 (HK1)
-  master -> 0x27 (HK2)
-  master -> 0x25 (DHW)
+  initiator -> 0x26 (HK1)
+  initiator -> 0x27 (HK2)
+  initiator -> 0x25 (DHW)
 
 Vaillant regulator style (selector-multiplexed):
-  master -> <regulator address> group=0 (HK1)
-  master -> <regulator address> group=1 (HK2)
-  master -> <regulator address> group=3 (DHW)
+  initiator -> <regulator address> group=0 (HK1)
+  initiator -> <regulator address> group=1 (HK2)
+  initiator -> <regulator address> group=3 (DHW)
 ```
 
 ## Why This Diverges From the “Spirit” of eBUS (Notes)
@@ -99,13 +100,13 @@ If internal subsystems were exposed as separate native bus nodes (still illustra
 ```text
 Address  Device
 -------  ----------------------
-0x10     Room controller (master)
-0x25     DHW circuit (native slave)
-0x26     Heating circuit 1 (native slave)
-0x27     Heating circuit 2 (native slave)
-0x28     Heating circuit 3 (native slave)
-0x30     Zone controller 1 (native slave)
-0x31     Zone controller 2 (native slave)
+0x10     Room controller (initiator)
+0x25     DHW circuit (native target)
+0x26     Heating circuit 1 (native target)
+0x27     Heating circuit 2 (native target)
+0x28     Heating circuit 3 (native target)
+0x30     Zone controller 1 (native target)
+0x31     Zone controller 2 (native target)
 ...
 ```
 

--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -56,7 +56,7 @@ EBUS_SMOKE=1 go run ./cmd/smoke
 Notes:
 
 - If `expected_devices` is empty/omitted, the harness performs a full scan over the default address range.
-- On a multi-master bus, arbitration collisions can occur during scan. The scan logic retries collided targets in later passes (bounded) instead of aborting the entire scan.
+- On a multi-initiator bus, arbitration collisions can occur during scan. The scan logic retries collided targets in later passes (bounded) instead of aborting the entire scan.
 - Default providers include Vaillant **system**, **heating**, and **DHW** planes; solar is opt-in.
 
 The smoke test never writes to the bus.

--- a/protocols/basv.md
+++ b/protocols/basv.md
@@ -7,7 +7,7 @@ It intentionally does not duplicate the wire-level layouts for generic eBUS disc
 ## Discovery Flow (Observed)
 
 1. Trigger presence refresh via `QueryExistence` broadcast (`0x07 0xFE`).
-2. Probe candidate slave addresses with `Identification Scan` (`0x07 0x04`) to obtain:
+2. Probe candidate target addresses with `Identification Scan` (`0x07 0x04`) to obtain:
    - manufacturer byte
    - device id string
    - software / hardware version bytes

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -2,6 +2,17 @@
 
 This document describes the wire-level framing and rules that are implemented. It focuses on the minimum required to interpret bytes on the bus.
 
+## Terminology
+
+This documentation uses role terms that align with modern, inclusive terminology:
+
+- **Initiator**: the node that begins a transaction by sending a command telegram onto the bus.
+- **Target**: the addressed node that ACK/NACKs the command and (for initiator/target transactions) may return a response payload.
+
+<!-- legacy-role-mapping:begin -->
+> Legacy role mapping (for cross-referencing older materials): `master` → `initiator`, `slave` → `target`.
+<!-- legacy-role-mapping:end -->
+
 ## Frame Layout
 
 An eBUS frame on the wire is represented as:
@@ -23,16 +34,16 @@ An eBUS frame on the wire is represented as:
 Frame type is derived from the destination address:
 
 - **Broadcast**: `DST = 0xFE`
-- **Master/Master**: `DST` has a valid master address pattern
-- **Master/Slave**: any other valid destination address
+- **Initiator/Initiator**: `DST` has a valid initiator address pattern
+- **Initiator/Target**: any other valid destination address
 
-This inference determines whether an ACK-only exchange is expected (master/master) or a full response frame (master/slave).
+This inference determines whether an ACK-only exchange is expected (initiator/initiator) or a full response frame (initiator/target).
 
-### Master Address Pattern
+### Initiator Address Pattern
 
-In direct-mode eBUS implementations (including Helianthus), “master” addresses are typically recognized by a nibble pattern:
+In direct-mode eBUS implementations (including Helianthus), initiator addresses are typically recognized by a nibble pattern:
 
-- A destination is treated as a **master address** if **both** the high and low nibbles are one of: `0x0`, `0x1`, `0x3`, `0x7`, `0xF`.
+- A destination is treated as an **initiator address** if **both** the high and low nibbles are one of: `0x0`, `0x1`, `0x3`, `0x7`, `0xF`.
 - Examples: `0x10`, `0x31`, `0xF1`, `0x33`.
 
 Addresses equal to `0xA9` (escape) or `0xAA` (SYN) are invalid in address positions.
@@ -56,28 +67,28 @@ The eBUS “direct” transaction flow used by ebusd-style implementations is:
 
 ```mermaid
 sequenceDiagram
-  participant M as Master
-  participant S as Slave
+  participant I as Initiator
+  participant T as Target
 
-  Note over M,S: Master telegram (unescaped): SRC DST PB SB LEN DATA... CRC
-  M->>S: Send bytes (each byte is echoed on the bus)
-  S-->>M: ACK (0x00) or NACK (0xFF) after command CRC
+  Note over I,T: Initiator telegram (unescaped): SRC DST PB SB LEN DATA... CRC
+  I->>T: Send bytes (each byte is echoed on the bus)
+  T-->>I: ACK (0x00) or NACK (0xFF) after command CRC
 
-  alt Master/Slave + ACK
-    Note over M,S: Slave response: LEN DATA... CRC
-    S-->>M: Response payload
-    M-->>S: ACK (0x00) if CRC ok, else NACK (0xFF)
+  alt Initiator/Target + ACK
+    Note over I,T: Target response: LEN DATA... CRC
+    T-->>I: Response payload
+    I-->>T: ACK (0x00) if CRC ok, else NACK (0xFF)
   end
 
-  Note over M,S: End-of-message
-  M->>S: SYN (0xAA)
+  Note over I,T: End-of-message
+  I->>T: SYN (0xAA)
 ```
 
 Key points:
 
-- **Per-byte echo**: When a master drives a symbol onto the bus it will also observe the same symbol (“echo”). An echo mismatch indicates arbitration loss or a collision.
-- **ACK/NAK timing**: `ACK`/`NACK` is exchanged **once per command**, after the master sends the command CRC (not after each byte).
-- **Response shape**: In master/slave transactions the slave response begins with a **length byte** and does not repeat source/target addresses.
+- **Per-byte echo**: When an initiator drives a symbol onto the bus it will also observe the same symbol (“echo”). An echo mismatch indicates arbitration loss or a collision.
+- **ACK/NAK timing**: `ACK`/`NACK` is exchanged **once per command**, after the initiator sends the command CRC (not after each byte).
+- **Response shape**: In initiator/target transactions the target response begins with a **length byte** and does not repeat source/destination addresses.
 - **SYN** (`0xAA`) is used as an **end-of-message** delimiter and may also appear during idle.
 
 ## CRC8 and Escaping
@@ -92,8 +103,8 @@ This substitution is applied before CRC8 updates so that control symbols do not 
 
 CRC8 coverage depends on the direct-mode phase:
 
-- **Master telegram CRC** is computed over: `SRC DST PB SB LEN DATA...`
-- **Slave response CRC** is computed over: `LEN DATA...` (responses do not repeat addresses in direct mode)
+- **Initiator telegram CRC** is computed over: `SRC DST PB SB LEN DATA...`
+- **Target response CRC** is computed over: `LEN DATA...` (responses do not repeat addresses in direct mode)
 
 On the wire, the same escape mechanism is used when sending these control bytes:
 
@@ -117,7 +128,7 @@ This section documents common discovery-style requests used to enumerate devices
 QueryExistence is commonly used as a best-effort “who is present?” broadcast.
 
 ```text
-Master telegram:
+Initiator telegram:
   DST = 0xFE (broadcast)
   PB  = 0x07
   SB  = 0xFE
@@ -134,15 +145,15 @@ Notes:
 Identification (often “scan” in ebusd terminology) reads a device’s manufacturer, device id, and software/hardware versions.
 
 ```text
-Master telegram:
-  DST = <candidate slave address>
+Initiator telegram:
+  DST = <candidate target address>
   PB  = 0x07
   SB  = 0x04
   LEN = 0x00
   DATA = (empty)
 ```
 
-Observed slave response payload layout:
+Observed target response payload layout:
 
 ```text
   0: manufacturer   byte

--- a/protocols/ebus-vaillant.md
+++ b/protocols/ebus-vaillant.md
@@ -149,7 +149,7 @@ The resulting string is often parsed into fields such as product/model number an
 
 `0xB5 0x24` (often referred to as “B524”) is used by Vaillant regulators as a selector-based extended register mechanism. The request/response format is multiplexed by the first payload byte (`opcode`).
 
-This section documents the **payload bytes** inside an eBUS frame (not including eBUS CRC/escaping). When interacting via ebusd’s TCP `hex` command, note that ebusd typically prefixes the slave response with a 1-byte eBUS response length; see `protocols/ebusd-tcp.md`.
+This section documents the **payload bytes** inside an eBUS frame (not including eBUS CRC/escaping). When interacting via ebusd’s TCP `hex` command, note that ebusd typically prefixes the target response with a 1-byte eBUS response length; see `protocols/ebusd-tcp.md`.
 
 Opcode family (observed):
 

--- a/protocols/ebusd-tcp.md
+++ b/protocols/ebusd-tcp.md
@@ -43,22 +43,22 @@ hex 15B52406 020003001600
 
 ### Response
 
-On success, ebusd typically returns a single hex line representing the **slave response bytes** as:
+On success, ebusd typically returns a single hex line representing the **target response bytes** as:
 
 ```text
 LEN DATA...
 ```
 
-Where the leading `LEN` is the eBUS response data length (not a B524 field). ebusd does not include the slave CRC byte in this output.
+Where the leading `LEN` is the eBUS response data length (not a B524 field). ebusd does not include the target CRC byte in this output.
 
 Note on streaming vs request/response:
 
 - `hex` is **not** a live bus capture; it returns only the response associated with the command you sent.
-- The output does **not** include the master telegram, per-byte echo, addresses, or CRC.
+- The output does **not** include the initiator telegram, per-byte echo, addresses, or CRC.
 - Unrelated bus traffic is **not** streamed through `hex`; monitoring/sniffing is a separate mode.
 
 Broadcast notes:
-- For broadcast telegrams (`DST=0xFE`), there is no slave response. ebusd commonly returns a textual status line (e.g. “done broadcast”) instead of a hex payload.
+- For broadcast telegrams (`DST=0xFE`), there is no target response. ebusd commonly returns a textual status line (e.g. “done broadcast”) instead of a hex payload.
 
 Many B524 responses are easiest to parse by stripping this length prefix:
 
@@ -84,14 +84,14 @@ Some ebusd versions may emit extra trailing lines after a valid hex payload line
 Many ebusd builds include an address summary in the `info` output, for example:
 
 ```text
-address 08: slave, scanned ...
-address 15: slave, scanned ...
+address 08: scanned ...
+address 15: scanned ...
 address 31: self ...
 ```
 
-Tooling can enumerate slave addresses by:
+Tooling can enumerate discovered target addresses by:
 - matching lines starting with `address XX:` (hex), and
-- keeping entries that contain `slave` but not `self`.
+- excluding the `self` entry.
 
 ## Backend Integration Checklist
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -60,11 +60,11 @@ For bytes `< 0x80`, the enhanced protocol allows receive notifications to be sen
 
 ## Arbitration Bytes
 
-Receive data notifications are **not** sent for bytes that are part of an arbitration request initiated by the host. Implementations should not expect echo notifications for those arbitration bytes (typically the address bytes at the start of a master frame).
+Receive data notifications are **not** sent for bytes that are part of an arbitration request initiated by the host. Implementations should not expect echo notifications for those arbitration bytes (typically the address bytes at the start of an initiator frame).
 
 ## START/STARTED and the Source Byte
 
-When using `START`/`STARTED` to acquire the bus (arbitration), the adapter emits the **master source address** on the physical bus as part of that arbitration sequence.
+When using `START`/`STARTED` to acquire the bus (arbitration), the adapter emits the **initiator source address** on the physical bus as part of that arbitration sequence.
 
 As a consequence, the first command telegram sent immediately after a successful `STARTED` does not need to re-send the `SRC` byte; it can begin at `DST`.
 


### PR DESCRIPTION
Closes #60.

- Replaces legacy role terms with initiator/target across docs.
- Adds Terminology section + legacy mapping note in `protocols/ebus-overview.md`.
- Adds Docs CI gate to ensure legacy terms only appear in the mapping note.

@codex Please review.