### PR TITLE
docs: document initiator join behavior (META-06.4 part 1)

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -234,3 +234,21 @@ For write confirmation (when a write API exists), perform targeted confirm reads
 - Promotion rule: a behind-controller device becomes **physical** once Helianthus implements a stable, deterministic protocol via the controller to read its identity/capabilities.
 
 **Consequences:** Device identity remains stable and explainable, UIs can render correct parent/child topology, and derived semantic devices do not pretend to be independently addressable hardware.
+
+## ADR-018: Initiator join uses passive warmup with bounded active inquiry
+
+**Status:** Accepted
+
+**Context:** On live buses, Helianthus may join while other initiators are already active. Joining should minimize additional traffic and avoid known address collisions.
+
+**Decision:**
+
+- Join starts with a passive listen warmup (default 5s) and builds source/target activity statistics.
+- Candidate initiator addresses are selected from the valid 25-address set.
+- Selection prefers highest addresses by default (lower arbitration priority) unless explicitly configured otherwise.
+- Companion target (`initiator + 0x05`) activity heuristics reject risky candidates when the companion target looks active.
+- Active `0x07 0xFE` inquiry is optional, rate-limited, and bounded per process session.
+- Last-good initiator persistence is best-effort and only reused when still safe.
+- If all initiator addresses are occupied, join fails explicitly by default; force mode is opt-in.
+
+**Consequences:** Default join behavior keeps bus chatter low, produces deterministic telemetry for selection rationale, and avoids unsafe address reuse while preserving an explicit operator override path.

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -48,6 +48,18 @@ In direct-mode eBUS implementations (including Helianthus), initiator addresses 
 
 Addresses equal to `0xA9` (escape) or `0xAA` (SYN) are invalid in address positions.
 
+### Helianthus Initiator Join Strategy
+
+When Helianthus must choose an initiator address on a live bus, it follows a low-disturbance join sequence:
+
+1. Passive listen warmup (default `5s`), collecting observed source and destination activity.
+2. Candidate selection from the valid 25-address initiator set.
+3. Default preference for higher addresses first (`FF, F7, ...`) to keep lower-priority arbitration behavior.
+4. Companion-target heuristic: reject a candidate if `(initiator + 0x05)` appears active as a probable target source or is frequently addressed as destination traffic.
+5. Optional active discovery (`0x07 0xFE`) is disabled by default and bounded/rate-limited when enabled.
+
+If all 25 initiator addresses are observed as occupied, join fails by default with an explicit error. Force selection is opt-in.
+
 ## ACK/NACK Symbols
 
 The bus uses one-byte symbols:


### PR DESCRIPTION
## Summary
- add `ADR-018` covering passive warmup, bounded inquiry, persistence, and force-mode semantics for initiator join
- document Helianthus initiator join strategy in `protocols/ebus-overview.md`
- clarify that default behavior is passive-first with optional bounded `0x07 0xFE` inquiry

## Validation
- `./scripts/ci_local.sh`

Part of #98
