### PR TITLE
docs: align ENH/ENS semantics with ebusd

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -21,27 +21,29 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Decision:** Define a `RawTransport` interface with `ReadByte()`, `Write([]byte)`, and `Close()` to represent the minimal byte-level contract.
 
-**Consequences:** ENH and ENS can share a common Bus implementation. Future transports can implement the same interface without touching protocol logic.
+**Consequences:** ENH (enhanced adapter protocol) and plain eBUS byte streams (with ESC/SYN escaping) can share a common Bus implementation. Future transports can implement the same interface without touching protocol logic.
 
 ## ADR-003: ENH framing uses 2-byte command/data sequences
 
 **Status:** Accepted
 
-**Context:** The enhanced protocol wraps each data byte in a 2-byte frame with command bits and a 6-bit data payload.
+**Context:** The enhanced adapter protocol uses either short-form bytes (`< 0x80`) or 2-byte encoded command/data sequences (for `>= 0x80` and all command symbols).
 
-**Decision:** Encode ENH as two bytes where the first carries the command and the high two data bits, and the second carries the remaining six data bits. Short-form receive notifications for bytes `< 0x80` are normalized into `ENHResReceived` frames by the parser.
+**Decision:** Encode ENH command/data sequences as two bytes where the first carries the command and the high two data bits, and the second carries the remaining six data bits. Short-form receive notifications for bytes `< 0x80` are normalized into `ENHResReceived` frames by the parser.
 
 **Consequences:** Transport decodes ENH frames and only forwards receive data bytes (`ENHResReceived`, including short-form) to the Bus, suppressing echoed bytes that match the outbound payload. Echo suppression tolerates missing address echoes by allowing a small leading skip when the adapter does not report arbitration bytes.
 
-## ADR-004: ENS uses explicit escaping for control symbols
+## ADR-004: Plain eBUS streams escape control symbols (ESC/SYN)
 
 **Status:** Accepted
 
-**Context:** ENS streams reserve specific control bytes and require escaping.
+**Context:** Plain eBUS byte streams reserve specific control bytes and require escaping.
 
 **Decision:** Use escape byte `0xA9` with `0x00` and `0x01` suffixes to represent `0xA9` and `0xAA` respectively; reject unescaped `0xAA`.
 
-**Consequences:** ENS framing is deterministic and reversible; invalid sequences are detected at decode time.
+**Consequences:** ESC/SYN escaping is deterministic and reversible; invalid sequences are detected at decode time.
+
+**Naming note:** ebusd uses `ens:` to mean “enhanced protocol at high serial speed” (see `protocols/ens.md`). To avoid confusion, this ADR refers to the plain wire-level escaping as “ESC/SYN escaping”.
 
 ## ADR-005: Frame type is inferred from destination address
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -28,8 +28,8 @@ flowchart TB
 
   subgraph Transport
     T1[RawTransport]
-    T2[ENH]
-    T3[ENS]
+    T2[ENH (enhanced adapter protocol)]
+    T3[ESC (plain eBUS escaping)]
   end
 
   G1 --> G0
@@ -47,6 +47,11 @@ flowchart TB
   T1 --> T2
   T1 --> T3
 ```
+
+Naming note:
+
+- `protocols/enh.md` / `protocols/ens.md` document ebusd’s ENH/ENS adapter protocol semantics.
+- In Helianthus code, the transport currently named `ens` is the plain eBUS escape encoding (`ESC=0xA9`, `SYN=0xAA`) described in `protocols/ebus-overview.md`. Treat it as “ESC” in prose to avoid ambiguity with ebusd’s `ens:` prefix.
 
 ## Gateway Runtime (Implemented)
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -32,26 +32,31 @@
 ### Example Transport Configurations
 
 ```bash
-# ENH over unix socket (default-style setup)
+# ENH over TCP adapter (enhanced adapter protocol, ebusd-style port 9999)
 go run ./cmd/gateway \
   -transport enh \
