### PR TITLE
docs: document VR90 mapped-command emulation

### DIFF
--- a/development/target-emulation.md
+++ b/development/target-emulation.md
@@ -1,9 +1,9 @@
-# Target Emulation (Identify Profiles + VR90 B509 Discovery)
+# Target Emulation (Identify Profiles + VR90 B509 + Mapped Commands)
 
 This document tracks implemented Helianthus target-emulation behavior merged in:
 
-- `helianthus-ebusgo` PR [#61](https://github.com/d3vi1/helianthus-ebusgo/pull/61), PR [#65](https://github.com/d3vi1/helianthus-ebusgo/pull/65), and PR [#69](https://github.com/d3vi1/helianthus-ebusgo/pull/69)
-- `helianthus-tinyebus` PR [#10](https://github.com/d3vi1/helianthus-tinyebus/pull/10), PR [#14](https://github.com/d3vi1/helianthus-tinyebus/pull/14), and PR [#18](https://github.com/d3vi1/helianthus-tinyebus/pull/18)
+- `helianthus-ebusgo` PR [#61](https://github.com/d3vi1/helianthus-ebusgo/pull/61), PR [#65](https://github.com/d3vi1/helianthus-ebusgo/pull/65), PR [#69](https://github.com/d3vi1/helianthus-ebusgo/pull/69), and PR [#71](https://github.com/d3vi1/helianthus-ebusgo/pull/71)
+- `helianthus-tinyebus` PR [#10](https://github.com/d3vi1/helianthus-tinyebus/pull/10), PR [#14](https://github.com/d3vi1/helianthus-tinyebus/pull/14), PR [#18](https://github.com/d3vi1/helianthus-tinyebus/pull/18), and PR [#20](https://github.com/d3vi1/helianthus-tinyebus/pull/20)
 
 ## Licensing Boundary
 
@@ -13,6 +13,7 @@ This document tracks implemented Helianthus target-emulation behavior merged in:
 CC0 references for wire-level model:
 - `protocols/ebus-overview.md#identification-scan-0x07-0x04`
 - `protocols/ebus-overview.md#identify-only-profile-fields-generic`
+- `protocols/ebus-vaillant.md#register-access-0xb5-0x09`
 - `protocols/ebus-vaillant.md#vaillant-scanid-chunks-qq0x240x27`
 
 ## Model Coverage (Helianthus API Surface)
@@ -23,13 +24,16 @@ Both implementations expose the same identify-only constructor profile:
 - response behavior: fixed response delay + timing envelope validation
 - identify recognition rule: match identification query `PB=0x07`, `SB=0x04`
 - VR90 optional discovery rule: match `PB=0xB5`, `SB=0x09`, `len(data)==1`, selector `0x24..0x27`
+- VR90 optional mapped-command rules: match `PB/SB` plus optional payload matcher (exact or prefix), then return deterministic response bytes
 
 Current implementation constraints:
 
 - identify-only behavior remains unchanged for all presets
 - VR90 B509 discovery is opt-in via profile flag (`EnableB509Discovery`)
+- VR90 mapped-command behavior is opt-in via profile map entries (`MappedCommands`)
 - unknown B509 selectors remain unmatched (no broad fallback)
-- no thermostat/write/register/timer emulation in this profile
+- unknown mapped commands remain unmatched (`ErrNoMatchingRule`)
+- no thermostat/write/register/timer state machine emulation in this profile
 - `device_id` is normalized to a 5-byte ASCII slot (trim + truncate/pad)
 - `scan_id` is normalized to a 32-byte ASCII slot (trim + truncate/pad with spaces)
 
@@ -37,15 +41,67 @@ Current implementation constraints:
 
 | Preset | Address | Manufacturer | Device ID | Software | Hardware | Scope |
 |---|---:|---:|---|---:|---:|---|
-| VR90 | `0x15` | `0xB5` | `B7V00` | `0x0422` | `0x5503` | identify recognition + optional B509 scan.id chunk discovery |
+| VR90 | `0x15` | `0xB5` | `B7V00` | `0x0422` | `0x5503` | identify recognition + optional B509 scan.id chunk discovery + optional mapped commands |
 | VR_71 | `0x26` | `0xB5` | `VR_71` | `0x0100` | `0x5904` | identify-only recognition |
 
 Known limits:
 
 - Presets are fixed defaults for recognition tests, not full device models.
 - Additional profiles can be created through the generic constructor.
-- B509 discovery coverage is currently only implemented for VR90 compatibility targets.
+- B509 discovery and mapped-command coverage are currently only implemented for VR90 compatibility targets.
+- Mapped responses are deterministic byte payloads and do not model register-side effects.
 - Timing accuracy expectations remain firmware-first for strict response windows.
+
+## Mapped-Command Model (VR90 Compatibility)
+
+Each mapped-command entry adds one deterministic match/response rule inside the VR90 profile:
+
+- command key: `Primary` + `Secondary`
+- optional payload matcher:
+  - `PayloadExact`: request payload must match exactly
+  - `PayloadPrefix`: request payload must start with the configured prefix
+  - no payload matcher: any payload matches for that `Primary`/`Secondary`
+- response payload: `ResponseData` bytes returned as-is
+- rule label: `Name` (if empty, an auto-generated name is assigned during normalization)
+
+All mapped-command responses use the same profile response delay and timing envelope checks as identify and B509 responses.
+
+## Rule Precedence and Fallback
+
+Matching order is deterministic and shared across both implementations:
+
+1. built-in identify rule (`0x07/0x04`)
+2. built-in B509 scan.id rule (`0xB5/0x09`, selector `0x24..0x27`) when enabled
+3. mapped-command rules in declaration order
+
+Implications:
+
+- built-in rules keep precedence over mapped collisions on the same `PB/SB`
+- mapped rules are first-match-wins; declaration order matters (a broad prefix rule can shadow a later exact rule)
+- if no rule matches, emulation returns `ErrNoMatchingRule`
+
+## Validation Constraints
+
+Profile-level normalization and validation:
+
+- response delay must satisfy the configured timing envelope
+- `device_id` is required after trim and normalized to 5 ASCII bytes
+- `scan_id` is normalized to 32 ASCII bytes (trim + truncate/pad with spaces)
+
+Mapped-command validation:
+
+- `PayloadExact` and `PayloadPrefix` are mutually exclusive (setting both is invalid)
+- `ResponseData` must be non-empty
+- input byte slices are copied during normalization to keep response payloads immutable from caller mutations
+
+## Smoke Path (Mapped Command Coverage)
+
+Canonical VR90 mapped-command smoke sequence:
+
+1. identify query: `PB=0x07`, `SB=0x04`
+2. B509 discovery query: `PB=0xB5`, `SB=0x09`, selector `0x24`
+3. mapped-command query: example `PB=0xB5`, `SB=0x06`, data prefix `0x01 0x00 ...`
+4. verify all responses remain within the configured timing envelope
 
 ## Implementation Mapping
 
@@ -61,6 +117,8 @@ Known limits:
   - `NewVR90Target(profile VR90Profile)` (kept for backward compatibility)
   - `VR90Profile.EnableB509Discovery` (opt-in selector handling for `0x24..0x27`)
   - `VR90Profile.ScanID` (scan.id source, normalized to 32-byte chunk space)
+  - `VR90Profile.MappedCommands` (optional deterministic command map)
+  - `VR90MappedCommand` (`Name`, `Primary`, `Secondary`, `PayloadExact`, `PayloadPrefix`, `ResponseData`)
 
 Smoke commands:
 
@@ -68,7 +126,7 @@ Smoke commands:
 cd /path/to/helianthus-ebusgo
 ./scripts/smoke-identify-only.sh
 ./scripts/smoke-vr90-minimal.sh
-go test ./emulation -run '^TestSmokeVR90B509DiscoveryQuerySet$' -count=1 -v
+go test ./emulation -run '^TestSmokeVR90MappedCommandQuerySet$' -count=1 -v
 ```
 
 Repository links:
@@ -88,6 +146,8 @@ Repository links:
   - `NewVR90Target(profile VR90Profile)` (kept for backward compatibility)
   - `VR90Profile.EnableB509Discovery` (opt-in selector handling for `0x24..0x27`)
   - `VR90Profile.ScanID` (scan.id source, normalized to 32-byte chunk space)
+  - `VR90Profile.MappedCommands` (optional deterministic command map)
+  - `VR90MappedCommand` (`Name`, `Primary`, `Secondary`, `PayloadExact`, `PayloadPrefix`, `ResponseData`)
 
 Smoke commands:
 
@@ -96,7 +156,7 @@ cd /path/to/helianthus-tinyebus
 ./scripts/smoke-vr90-minimal.sh vr90
 ./scripts/smoke-vr90-minimal.sh vr71
 ./scripts/smoke-vr90-minimal.sh all
-GOWORK=off go test ./firmware/emulation -run '^TestSmokeVR90B509DiscoveryQuerySet$' -count=1 -v
+GOWORK=off go test ./firmware/emulation -run '^TestSmokeVR90MappedCommandQuerySet$' -count=1 -v
 ```
 
 Repository link:
@@ -113,8 +173,8 @@ See also: `protocols/ebusd-tcp.md#timing-caveat-for-target-emulation`.
 
 ## Out of Scope (Current Phase)
 
-The following remain out of scope for the current identify + B509 profile abstraction:
+The following remain out of scope for the current identify + B509 + mapped-command profile abstraction:
 
-- full VR90 thermostat/register coverage beyond identify + B509 scan.id chunk discovery
+- full VR90 thermostat/register coverage beyond identify + B509 scan.id chunk discovery + deterministic mapped responses
 - full VR_71 command/register behavior beyond identify
 - VR92, VR70, recoVAIR, VR50 full emulation

--- a/protocols/ebus-vaillant.md
+++ b/protocols/ebus-vaillant.md
@@ -132,6 +132,8 @@ Where QQ is typically one of: 0x24, 0x25, 0x26, 0x27
 
 For deterministic target emulation, keep matching strict: this chunk format is only applicable when the payload is exactly one selector byte and that selector is explicitly supported by the emulated profile.
 
+When multiple `0xB5 0x09` payload sub-formats are modeled together, evaluate this strict one-byte `QQ=0x24..0x27` form before broader selector maps so scan.id chunk discovery is not shadowed by generic matches.
+
 Each response returns one chunk:
 
 ```text


### PR DESCRIPTION
## Summary
- update `development/target-emulation.md` with the VR90 mapped-command model, rule precedence, validation constraints, and mapped-command smoke path
- extend implementation mapping references to include mapped-command APIs and current smoke commands for both repositories
- add a protocol-side neutral ordering note in `protocols/ebus-vaillant.md` for mixed `0xB5 0x09` payload sub-formats

## Validation
- markdown CI local checks (tabs/trailing spaces + terminology gate)

Closes #72
