### PR TITLE
docs: document collision monitor behavior (META-06.4 part 2)

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -252,3 +252,21 @@ For write confirmation (when a write API exists), perform targeted confirm reads
 - If all initiator addresses are occupied, join fails explicitly by default; force mode is opt-in.
 
 **Consequences:** Default join behavior keeps bus chatter low, produces deterministic telemetry for selection rationale, and avoids unsafe address reuse while preserving an explicit operator override path.
+
+## ADR-019: Collision monitor enforces fail-fast writes on foreign same-source traffic
+
+**Status:** Accepted
+
+**Context:** In shared-bus or proxied deployments, another participant can emit frames with the same initiator address Helianthus currently uses. Without explicit detection, request/response ordering and arbitration assumptions become unsafe.
+
+**Decision:**
+
+- Track recently transmitted frames in a bounded history with timestamps.
+- For each received frame with `SRC == active initiator`, compare against recent local transmit history inside an echo window (default `200ms`):
+  - matching frame: treat as local echo, no collision event,
+  - non-matching frame: mark collision as foreign same-source.
+- If runtime is in muted/listen-only mode, any `SRC == active initiator` frame is treated as collision.
+- After rejoin (initiator change), ignore frames from the previous initiator during a grace window (default `750ms`) to avoid delayed-echo false positives.
+- While collision state is active, new writes fail fast with an explicit arbitration-failed error classification.
+
+**Consequences:** Collision state becomes deterministic and observable, upper layers can immediately stop unsafe writes, and rejoin transitions remain stable under delayed bus echoes.

--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -103,6 +103,18 @@ Key points:
 - **Response shape**: In initiator/target transactions the target response begins with a **length byte** and does not repeat source/destination addresses.
 - **SYN** (`0xAA`) is used as an **end-of-message** delimiter and may also appear during idle.
 
+### Collision Detection Model (Helianthus)
+
+For multi-client/proxy setups, Helianthus collision handling uses a receive-vs-transmit check:
+
+- Maintain a bounded history of locally transmitted frames with timestamps.
+- On receive, when `SRC == active initiator`:
+  - if frame matches a recent local transmit inside the echo window (`200ms` default), treat as local echo,
+  - otherwise classify as foreign same-source collision.
+- In muted/listen-only mode, any `SRC == active initiator` receive frame is classified as collision.
+- After initiator rejoin, frames with the previous initiator source are ignored during a grace window (`750ms` default).
+- While collision is active, write attempts fail fast with an arbitration-failed classification.
+
 ## CRC8 and Escaping
 
 CRC8 is computed over the frame data with special handling for control symbols:


### PR DESCRIPTION
## Summary
- add `ADR-019` for collision monitor behavior and fail-fast arbitration semantics
- document receive-vs-transmit collision classification in `protocols/ebus-overview.md`
- document muted-mode collision handling and rejoin grace window semantics

## Validation
- `./scripts/ci_local.sh`

Part of #98