-  -network unix \
-  -address /var/run/ebusd/ebusd.socket
+  -network tcp \
+  -address 203.0.113.10:9999
 
-# ENS over TCP adapter
+# Plain escaped byte stream over TCP (ESC/SYN escaping; only for raw bridge devices)
 go run ./cmd/gateway \
   -transport ens \
   -network tcp \
-  -address 127.0.0.1:9999
+  -address 203.0.113.10:12345
 
-# ebusd command backend over TCP
+# ebusd command backend over unix socket
 go run ./cmd/gateway \
   -transport ebusd-tcp \
-  -network tcp \
-  -address 127.0.0.1:8888
+  -network unix \
+  -address /var/run/ebusd/ebusd.socket
 ```
 
 For ebusd command syntax and response framing details, see `protocols/ebusd-tcp.md`.
+
+Terminology note:
+
+- `protocols/enh.md` / `protocols/ens.md` describe ebusd’s enhanced adapter protocol and the meaning of the `enh:`/`ens:` prefixes.
+- In Helianthus gateway CLI, `-transport ens` currently refers to the plain ESC/SYN escaping transport (wire-level), not ebusd’s `ens:` prefix name.
 
 ## ebusd-tcp Backend Notes (Gateway)
 

--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -50,7 +50,7 @@ EBUS_SMOKE=1 go run ./cmd/smoke
 1. Build gateway stack (transport → bus → registry → router).
 2. Scan the bus with a per-device timeout.
 3. Log discovered devices and compare against `expected_devices`.
-4. Start a **passive broadcast listener** on a separate ENH/ENS connection after the scan.
+4. Start a **passive broadcast listener** on a separate ENH connection after the scan.
 5. Run the optional **register dump** when configured.
 6. Invoke **read-only** methods for each discovered plane.
 7. Log **semantic energy totals** as B516 broadcasts arrive (if present on the bus).

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -1,8 +1,26 @@
-# ENH (Enhanced) Framing
+# ENH (Enhanced) Adapter Protocol
 
-ENH wraps each data byte in a two-byte frame that carries a command nibble and the data byte.
+ENH is the “enhanced” host↔adapter protocol used by ebusd-style interfaces (commonly on TCP port `9999`).
 
-## Byte Layout
+It is a byte-stream protocol where:
+
+- bytes `< 0x80` **may be transferred as-is** (short form),
+- bytes `>= 0x80` are transferred as a **2-byte encoded sequence** that also carries a 4-bit command ID.
+
+The specification below follows ebusd’s `docs/enhanced_proto.md`.
+
+## Encoding
+
+### Short form (bytes `< 0x80`)
+
+Any byte with the high bit clear (`0b0xxxxxxx`) can appear unframed on the stream.
+
+- host→adapter: short-form bytes represent “send this data byte”
+- adapter→host: short-form bytes represent “received this data byte”
+
+### Encoded form (bytes `>= 0x80`, and all command symbols)
+
+Encoded sequences are 2 bytes:
 
 ```text
 byte1: 1 1 C C C C D D
@@ -12,7 +30,7 @@ byte2: 1 0 D D D D D D
 - `C` = 4-bit command
 - `D` = 8-bit data payload (split across the two bytes)
 
-The data bits are assembled as:
+Reconstruction:
 
 ```text
 data[7:6] = byte1[1:0]
@@ -21,14 +39,16 @@ data[5:0] = byte2[5:0]
 
 ## Command IDs
 
+The 4-bit command nibble is interpreted by direction:
+
 ```text
-Requests:
+Requests (host → adapter):
   0x0 = INIT
   0x1 = SEND
   0x2 = START
   0x3 = INFO
 
-Responses:
+Responses (adapter → host):
   0x0 = RESETTED
   0x1 = RECEIVED
   0x2 = STARTED
