### PR TITLE
docs: target emulation framework and VR90 minimal behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Implementation-neutral references for the eBUS wire protocol and data types live
 For Home Assistant onboarding and GraphQL capability expectations, see `development/ha-integration.md`.
 For ebusd command-backend usage (gateway transport selection + protocol behavior), see `deployment/full-stack.md` and `protocols/ebusd-tcp.md`.
 For cross-repo smoke execution order (gateway → add-on → integration), see `development/end-to-end-smoke.md`.
+For target emulation framework and VR90 minimal behavior, see `development/target-emulation.md` and `protocols/ebus-overview.md`.
 
 ## Documentation Gate
 

--- a/development/target-emulation.md
+++ b/development/target-emulation.md
@@ -1,0 +1,78 @@
+# Target Emulation (VR90 Minimal)
+
+This document tracks implemented Helianthus target-emulation behavior merged in:
+
+- `helianthus-ebusgo` PR [#61](https://github.com/d3vi1/helianthus-ebusgo/pull/61)
+- `helianthus-tinyebus` PR [#10](https://github.com/d3vi1/helianthus-tinyebus/pull/10)
+
+## Licensing Boundary
+
+- Protocol-generic wire behavior and query layouts stay in **CC0** docs under `protocols/`.
+- This page is **AGPL** and documents Helianthus implementation details (package structure, harness behavior, and project smoke commands).
+
+## Framework Shape (Generic Concepts)
+
+Both implementations use the same logical model:
+
+- request matcher (`PB/SB` and optional payload prefix matching),
+- response builder (returns delay + response payload),
+- timing constraints (min/max response delay validation),
+- deterministic harness (virtual time sequence runner for tests).
+
+## Minimal VR90 Behavior (Current Scope)
+
+Current behavior is intentionally minimal and limited to recognition:
+
+- responds to identification query `0x07 0x04`,
+- configurable target address,
+- configurable identity fields: manufacturer, device id, software version, hardware version,
+- no extended thermostat command coverage in this phase.
+
+For the protocol-level query layout, see:
+- `protocols/ebus-overview.md#identification-scan-0x07-0x04`
+- `protocols/ebus-overview.md#minimal-vr90-recognition-query-set-observed`
+
+## Implementation Mapping
+
+### `helianthus-ebusgo`
+
+- Package: `emulation`
+- Entry point: `NewVR90Target(profile VR90Profile)`
+- Deterministic harness: `Harness` with virtual `time.Duration`
+
+Minimal smoke command:
+
+```bash
+cd /path/to/helianthus-ebusgo
+./scripts/smoke-vr90-minimal.sh
+```
+
+### `helianthus-tinyebus`
+
+- Package: `firmware/emulation`
+- Entry point: `NewVR90Target(profile VR90Profile)`
+- Deterministic harness: `Harness` with millisecond virtual time (`uint32`)
+
+Minimal smoke command:
+
+```bash
+cd /path/to/helianthus-tinyebus
+./scripts/smoke-vr90-minimal.sh
+```
+
+## Timing Rationale
+
+For strict target emulation, timing should run firmware-side (adapter MCU / TinyGo runtime) where response delay control is predictable.
+
+Host-side relay paths (for example `ebusd-tcp`) are still useful for functional checks but can add scheduler/network jitter, so they should not be treated as cycle-accurate emulation backends.
+
+See also: `protocols/ebusd-tcp.md#timing-caveat-for-target-emulation`.
+
+## Out of Scope (Current Phase)
+
+The following devices/behaviors are not included in this minimal phase:
+
+- VR92
+- VR70 / VR71
+- recoVAIR
+- VR50

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -166,6 +166,26 @@ Notes:
 - The response length varies by device because the device id field is variable-length.
 - Many tools treat `sw`/`hw` as opaque hex.
 
+### Minimal VR90 Recognition Query Set (Observed)
+
+For basic recognition of a wired VR90-style target in controlled setups, the smallest observed query set is:
+
+1. Send one identification query to the candidate target address (`PB=0x07`, `SB=0x04`, empty payload).
+2. Accept a valid target response payload with manufacturer + identity fields.
+
+Minimal response payload shape used in practice:
+
+```text
+  0: manufacturer   byte
+  1..5: device_id   5 bytes ASCII
+  6..7: sw_version  2 bytes (opaque)
+  8..9: hw_version  2 bytes (opaque)
+```
+
+Notes:
+- This is a practical minimum profile for VR90 recognition behavior; it is not a full thermostat command set.
+- Other targets may return longer device identifiers and therefore a different overall response length.
+
 ## See Also
 
 - `protocols/ebusd-tcp.md` – ebusd daemon TCP command protocol (for tooling that sends direct-mode telegrams via ebusd).

--- a/protocols/ebusd-tcp.md
+++ b/protocols/ebusd-tcp.md
@@ -102,3 +102,9 @@ For deterministic request/response behavior when integrating ebusd TCP:
 - Strip the leading eBUS response length byte (`LEN`) before higher-layer payload parsing when applicable.
 - Treat `done...` responses as successful no-payload outcomes (commonly broadcast sends).
 - Treat timeout/no-answer `ERR:` responses as timeout conditions; map other `ERR:` responses to invalid payload or command failure.
+
+## Timing Caveat for Target Emulation
+
+`ebusd` TCP is a host-side command relay and is useful for functional request/response validation. For strict response-timing emulation, it is usually insufficient because host scheduling and network jitter can shift response timing outside tight target windows.
+
+For cycle-accurate target emulation behavior, place emulation logic near the adapter/firmware side where timing control is deterministic.


### PR DESCRIPTION
## Summary
- document target emulation framework and minimal VR90 behavior aligned with merged implementations in `helianthus-ebusgo#61` and `helianthus-tinyebus#10`
- add protocol-generic VR90 minimal query/response notes in `protocols/ebus-overview.md` (CC0 scope)
- add `ebusd-tcp` timing caveat for precise target emulation
- add Helianthus implementation mapping + smoke script references in `development/target-emulation.md` (AGPL scope)
- update root README navigation to include the new target emulation docs

## Licensing boundary applied
- CC0: protocol-generic wire/query content under `protocols/`
- AGPL: Helianthus implementation details under `development/`

## Validation
- docs-ci parity checks run locally:
  - markdown file presence
  - tabs/trailing-space checks
  - terminology gate script

Closes #62
