### PR TITLE
META-01: fix private IPv4 gate classification

### DIFF
--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -112,12 +112,22 @@ import sys
 md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
 ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
 
-def is_private(ip: str) -> bool:
+PRIVATE_NETS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local
+]
+
+def is_private_ipv4(ip: str) -> bool:
     try:
         addr = ipaddress.ip_address(ip)
     except ValueError:
         return False
-    return addr.version == 4 and (addr.is_private or addr.is_link_local)
+    if addr.version != 4:
+        return False
+    return any(addr in net for net in PRIVATE_NETS)
 
 failed = False
 
@@ -125,7 +135,7 @@ for file_path in md_files:
     text = pathlib.Path(file_path).read_text(encoding="utf-8")
     for match in ipv4_re.finditer(text):
         ip = match.group(0)
-        if not is_private(ip):
+        if not is_private_ipv4(ip):
             continue
         line = text.count("\n", 0, match.start()) + 1
         print(f"{file_path}:{line}: private IPv4 address found (redact and use a placeholder)", file=sys.stderr)


### PR DESCRIPTION
Fixes #102.

- Make the private IPv4 leak gate RFC1918/CGNAT/link-local only (avoid false positives on TEST-NET + loopback placeholders).