### PR TITLE
Architecture: document scan alias-face retention (#119)

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -74,6 +74,8 @@ The registry layer treats each physical eBUS device as a **DeviceEntry** discove
 - a deterministic primary `Address()` (first/canonical address used in projection paths),
 - an alias list `Addresses()` (all observed addresses for that same physical identity).
 
+During scan, Helianthus treats the response source as canonical when available, but still retains the queried target as an alias face when source and target differ. This avoids losing valid faces (for example, a SOL00-style `0xEC` target) when multiple targets answer with the same source identity.
+
 A DeviceEntry does not directly expose behavior; instead, **PlaneProviders** match against the DeviceInfo (manufacturer, device ID, HW/SW versions, and stable identifiers when available) and **create one or more Planes** that represent distinct semantic views of that same device (e.g., heating, DHW, system).
 
 Each Plane publishes:


### PR DESCRIPTION
## Summary
- document 0x07/0x04 behavior when response source differs from queried target
- clarify scanner keeps queried target as alias face to avoid misses like SOL00 `0xEC`

## Validation
- `./scripts/ci_local.sh`

Closes #119
Related: d3vi1/helianthus-ebusreg#81