### PR TITLE
Document matrix blocked-infra + UDP plain START controls

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -30,6 +30,7 @@ flowchart TB
     T1[RawTransport]
     T2[ENH (enhanced adapter protocol)]
     T3[UDP-PLAIN (raw UDP eBUS bytes)]
+    T4[TCP-PLAIN (raw TCP eBUS bytes)]
   end
 
   G1 --> G0
@@ -46,6 +47,7 @@ flowchart TB
   P1 --> T1
   T1 --> T2
   T1 --> T3
+  T1 --> T4
 ```
 
 Naming note:
@@ -53,6 +55,7 @@ Naming note:
 - `protocols/enh.md` / `protocols/ens.md` document ebusd’s ENH/ENS adapter protocol semantics.
 - The eBUS wire-level escape sequences (`ESC=0xA9`, `SYN=0xAA`) are documented in `protocols/ebus-overview.md` and decoded in the protocol layer (Bus decoder), not as a separate transport.
 - `protocols/udp-plain.md` documents raw UDP byte-stream adapters that do not implement ENH framing.
+- `tcp-plain` in gateway and proxy uses the same raw-byte semantics as UDP-plain over TCP stream sockets.
 
 ## Gateway Runtime (Implemented)
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -22,7 +22,7 @@
 
 | Flag | Purpose | Notes |
 |---|---|---|
-| `-transport` | Backend protocol | `enh`, `ens` (alias of `enh`), `udp-plain`, or `ebusd-tcp` |
+| `-transport` | Backend protocol | `enh`, `ens` (alias of `enh`), `udp-plain`, `tcp-plain`, or `ebusd-tcp` |
 | `-network` | Dial network | `unix`, `tcp`, or `udp` |
 | `-address` | Socket path or host:port | Example: `/var/run/ebusd/ebusd.socket` or `127.0.0.1:8888` |
 | `-source-addr` | Initiator/source address used by scan + semantic reads | Hex (`0xF0`), decimal, `0x00`, or `auto` |
@@ -53,6 +53,13 @@ go run ./cmd/gateway \
   -address 203.0.113.10:9999 \
   -source-addr auto
 
+# Raw TCP byte stream (software arbitration required above transport)
+go run ./cmd/gateway \
+  -transport tcp-plain \
+  -network tcp \
+  -address 203.0.113.10:9999 \
+  -source-addr auto
+
 # ebusd command backend over unix socket
 go run ./cmd/gateway \
   -transport ebusd-tcp \
@@ -64,7 +71,7 @@ For ebusd command syntax and response framing details, see `protocols/ebusd-tcp.
 
 ### Source-address behavior
 
-- `-source-addr auto` (or `-source-addr 0x00`) enables **gentle-join** behavior with proxy-mediated ENS/ENH/UDP-plain flows.
+- `-source-addr auto` (or `-source-addr 0x00`) enables **gentle-join** behavior with proxy-mediated ENS/ENH/UDP-plain/TCP-plain flows.
 - In gentle-join mode, Helianthus asks the proxy to select a free initiator dynamically instead of pinning a fixed address.
 - `-source-addr 0x31` should be avoided when `ebusd` is also active, because `0x31` is `ebusd`'s common default initiator.
 - With `-transport ebusd-tcp`, source selection only affects ebusd command parameters; the on-wire initiator is still ebusd's own bus identity.

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -56,3 +56,14 @@ Doc-gate is mandatory for changes that affect implemented architecture, APIs, or
 - [ ] Wire formats / API fields / behavior notes include concrete, testable details where needed.
 - [ ] PR description includes clear evidence of doc updates (or valid non-trigger rationale).
 - [ ] I will withhold approval if doc-gate requirements are incomplete.
+
+## Transport Runtime Gate (Merge Blocking)
+
+For eBUS transport/protocol changes, merge readiness requires an additional runtime gate:
+
+- **Scope:** changes in transport/protocol code paths (gateway transport selection, proxy upstream/downstream transport behavior, ebusgo transport implementations, arbitration behavior tied to wire protocol).
+- **Required artifact:** full matrix result (`T01..T88`) with no unexpected failures (`fail`) and no unexpected passes (`xpass`) against the active expected-failure inventory.
+- **Required reference:** PR description must include the `results/index.json` path or attachment reference.
+- **Expected-failure inventory:** any `xfail` must map to a documented transport limitation (case IDs + reason), and that inventory must be attached in the PR description.
+- **Default policy:** if runtime gate is not satisfied, merge is blocked.
+- **Owner override:** only explicit owner approval may bypass this gate, with a written reason.

--- a/development/smoke-matrix.md
+++ b/development/smoke-matrix.md
@@ -1,15 +1,24 @@
-# 42-Topology Smoke Matrix Runner
+# 88-Topology Smoke Matrix Runner
 
-This runbook documents the matrix runner from `helianthus-ebusgateway` (`cmd/matrix-runner`) used to plan/execute the 42 topology combinations.
+This runbook documents the matrix runner from `helianthus-ebusgateway` (`cmd/matrix-runner`) used to plan/execute the full 88 topology combinations.
 
 ## Matrix coverage
 
-The matrix is generated as cases `T01..T42`:
+The matrix is generated as cases `T01..T88` with transport set:
 
