### PR TITLE
B524 docs: add heating/mixer circuit enum semantics

### DIFF
--- a/protocols/ebus-vaillant-GetExtendedRegisters.md
+++ b/protocols/ebus-vaillant-GetExtendedRegisters.md
@@ -243,7 +243,7 @@ if raw == 3:
 Context inputs used for interpretation:
 
 - `cooling_enabled`: `GG=0x02 RR=0x06`
-- `system_schema`: `GG=0x00 RR=0x01` (or equivalent system-schema source)
+- `system_schema`: installation/hydraulic-schema metadata source (not `GG=0x00 RR=0x01`, which maps to `HwcBivalencePoint`)
 - `pool_sensor_present`: VR70/VR71 external sensor mapping (S1/S2)
 - `gg05_present`: group-presence check for `GG=0x05`
 


### PR DESCRIPTION
## Summary
- add explicit enum semantics for `GG=0x02 RR=0x01` (`heating_circuit_type`)
- add contextual resolution model for `GG=0x02 RR=0x02` (`mixer_circuit_type_external`)
- document context sources used by resolution (`cooling_enabled`, `system_schema`, VR70/VR71 pool sensor path, `GG=0x05` presence)
- update constraint-table enum labels for RR `0x01` and `0x02`

## Notes
- keeps raw storage values stable while documenting context-dependent display semantics
- no changes to transport framing or opcode semantics
