### PR TITLE
docs: META-05 ebusd-tcp smoke/runtime hardening notes

### DIFF
--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -95,8 +95,11 @@ When `-transport ebusd-tcp` is selected, the gateway uses ebusd's text command c
 
 - `ERR:` lines with timeout/no-answer wording are treated as timeouts.
 - Other `ERR:` lines (or malformed hex/usage responses) are treated as invalid payload errors.
+- `dump enabled` / `dump disabled` banners are treated as non-semantic noise and ignored.
 - If multiple lines are returned, parsers should use the first valid hex payload line and ignore later trailing noise.
+- If an `ERR:` line appears before the actual hex payload in the same command response burst, parsers keep a short follow-up window to catch the valid hex line.
 - Empty/no non-empty response lines are treated as timeout conditions.
+- Runtime transport setup clamps `ebusd-tcp` read/write deadlines to at least `scan-request-timeout` (default floor `400ms`) to reduce cross-command stream desynchronization.
 
 ## mDNS Discovery
 

--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -22,6 +22,7 @@ enh:
   timeout_sec: 10
 
 smoke:
+  profile: enh|ens|ebusd-tcp
   verbose_frames: false
   scan_timeout_sec: 5
   method_timeout_sec: 10
@@ -36,6 +37,13 @@ expected_devices:
     sw_version: ""
     hw_version: ""
 ```
+
+`smoke.profile` notes:
+
+- `enh` and `ens` use enhanced adapter framing (`ens` is accepted as compatibility alias of ENH).
+- `ebusd-tcp` routes requests through ebusd command mode (`hex` on port `8888` by default).
+- `ebusd` is accepted as alias of `ebusd-tcp` in smoke config normalization.
+- For `ebusd-tcp`, `enh.type` must be `tcp` (host/port), not `unix`.
 
 If `EBUS_SMOKE=1` is set and `AGENT-local.md` is missing or invalid, the test **fails** with an error.
 


### PR DESCRIPTION
Doc-gate update for META-05 transport/runtime hardening in `helianthus-ebusgo#88` and `helianthus-ebusgateway#119`.

## Summary
- document `smoke.profile` options and `ebusd` alias behavior
- document `ebusd-tcp` requirement for `enh.type: tcp`
- document parser handling for `dump enabled/disabled` noise lines
- document short follow-up window for `ERR` + delayed-hex response bursts
- document gateway timeout clamp floor for `ebusd-tcp` read/write deadlines

## Validation
- `./scripts/ci_local.sh` (pass)