@@ -38,42 +58,94 @@ Responses:
   0xC = ERROR_HOST
 ```
 
-## INIT Handshake (Observed)
+## INIT / RESETTED
 
-Hosts typically send `INIT` once with a feature byte (often `0x00`). Some adapters respond with `RESETTED`, but others immediately start streaming bus data or `INFO` without ever sending `RESETTED`.
+`INIT` requests adapter initialization and feature negotiation:
 
-Practical, ebusd-compatible behavior is to treat `INIT` as **best-effort**: send it, then proceed if a `RESETTED` arrives *or* if no `RESETTED` appears within a short timeout while valid data continues to flow.
+```text
+<INIT> <features>
+```
 
-## Stream Parsing
+Adapters are expected to reply with:
 
-When parsing a byte stream:
+```text
+<RESETTED> <features>
+```
 
-- If the high bit is **0**, the byte is treated as a raw data byte.
-- If the byte matches the ENH header (`11xxxxxx`), the parser expects a second byte (`10xxxxxx`) to complete the ENH frame.
-- A valid `RECEIVED` response yields one data byte to the upper layer.
+Feature bits:
 
-Invalid header combinations are rejected.
+- bit `0`: adapter supports **additional INFO** queries (version / HW ID / voltage / etc.)
 
-## Short-Form Receive Notifications
+Practical note: some adapters may start streaming bus bytes before emitting `RESETTED`. A robust client treats `INIT` as best-effort and proceeds once it sees either a valid `RESETTED` or valid bus traffic within a short timeout window.
 
-For bytes `< 0x80`, the enhanced protocol allows receive notifications to be sent without an ENH frame prefix. These unframed bytes are semantically equivalent to a `RECEIVED` response carrying the same data byte.
+## SEND
 
-## Arbitration Bytes
+`SEND` requests transmission of a single byte onto the eBUS:
 
-Receive data notifications are **not** sent for bytes that are part of an arbitration request initiated by the host. Implementations should not expect echo notifications for those arbitration bytes (typically the address bytes at the start of an initiator frame).
+```text
+<SEND> <data>
+```
 
-## START/STARTED and the Source Byte
+For `data < 0x80`, the short-form (unframed) byte is also allowed.
 
-When using `START`/`STARTED` to acquire the bus (arbitration), the adapter emits the **initiator source address** on the physical bus as part of that arbitration sequence.
+## START / STARTED / FAILED
 
-As a consequence, the first command telegram sent immediately after a successful `STARTED` does not need to re-send the `SRC` byte; it can begin at `DST`.
+`START` requests that the adapter begins arbitration after the next bus `SYN` (`0xAA`) and uses the supplied initiator address:
 
-This matches ebusd-style “direct” operation over ENH and explains why `SRC` echo notifications are typically absent right after arbitration.
+```text
+<START> <master>
+```
+
+If `<master>` is `SYN` (`0xAA`), a running arbitration is cancelled.
+
+Outcomes:
+
+- `<STARTED> <master>`: arbitration won
+- `<FAILED> <winner>`: arbitration lost (the data byte indicates the winning initiator address)
+
+### Arbitration byte visibility
+
+During arbitration initiated by the host, adapters **must not** emit `RECEIVED` notifications for the arbitration bytes they put on the bus. Clients should not rely on echo notifications for those bytes.
+
+### Why ebusd sends `DST` first after STARTED
+
+In ebusd “direct” mode, the initiator address byte is emitted as part of arbitration. After a successful `STARTED`, the host continues the telegram by sending `DST`, then `PB SB LEN ...` (i.e., it does not re-send `SRC`).
+
+## INFO
+
+`INFO` requests additional adapter metadata:
+
+```text
+<INFO> <info_id>
+```
+
+The response is a stream of `<INFO> <data>` bytes where the **first** byte is a length `N` (excluding the length byte itself), followed by `N` data bytes.
+
+Sending a new `INFO` request while a previous response is still streaming immediately terminates the previous transfer.
+
+Common `info_id` values include:
+
+- `0x00`: version + feature bits + checksums + jumper flags (length varies by adapter firmware)
+- `0x01`: HW ID
+- `0x02`: HW config
+- `0x03`: HW temperature
+- `0x04`: HW supply voltage
+- `0x05`: bus voltage
+- `0x06`: reset info
+- `0x07`: WiFi RSSI
+
+## Errors
+
+The adapter can report:
+
+- `<ERROR_EBUS> <error>`: UART/bus-side errors (e.g. `0x00` framing, `0x01` overrun)
+- `<ERROR_HOST> <error>`: host-side transport errors
 
 ## Example (Hex)
 
+SEND data byte `0x5A` (encoded form):
+
 ```text