-- `T01..T03`: direct gateway access to adapter via `ENS`, `ENH`, `UDP`.
-- `T04..T06`: gateway via `ebusd-tcp`, where `ebusd` connects southbound via `ENS`, `ENH`, `UDP`.
-- `T07..T15`: gateway via proxy (single client), with `gateway->proxy` x `proxy->adapter` (`3 x 3`).
-- `T16..T42`: gateway + `ebusd` simultaneously through proxy (`3 x 3 x 3`).
+- `ENS`
+- `ENH`
+- `UDP-plain`
+- `TCP-plain`
+
+Case families:
+
+- `T01..T04`: direct gateway access to adapter (`4` transports).
+- `T05..T08`: gateway via `ebusd-tcp`, where `ebusd` southbound uses `4` transports.
+- `T09..T24`: gateway via proxy (single client), with `gateway->proxy` x `proxy->adapter` (`4 x 4 = 16`).
+- `T25..T88`: gateway + `ebusd` simultaneously through proxy (`gateway->proxy` x `proxy->adapter` x `ebusd->proxy` = `4 x 4 x 4 = 64`).
+
+Total: `4 + 4 + 16 + 64 = 88`.
 
 ## Artifacts
 
@@ -52,6 +61,56 @@ go run ./cmd/matrix-runner \
   --smoke-command "<smoke validation command>"
 ```
 
+Optional expected-failure inputs:
+
+- `--expected-failures T07,T08` with a shared reason from `--expected-failure-reason`.
+- `--expected-failures-file expected_failures.json` where JSON format is:
+
+```json
+{
+  "T07": "gentle-join not verifiable via ebusd-tcp",
+  "T33": "known udp southbound limitation"
+}
+```
+
+### Full run recommendation
+
+For transport/protocol merges, run the complete set (`T01..T88`) and keep `results/index.json` as the merge-gate artifact:
+
+```bash
+go run ./cmd/matrix-runner \
+  --target ha-addon \
+  --execute \
+  --start-gateway "<start gateway command>" \
+  --stop-gateway "<stop gateway command>" \
+  --start-proxy "<start proxy command>" \
+  --stop-proxy "<stop proxy command>" \
+  --start-ebusd "<start ebusd command>" \
+  --stop-ebusd "<stop ebusd command>" \
+  --smoke-command "<smoke validation command>"
+```
+
+`smoke` should include the Home Assistant inventory verifier (`helianthus-ha-integration/scripts/ha_inventory_verifier.py`) so each case validates both transport behavior and HA-visible inventory consistency.
+
+### Current expected-fail categories
+
+`matrix-runner` currently marks these families as expected failures by default:
+
+- `T05..T08` (`via-ebusd-tcp`): gentle-join cannot be verified when Helianthus uses `ebusd-tcp`.
+- `proxy-dual-client` with `ebusd->proxy = udp`: bus-traffic visibility is not reliable for the current proxy behavior.
+- `proxy-dual-client` with `proxy->adapter = udp` or `proxy->adapter = tcp`: dual-client cohabitation is currently unstable across these southbound modes.
+
+When running the gate, treat `xfail` as known limitations only if the reason is explicitly listed in the attached expected-failure inventory.
+
+### Infrastructure-blocked outcome
+
+When a case cannot run due adapter infrastructure state (for example adapter preflight reports `eBUS signal is not acquired`), matrix verdict uses:
+
+- `outcome = blocked-infra`
+- `infra_reason = adapter_no_signal`
+
+Transport gate accepts `blocked-infra` only with `infra_reason=adapter_no_signal`.
+
 ## Verdict semantics
 
 `verdict.json` status values:
@@ -61,6 +120,15 @@ go run ./cmd/matrix-runner \
 - `failed`: at least one configured command failed.
 
 Each command step is logged with command string, timestamps, status, and exit code (when available).
+
+`verdict.json` outcome values:
+
+- `pass`: expected pass and case passed.
+- `fail`: expected pass and case failed.
+- `xfail`: expected fail and case failed.
+- `xpass`: expected fail but case passed.
+- `blocked-infra`: run blocked by infrastructure precondition (see `infra_reason`).
+- `planned`: dry-run outcome.
 
 ## Privacy and secrets
 

--- a/development/smoke-test.md
+++ b/development/smoke-test.md
@@ -53,7 +53,7 @@ If `EBUS_SMOKE=1` is set and `AGENT-local.md` is missing or invalid, the test **
 EBUS_SMOKE=1 go run ./cmd/smoke
 ```
 
-For the full 42-topology matrix runner (`T01..T42`), see `development/smoke-matrix.md`.
+For the full 88-topology matrix runner (`T01..T88`), see `development/smoke-matrix.md`.
 
 ## Behavior
 

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -71,6 +71,8 @@ Current proxy behavior for UDP-PLAIN arbitration:
 - retries are bounded (`4` attempts),
 - exponential backoff is applied (`25ms`, `50ms`, `100ms`, `200ms`, capped by config constants),
 - bounded jitter is applied on retry backoff (`udp-retry-jitter`, default `0.2`) to avoid synchronized retry storms,
+- START arbitration timeout is configurable (`udp-plain-start-wait`, default `5s`),
+- timeout fallback to `STARTED` is enabled by default for plain-wire interoperability and can be disabled with `udp-plain-disable-start-fallback=true`,
 - ownership is released on upstream idle boundary (`SYN`/`0xAA`) and terminal upstream errors (`ERROR_EBUS`, `ERROR_HOST`),
 - timeout paths return host-side error to the northbound client.
 


### PR DESCRIPTION
Fixes #113

## What
- documents expected-failure runner flags and 88-case full-run guidance in smoke matrix docs
- documents blocked-infra outcome semantics with infra_reason=adapter_no_signal
- documents UDP-plain START timeout/fallback controls in protocol docs
- includes related architecture/deployment/contributing doc alignment already part of this branch

## Validation
- ./scripts/ci_local.sh
