### PR TITLE
M0: Doc-gate VR90 B509 discovery emulation

### DIFF
--- a/development/target-emulation.md
+++ b/development/target-emulation.md
@@ -1,9 +1,9 @@
-# Target Emulation (Identify-Only Profiles)
+# Target Emulation (Identify Profiles + VR90 B509 Discovery)
 
 This document tracks implemented Helianthus target-emulation behavior merged in:
 
-- `helianthus-ebusgo` PR [#61](https://github.com/d3vi1/helianthus-ebusgo/pull/61) and PR [#65](https://github.com/d3vi1/helianthus-ebusgo/pull/65)
-- `helianthus-tinyebus` PR [#10](https://github.com/d3vi1/helianthus-tinyebus/pull/10) and PR [#14](https://github.com/d3vi1/helianthus-tinyebus/pull/14)
+- `helianthus-ebusgo` PR [#61](https://github.com/d3vi1/helianthus-ebusgo/pull/61), PR [#65](https://github.com/d3vi1/helianthus-ebusgo/pull/65), and PR [#69](https://github.com/d3vi1/helianthus-ebusgo/pull/69)
+- `helianthus-tinyebus` PR [#10](https://github.com/d3vi1/helianthus-tinyebus/pull/10), PR [#14](https://github.com/d3vi1/helianthus-tinyebus/pull/14), and PR [#18](https://github.com/d3vi1/helianthus-tinyebus/pull/18)
 
 ## Licensing Boundary
 
@@ -13,32 +13,38 @@ This document tracks implemented Helianthus target-emulation behavior merged in:
 CC0 references for wire-level model:
 - `protocols/ebus-overview.md#identification-scan-0x07-0x04`
 - `protocols/ebus-overview.md#identify-only-profile-fields-generic`
+- `protocols/ebus-vaillant.md#vaillant-scanid-chunks-qq0x240x27`
 
-## Identify-Only Model (Helianthus API Surface)
+## Model Coverage (Helianthus API Surface)
 
-Both implementations expose the same logical identify-only constructor profile:
+Both implementations expose the same identify-only constructor profile:
 
 - target identity: `address`, `manufacturer`, `device_id`, `software`, `hardware`
 - response behavior: fixed response delay + timing envelope validation
-- single recognition rule: match identification query `PB=0x07`, `SB=0x04`
+- identify recognition rule: match identification query `PB=0x07`, `SB=0x04`
+- VR90 optional discovery rule: match `PB=0xB5`, `SB=0x09`, `len(data)==1`, selector `0x24..0x27`
 
 Current implementation constraints:
 
-- identify-only behavior responds only to `0x07 0x04`
-- no thermostat/write/register emulation in this profile
+- identify-only behavior remains unchanged for all presets
+- VR90 B509 discovery is opt-in via profile flag (`EnableB509Discovery`)
+- unknown B509 selectors remain unmatched (no broad fallback)
+- no thermostat/write/register/timer emulation in this profile
 - `device_id` is normalized to a 5-byte ASCII slot (trim + truncate/pad)
+- `scan_id` is normalized to a 32-byte ASCII slot (trim + truncate/pad with spaces)
 
 ## Supported Presets (Current Coverage)
 
 | Preset | Address | Manufacturer | Device ID | Software | Hardware | Scope |
 |---|---:|---:|---|---:|---:|---|
-| VR90 | `0x15` | `0xB5` | `B7V00` | `0x0422` | `0x5503` | identify-only recognition |
+| VR90 | `0x15` | `0xB5` | `B7V00` | `0x0422` | `0x5503` | identify recognition + optional B509 scan.id chunk discovery |
 | VR_71 | `0x26` | `0xB5` | `VR_71` | `0x0100` | `0x5904` | identify-only recognition |
 
 Known limits:
 
 - Presets are fixed defaults for recognition tests, not full device models.
-- Additional profiles can be created through the generic constructor, but only identify behavior is implemented.
+- Additional profiles can be created through the generic constructor.
+- B509 discovery coverage is currently only implemented for VR90 compatibility targets.
 - Timing accuracy expectations remain firmware-first for strict response windows.
 
 ## Implementation Mapping
@@ -50,8 +56,11 @@ Known limits:
   - `NewIdentifyOnlyTarget(profile IdentifyOnlyProfile)`
   - `PresetVR90IdentifyOnlyProfile()`
   - `PresetVR71IdentifyOnlyProfile()`
-- Compatibility API:
+- VR90 compatibility API:
+  - `DefaultVR90Profile()`
   - `NewVR90Target(profile VR90Profile)` (kept for backward compatibility)
+  - `VR90Profile.EnableB509Discovery` (opt-in selector handling for `0x24..0x27`)
+  - `VR90Profile.ScanID` (scan.id source, normalized to 32-byte chunk space)
 
 Smoke commands:
 
@@ -59,6 +68,7 @@ Smoke commands:
 cd /path/to/helianthus-ebusgo
 ./scripts/smoke-identify-only.sh
 ./scripts/smoke-vr90-minimal.sh
+go test ./emulation -run '^TestSmokeVR90B509DiscoveryQuerySet$' -count=1 -v
 ```
 
 Repository links:
@@ -73,8 +83,11 @@ Repository links:
   - `NewIdentifyOnlyTarget(profile IdentifyOnlyProfile)`
   - `PresetVR90IdentifyOnlyProfile()`
   - `PresetVR71IdentifyOnlyProfile()`
-- Compatibility API:
+- VR90 compatibility API:
+  - `DefaultVR90Profile()`
   - `NewVR90Target(profile VR90Profile)` (kept for backward compatibility)
+  - `VR90Profile.EnableB509Discovery` (opt-in selector handling for `0x24..0x27`)
+  - `VR90Profile.ScanID` (scan.id source, normalized to 32-byte chunk space)
 
 Smoke commands:
 
@@ -83,6 +96,7 @@ cd /path/to/helianthus-tinyebus
 ./scripts/smoke-vr90-minimal.sh vr90
 ./scripts/smoke-vr90-minimal.sh vr71
 ./scripts/smoke-vr90-minimal.sh all
+GOWORK=off go test ./firmware/emulation -run '^TestSmokeVR90B509DiscoveryQuerySet$' -count=1 -v
 ```
 
 Repository link:
@@ -99,8 +113,8 @@ See also: `protocols/ebusd-tcp.md#timing-caveat-for-target-emulation`.
 
 ## Out of Scope (Current Phase)
 
-The following remain out of scope for the identify-only profile abstraction:
+The following remain out of scope for the current identify + B509 profile abstraction:
 
-- full VR90 thermostat command coverage beyond identify
+- full VR90 thermostat/register coverage beyond identify + B509 scan.id chunk discovery
 - full VR_71 command/register behavior beyond identify
 - VR92, VR70, recoVAIR, VR50 full emulation

--- a/protocols/ebus-vaillant.md
+++ b/protocols/ebus-vaillant.md
@@ -130,6 +130,8 @@ Request payload (1 byte):
 Where QQ is typically one of: 0x24, 0x25, 0x26, 0x27
 ```
 
+For deterministic target emulation, keep matching strict: this chunk format is only applicable when the payload is exactly one selector byte and that selector is explicitly supported by the emulated profile.
+
 Each response returns one chunk:
 
 ```text
@@ -144,6 +146,8 @@ To assemble the full scan id:
 3. Strip trailing NULs and whitespace.
 
 The resulting string is often parsed into fields such as product/model number and a serial-like suffix; the exact format may vary across Vaillant device generations.
+
+Helianthus implementation APIs and smoke verification commands for this discovery path are documented in `development/target-emulation.md` (AGPL scope).
 
 ## Extended Register Access (0xB5 0x24)
 


### PR DESCRIPTION
## Summary
- document VR90 optional B509 (`0xB5 0x09`) scan.id selector emulation (`0x24..0x27`) in `development/target-emulation.md`
- add B509 smoke verification paths/commands for both `helianthus-ebusgo` and `helianthus-tinyebus`
- update `protocols/ebus-vaillant.md` scan.id section with strict selector-matching guidance and AGPL handoff for implementation commands

## Validation
- local docs CI markdown gates (tabs/trailing-space + terminology) pass

Closes #70
