### PR TITLE
DOC: Centralize MCP-first ADR architecture and workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Implementation-neutral references for the eBUS wire protocol and data types live
 
 | Area | Start docs |
 |---|---|
-| Architecture | [architecture/overview.md](architecture/overview.md), [architecture/decisions.md](architecture/decisions.md) |
+| Architecture | [architecture/overview.md](architecture/overview.md), [architecture/decisions.md](architecture/decisions.md), [architecture/mcp-first-development.md](architecture/mcp-first-development.md) |
 | Protocols | [protocols/ebus-overview.md](protocols/ebus-overview.md), [protocols/ebusd-tcp.md](protocols/ebusd-tcp.md), [protocols/ebus-vaillant.md](protocols/ebus-vaillant.md), [protocols/ebus-vaillant-GetExtendedRegisters.md](protocols/ebus-vaillant-GetExtendedRegisters.md) |
 | Types | [types/overview.md](types/overview.md), [types/primitives.md](types/primitives.md), [types/composite.md](types/composite.md) |
 | API | [api/graphql.md](api/graphql.md), [api/mcp.md](api/mcp.md) |

--- a/api/mcp.md
+++ b/api/mcp.md
@@ -8,3 +8,16 @@ The MCP server is implemented and served by `cmd/gateway` at `/mcp`.
 
 - `ebus.devices`: list devices, planes, and methods
 - `ebus.invoke`: invoke a plane method with params
+
+## MCP-first Usage in Development
+
+Helianthus uses MCP as the first integration surface for new capabilities.
+The development order is:
+
+1. MCP prototype and stabilization (`ebus.v1.*` contract)
+2. GraphQL parity after MCP determinism/contract gates are green
+3. Consumer rollout (HA and others) after GraphQL parity
+
+The architecture model and gates are documented in:
+
+- [architecture/mcp-first-development.md](../architecture/mcp-first-development.md)

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -289,3 +289,26 @@ For write confirmation (when a write API exists), perform targeted confirm reads
 - Cached representation stores raw decoded response frame copy, and each caller re-decodes from that frame to avoid shared mutable decoded state.
 
 **Consequences:** Bus load drops under concurrent subscriptions, duplicate register reads are eliminated during active refresh windows, and response ordering risk is reduced because a single bus read serves concurrent callers for the same key.
+
+## ADR-021: MCP-first delivery order and parity gates
+
+**Status:** Accepted
+
+**Context:** Feature development needs a deterministic integration path that avoids drift between internal prototyping and external consumers.
+
+**Decision:** Use MCP as the primary development surface, then implement GraphQL parity, and only then enable consumer-facing integrations.
+Graduation requires deterministic MCP contracts, golden snapshots, and MCP <-> GraphQL parity tests.
+
+**Consequences:** New capabilities are stabilized earlier in a tool-oriented interface and cross-surface drift is detected before consumer rollout.
+
+See [MCP-first Development Model](mcp-first-development.md).
+
+## ADR-022: Centralized MCP architecture documentation in docs repository
+
+**Status:** Accepted
+
+**Context:** ADR content duplicated across runtime repositories creates drift and weakens doc-gate enforcement.
+
+**Decision:** Keep MCP architecture decisions centralized in `helianthus-docs-ebus` and remove duplicated local ADR files from runtime repos.
+
+**Consequences:** Documentation has a single canonical source and repository-level doc-gates remain auditable.

--- a/architecture/mcp-first-development.md
+++ b/architecture/mcp-first-development.md
@@ -1,0 +1,74 @@
+# MCP-first Development Model
+
+## Purpose
+
+This document defines how MCP is used as the primary development interface in Helianthus.
+It also centralizes the architecture decisions that were previously duplicated as local ADR files in runtime repositories.
+
+## Delivery Order
+
+New capability rollout order is mandatory:
+
+1. MCP-first prototype and stabilization
+2. GraphQL parity on top of stable MCP contracts
+3. Consumer rollout (Home Assistant and other clients) only after GraphQL parity gates are green
+
+## MCP Contract Baseline
+
+Core MCP tools (`ebus.v1.*`) use a stable envelope:
+
+- `meta`:
+  - `contract`
+  - `consistency`
+  - `data_timestamp`
+  - `data_hash`
+- `data`
+- `error` (null or structured error)
+
+Breaking contract changes require a new major namespace (`ebus.v2.*`).
+
+## Determinism Rules
+
+- Stable ordering for list-like outputs
+- Stable schema and field naming for `ebus.v1.*`
+- Snapshot mode must produce stable `data_hash` for identical input
+- Golden snapshots are required for schemas and representative outputs
+
+## Invoke Safety Model
+
+`ebus.v1.rpc.invoke` must enforce explicit intent and guardrails:
+
+- `intent`: `READ_ONLY` or `MUTATE`
+- `allow_dangerous=true` for mutating or unknown methods
+- `idempotency_key` for mutating intent
+
+Unknown mutability defaults to safe denial unless explicitly allowed.
+
+## Graduation Gates: MCP -> GraphQL
+
+A capability may graduate to GraphQL only when:
+
+1. It is implemented as core stable MCP (`ebus.v1.*`)
+2. Determinism + contract + golden tests are green
+3. MCP <-> GraphQL parity tests are green
+
+## Experimental Surface and Cleanup
+
+Experimental tools live under `ebus.experimental.*` and are not consumer-facing.
+At cycle end, each experimental tool must be:
+
+- promoted to core stable, or
+- removed, or
+- moved to internal-only with written justification
+
+No temporary/junk tools remain in the showroom MCP surface.
+
+## ADR Set (Centralized)
+
+This document supersedes duplicated local ADR notes previously added to runtime repositories.
+Canonical decisions are:
+
+1. MCP-first governance
+2. MCP v1 contract envelope
+3. Parity gates and cleanup policy
+4. Invoke safety and idempotency


### PR DESCRIPTION
## Summary
- add canonical MCP-first architecture document under architecture/
- document how MCP is used for Helianthus development lifecycle
- add ADR entries for MCP-first gates and centralized documentation policy
- update API MCP page to reference MCP-first development model

## Issue
Closes #123

## Validation
- ./scripts/ci_local.sh (pass)