-Command SEND (0x1), Data 0x5A:
 byte1 = 0xC0 | (0x1 << 2) | (0x5A >> 6) = 0xC5
 byte2 = 0x80 | (0x5A & 0x3F)           = 0x9A
 ```

--- a/protocols/ens.md
+++ b/protocols/ens.md
@@ -1,35 +1,34 @@
-# ENS (Escaped) Stream Encoding
+# ENS (Enhanced, High-Speed Serial)
 
-ENS is a byte-stuffing scheme that reserves control symbols and escapes them in a byte stream.
+In ebusd-style device naming, `ens:` selects the **enhanced adapter protocol** (see `protocols/enh.md`) and uses the **high-speed serial** variant (typically `115200` Baud).
 
-## Reserved Bytes
+This is distinct from the eBUS wire-level escaping of `ESC=0xA9` / `SYN=0xAA`, which is documented in `protocols/ebus-overview.md`.
+
+## Device Prefix Semantics (ebusd)
+
+ebusd recognizes two “enhanced” prefixes:
+
+- `enh:` → enhanced protocol over serial at `9600` Baud
+- `ens:` → enhanced protocol over serial at `115200` Baud
+
+Both prefixes enable the same ENH framing; only the serial transfer speed differs.
+
+### Network transports
+
+When the underlying transport is TCP/UDP (for example `host:9999`), there is no serial baud rate. In that case, `enh:` and `ens:` are effectively equivalent and simply indicate “use ENH framing”.
+
+## Examples
+
+Serial:
 
 ```text
-ESC = 0xA9
-SYN = 0xAA
+enh:/dev/ttyUSB0
+ens:/dev/ttyUSB0
 ```
 
-## Encoding Rules
+Network:
 
 ```text
-0xA9 -> 0xA9 0x00
-0xAA -> 0xA9 0x01
-```
-
-All other bytes are transmitted unchanged.
-
-## Decoding Rules
-
-```text
-0xA9 0x00 -> 0xA9
-0xA9 0x01 -> 0xAA
-```
-
-Unescaped `0xAA` is invalid. An escape at end-of-stream is invalid.
-
-## Example
-
-```text
-Input:  0x10 0xA9 0xAA 0x20
-Output: 0x10 0xA9 0x00 0xA9 0x01 0x20
+enh:tcp:203.0.113.10:9999
+ens:203.0.113.10:9999
 ```


### PR DESCRIPTION
Updates protocol docs to match ebusd source-of-truth:

- protocols/enh.md: documents short-form bytes (<0x80), START cancel via START+SYN, INFO length framing, feature bit 0, and error semantics per ebusd docs/enhanced_proto.md.
- protocols/ens.md: rewrites ENS as ebusd's "enhanced high-speed serial" prefix (115200 baud) vs ENH (9600 baud); notes enh/ens equivalence on TCP/UDP.
- architecture/ + deployment/ + development/: remove the previous (incorrect) assumption that "ENS" refers to ESC/SYN byte-stuffing; treat wire escaping as ESC/SYN escaping and add explicit naming notes.

References:
- external/ebusd/docs/enhanced_proto.md
- external/ebusd/src/lib/ebus/protocol.cpp (enh/en s prefix parsing)
- external/ebusd/src/lib/ebus/transport.cpp (serial speed selection)
