### PR TITLE
docs(graphql): update Device fields

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -38,8 +38,15 @@ type Device {
   address: Int!
   manufacturer: String!
   deviceId: String!
+  serialNumber: String
+  macAddress: String
   softwareVersion: String!
   hardwareVersion: String!
+  displayName: String
+  productFamily: String
+  productModel: String
+  partNumber: String
+  role: String
   planes: [Plane!]!
   projections: [Projection!]!
 }


### PR DESCRIPTION
Closes #83.

Updates `api/graphql.md` to include `serialNumber`/`macAddress` and the new Vaillant product metadata fields on `Device` (`displayName`, `productFamily`, `productModel`, `partNumber`, `role`).

Related: d3vi1/helianthus-ebusgateway#98.