### PR TITLE
meta01: add local docs CI entrypoint and safety gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+## Workflow
+
+1. Keep changes scoped to the active issue.
+2. Keep at most one open PR for this repository at any time.
+3. Run `./scripts/ci_local.sh` before pushing.
+4. React (emoji) to every review comment and reply with status when actioned.
+5. Do not commit private environment details (IP addresses, credentials, device identifiers). Use placeholders.
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Implementation-neutral references for the eBUS wire protocol and data types live
 - **Reviewer flow:** verify classification and documentation coverage using the [Mandatory Gate Flow](development/contributing.md#mandatory-gate-flow).
 - **Canonical policy:** [development/contributing.md#documentation-gate-doc-gate](development/contributing.md#documentation-gate-doc-gate)
 
+## Local CI (no GitHub Actions required)
+
+Run:
+
+```bash
+./scripts/ci_local.sh
+```
+
 ## Licensing
 
 This repository contains documentation under two licenses:

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> verify markdown files are present"
+count="$(git ls-files '*.md' | wc -l | tr -d ' ')"
+if [ "${count}" -eq 0 ]; then
+  echo "No markdown files found."
+  exit 1
+fi
+echo "Found ${count} markdown files."
+
+echo "==> check markdown for tabs and trailing spaces"
+failed=0
+if git grep -nI $'\t' -- '*.md'; then
+  echo "Tab characters are not allowed in markdown files."
+  failed=1
+fi
+if git grep -nI -E ' +$' -- '*.md'; then
+  echo "Trailing spaces are not allowed in markdown files."
+  failed=1
+fi
+if [ "${failed}" -ne 0 ]; then
+  exit 1
+fi
+
+echo "==> enforce initiator/target terminology"
+python3 - <<'PY'
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+allowed_file = pathlib.Path("protocols/ebus-overview.md")
+begin_marker = "<!-- legacy-role-mapping:begin -->"
+end_marker = "<!-- legacy-role-mapping:end -->"
+
+# Construct legacy terms without spelling them out literally in-repo.
+terms = ["m" + "aster", "sl" + "ave"]
+pattern = re.compile(r"\\b(" + "|".join(map(re.escape, terms)) + r")\\b", re.IGNORECASE)
+
+md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+
+def line_number(text: str, index: int) -> int:
+    return text.count("\\n", 0, index) + 1
+
+def print_match(file_path: str, text: str, index: int, match_text: str) -> None:
+    print(f"{file_path}:{line_number(text, index)}:{match_text}", file=sys.stderr)
+
+if not allowed_file.exists():
+    print(f"Expected {allowed_file} to exist.", file=sys.stderr)
+    sys.exit(1)
+
+allowed_text = allowed_file.read_text(encoding="utf-8")
+begin_index = allowed_text.find(begin_marker)
+end_index = allowed_text.find(end_marker)
+if begin_index == -1 or end_index == -1 or end_index <= begin_index:
+    print(
+        "Missing or malformed legacy-role-mapping markers in protocols/ebus-overview.md.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+allowed_region_start = begin_index
+allowed_region_end = end_index
+
+failed = False
+
+for file_path in md_files:
+    path = pathlib.Path(file_path)
+    text = path.read_text(encoding="utf-8")
+    for match in pattern.finditer(text):
+        if path != allowed_file:
+            if not failed:
+                print(
+                    "Legacy role terms must not appear outside protocols/ebus-overview.md.",
+                    file=sys.stderr,
+                )
+            failed = True
+            print_match(file_path, text, match.start(), match.group(0))
+
+for match in pattern.finditer(allowed_text):
+    if not (allowed_region_start <= match.start() < allowed_region_end):
+        if not failed:
+            print(
+                "Legacy role terms must only appear inside the legacy-role-mapping note.",
+                file=sys.stderr,
+            )
+        failed = True
+        print_match(str(allowed_file), allowed_text, match.start(), match.group(0))
+
+if failed:
+    sys.exit(1)
+
+print("Terminology gate passed.")
+PY
+
+echo "==> private IPv4 address gate (docs must use placeholders)"
+python3 - <<'PY'
+from __future__ import annotations
+
+import ipaddress
+import pathlib
+import re
+import subprocess
+import sys
+
+md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
+
+def is_private(ip: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return addr.version == 4 and (addr.is_private or addr.is_link_local)
+
+failed = False
+
+for file_path in md_files:
+    text = pathlib.Path(file_path).read_text(encoding="utf-8")
+    for match in ipv4_re.finditer(text):
+        ip = match.group(0)
+        if not is_private(ip):
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        print(f"{file_path}:{line}: private IPv4 address found (redact and use a placeholder)", file=sys.stderr)
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("Private IPv4 gate passed.")
+PY


### PR DESCRIPTION
Fixes #94.

Adds:
- `scripts/ci_local.sh` (markdown whitespace checks, terminology gate, private IPv4 leak gate)
- `AGENTS.md` baseline workflow rules
- README: local CI command