### PR TITLE
Reorganize protocol docs for BASV and terminology cleanup

### DIFF
--- a/protocols/basv.md
+++ b/protocols/basv.md
@@ -1,17 +1,27 @@
 # Device Discovery (BASV) (Observed)
 
-This document describes the **BASV discovery flow** used to enumerate devices on the eBUS and collect identity metadata.
+This document describes the **BASV orchestration flow** used to enumerate devices and build one coherent identity view.
 
-It intentionally does not duplicate the wire-level layouts for generic eBUS discovery or vendor extensions; those are documented in the protocol overview pages linked below.
+Wire-level message layouts are intentionally documented in protocol-centric docs:
+- standard eBUS discovery functions in `protocols/ebus-overview.md`,
+- Vaillant extended discovery in `protocols/ebus-vaillant.md`.
 
-## Discovery Flow (Observed)
+## BASV Orchestration Flow (Observed)
 
-1. Trigger presence refresh via `QueryExistence` broadcast (`0x07 0xFE`).
-2. Probe candidate target addresses with `Identification Scan` (`0x07 0x04`) to obtain:
-   - manufacturer byte
-   - device id string
-   - software / hardware version bytes
-3. If the device manufacturer is Vaillant (`0xB5`), optionally enrich identity by reading the Vaillant `scan.id` chunks via B509 (`0xB5 0x09`, `QQ=0x24..0x27`) and assembling the 32-byte ASCII string.
+1. Run a presence-refresh phase.
+2. Run an identity-probe phase against candidate target addresses.
+3. For Vaillant-class identities, optionally run vendor enrichment.
+4. Merge results into one device identity record per discovered target.
+
+## BASV Output Shape (Observed)
+
+Each BASV discovery record is expected to include:
+- target address,
+- manufacturer,
+- device id,
+- software version,
+- hardware version,
+- optional vendor-enriched metadata (for example Vaillant `scan.id`).
 
 ## References
 

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -10,7 +10,7 @@ This documentation uses role terms that align with modern, inclusive terminology
 - **Target**: the addressed node that ACK/NACKs the command and (for initiator/target transactions) may return a response payload.
 
 <!-- legacy-role-mapping:begin -->
-> Legacy role mapping (for cross-referencing older materials): `master` → `initiator`, `slave` → `target`.
+> Legacy role mapping (for cross-referencing older materials): `master` → `initiator`, `slave` → `target`. Helianthus documentation uses `initiator`/`target`.
 <!-- legacy-role-mapping:end -->
 
 ## Frame Layout
@@ -123,6 +123,8 @@ The CRC byte depends on the exact CRC8 implementation and the escape-aware subst
 
 This section documents common discovery-style requests used to enumerate devices and read basic identity metadata. The layouts describe the **payload bytes** inside an eBUS frame (not including CRC/escaping).
 
+In BASV-style discovery orchestration, these standard functions are the protocol-level building blocks for presence refresh and identity probing.
+
 ### QueryExistence (0x07 0xFE)
 
 QueryExistence is commonly used as a best-effort “who is present?” broadcast.
@@ -221,4 +223,5 @@ Notes:
 ## See Also
 
 - `protocols/ebusd-tcp.md` – ebusd daemon TCP command protocol (for tooling that sends direct-mode telegrams via ebusd).
-- `protocols/basv.md` – BASV discovery flow (observed).
+- `protocols/ebus-vaillant.md#vaillant-scanid-chunks-qq0x240x27` – Vaillant extended discovery (`0xB5 0x09`) details.
+- `protocols/basv.md` – BASV discovery orchestration flow (observed).

--- a/protocols/ebus-vaillant.md
+++ b/protocols/ebus-vaillant.md
@@ -121,6 +121,8 @@ Response payload layout is device/register-specific. In some cases, a single `0x
 
 ### Vaillant scan.id chunks (QQ=0x24..0x27)
 
+This subsection is the Vaillant extended discovery function used by BASV-style discovery enrichment (`0xB5 0x09` with well-known selector values).
+
 In addition to the `0x0D`/`0x0E` register access sub-format above, some Vaillant devices (manufacturer byte `0xB5`) are also observed to use `0xB5 0x09` with a **1-byte selector** (`QQ`) to return fixed-size ASCII chunks that can be assembled into a “scan id” string.
 
 ```text


### PR DESCRIPTION
Fixes #74

## Summary
- keep protocol docs protocol-centric: standard eBUS discovery functions remain in `protocols/ebus-overview.md`, Vaillant extended discovery remains in `protocols/ebus-vaillant.md`
- make `protocols/basv.md` BASV-only (orchestration + output shape), removing function-level opcode duplication
- clarify the one allowed legacy terminology compatibility note in `protocols/ebus-overview.md` while preserving `initiator`/`target` as the Helianthus terminology
- add cross-reference updates between overview/BASV/Vaillant sections for discovery paths

## Notes on filename requirement
- `protocols/ebus-vaillant.md` is already the canonical file on `main`; there is no remaining `protocols/vaillant.md` path in this branch.

## Validation
- markdown whitespace checks (tabs + trailing spaces): pass
- docs terminology gate from `.github/workflows/docs-ci.yml`: pass
- markdown link check (local relative links + anchors): pass
- `rg -n -i -w "master|slave" --hidden --glob '!.git'`: only one compatibility note match in `protocols/ebus-overview.md`
