### PR TITLE
docs: portal ADR and M0 API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Implementation-neutral references for the eBUS wire protocol and data types live
 
 ## Start Here by Role
 
-- **Developer path:** [architecture/overview.md](architecture/overview.md) → [api/graphql.md](api/graphql.md) → [development/contributing.md](development/contributing.md)
+- **Developer path:** [architecture/overview.md](architecture/overview.md) → [api/graphql.md](api/graphql.md) → [api/portal.md](api/portal.md) → [development/contributing.md](development/contributing.md)
 - **Operator path:** [deployment/full-stack.md](deployment/full-stack.md) → [development/end-to-end-smoke.md](development/end-to-end-smoke.md) → [development/smoke-test.md](development/smoke-test.md)
 - **Researcher path:** [protocols/ebus-overview.md](protocols/ebus-overview.md) → [types/overview.md](types/overview.md) → [architecture/vaillant.md](architecture/vaillant.md)
 
@@ -21,7 +21,7 @@ Implementation-neutral references for the eBUS wire protocol and data types live
 | Architecture | [architecture/overview.md](architecture/overview.md), [architecture/decisions.md](architecture/decisions.md), [architecture/mcp-first-development.md](architecture/mcp-first-development.md) |
 | Protocols | [protocols/ebus-overview.md](protocols/ebus-overview.md), [protocols/ebusd-tcp.md](protocols/ebusd-tcp.md), [protocols/ebus-vaillant.md](protocols/ebus-vaillant.md), [protocols/ebus-vaillant-GetExtendedRegisters.md](protocols/ebus-vaillant-GetExtendedRegisters.md) |
 | Types | [types/overview.md](types/overview.md), [types/primitives.md](types/primitives.md), [types/composite.md](types/composite.md) |
-| API | [api/graphql.md](api/graphql.md), [api/mcp.md](api/mcp.md) |
+| API | [api/graphql.md](api/graphql.md), [api/mcp.md](api/mcp.md), [api/portal.md](api/portal.md) |
 | Deployment | [deployment/full-stack.md](deployment/full-stack.md), [deployment/tinygo-esp32.md](deployment/tinygo-esp32.md) |
 | Development | [development/contributing.md](development/contributing.md), [development/conventions.md](development/conventions.md), [development/ha-integration.md](development/ha-integration.md) |
 

--- a/api/portal.md
+++ b/api/portal.md
@@ -1,0 +1,75 @@
+# Portal API
+
+## Status
+
+Portal API is exposed by `helianthus-ebusgateway` as an additive HTTP surface.
+
+- UI shell: `/portal`
+- Versioned API base: `/portal/api/v1`
+
+M0 provides the read-only skeleton only. Data exploration APIs are added in later milestones.
+
+## Design Constraints
+
+- Gateway-first: semantic logic stays in gateway runtime.
+- Read-only by default for portal API.
+- Versioned endpoint paths (`/api/v1`) for forward evolution.
+- Runtime is Go-only; frontend assets are embedded in the gateway binary.
+
+## M0 Endpoints
+
+### `GET /portal/api/v1/health`
+
+Returns lightweight health metadata used by the portal shell.
+
+Example response:
+
+```json
+{
+  "status": "ok",
+  "gateway_version": "dev",
+  "build_id": "unknown",
+  "time_utc": "2026-02-24T00:00:00Z"
+}
+```
+
+### `GET /portal/api/v1/bootstrap`
+
+Returns portal boot configuration and capability flags.
+
+Example response:
+
+```json
+{
+  "capabilities": {
+    "registry": true,
+    "semantic": true,
+    "projection": true,
+    "stream": false
+  },
+  "endpoints": {
+    "graphql": "/graphql",
+    "snapshot": "/snapshot",
+    "subscriptions": "/graphql/subscriptions",
+    "mcp": "/mcp"
+  },
+  "limits": {
+    "max_events_per_second": 200,
+    "snapshot_retention": "disabled_in_m0"
+  },
+  "ui_version": "m0"
+}
+```
+
+## Security Defaults
+
+- Portal API accepts `GET` only in M0.
+- CORS remains same-origin by default.
+- No mutating/invoke actions are exposed by portal routes in M0.
+
+## Observability and Performance
+
+- M0 target latency:
+  - portal list/read endpoints p95 < 200ms
+- Static assets should include caching headers where possible.
+- Portal-specific request metrics and logs should be tagged by route.

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -312,3 +312,18 @@ See [MCP-first Development Model](mcp-first-development.md).
 **Decision:** Keep MCP architecture decisions centralized in `helianthus-docs-ebus` and remove duplicated local ADR files from runtime repos.
 
 **Consequences:** Documentation has a single canonical source and repository-level doc-gates remain auditable.
+## ADR-023: Gateway-hosted Portal API for evidence-first reverse engineering
+
+**Status:** Accepted
+
+**Context:** `helianthus-vrc-explorer` (Python) provided useful reverse-engineering workflows, but Helianthus runtime is Go-first. We need a dynamic portal that exposes multiple runtime views (functional planes, projections, semantic contract, and raw traces) without moving semantic logic into Home Assistant.
+
+**Decision:**
+
+- Add a dedicated gateway-hosted portal surface under `/portal`, with versioned read APIs under `/portal/api/v1/*`.
+- Keep portal API **read-only by default**. Any future mutating controls must be explicit, separately flagged, rate-limited, and audited.
+- Treat the gateway as the sole semantic authority; Home Assistant remains a consumer of GraphQL semantic contract only.
+- Use evidence-first workflow in the portal: investigation context, provenance, and exportable issue bundles are first-class outcomes.
+- Keep runtime Node-free: frontend assets are built at build-time and embedded in gateway binaries via Go `embed`.
+
+**Consequences:** Helianthus gains a native, production-aligned portal that can replace VRC-Explorer incrementally, while preserving architectural layering and minimizing operational complexity.


### PR DESCRIPTION
## What
Adds portal architecture ADR and M0 portal API documentation.

## Why
Gateway is adding a new externally visible `/portal` surface. Doc-gate requires canonical architecture/API updates.

## Includes
- ADR-021 in `architecture/decisions.md`
- New `api/portal.md`
- README API navigation update

Closes #125
Refs d3vi1/helianthus-ebusgateway#142
