### PR TITLE
docs: startup FSM + cache/live epoch semantics

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -118,6 +118,16 @@ Address semantics:
 - Value format is `0xNN` when resolved from runtime configuration.
 - In auto-leased proxy mode where the initiator is negotiated downstream, the field may return `auto`.
 
+## Semantic Startup Runtime Contract
+
+The semantic runtime distinguishes cache bootstrap from live updates during startup.
+
+- Cache-backed semantic payload may be published first and treated as stale bootstrap data.
+- Runtime transitions through startup phases (`BOOT_INIT` → `CACHE_LOADED_STALE` → `LIVE_WARMUP` → `LIVE_READY`, with `DEGRADED` timeout fallback).
+- If `-boot-live-timeout` elapses before `LIVE_READY`, runtime enters `DEGRADED` until live epochs recover.
+
+Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
+
 ### Projection Notes
 
 - **ProjectionNode.id** derives from the canonical Service path for the node (stable across projections).

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -67,6 +67,16 @@ The gateway now provides a runtime wiring layer that instantiates the bus, regis
 - **Router refresh**: `RefreshRouterPlanes()` extracts `router.Plane` implementations from the registry and updates the router’s subscription table.
 - **GraphQL schema rebuild**: the schema builder consumes registry entries and rebuilds schema snapshots whenever a registry change signal is emitted.
 
+## Semantic Startup Runtime
+
+Gateway semantic publication uses an explicit startup FSM to distinguish cache bootstrap from live runtime updates.
+
+- startup phases: `BOOT_INIT`, `CACHE_LOADED_STALE`, `LIVE_WARMUP`, `LIVE_READY`, `DEGRADED`
+- readiness criteria: live-ready is reached after at least two live semantic epochs
+- timeout control: `-boot-live-timeout` (default `2m`)
+
+See full state machine and transition table in [`architecture/startup-semantic-fsm.md`](./startup-semantic-fsm.md).
+
 ## Plane/Provider Model
 
 The registry layer treats each physical eBUS device as a **DeviceEntry** discovered via a 0x07/0x04 identification scan. A single physical device may be observed on multiple eBUS addresses (alias faces). The registry resolves these to one canonical DeviceEntry with:

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -1,0 +1,59 @@
+# Semantic Startup FSM
+
+This page documents the startup behavior for semantic data publication in `helianthus-ebusgateway`.
+
+Goal: publish deterministic semantic data during startup without pretending cached values are live.
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> BOOT_INIT
+
+  BOOT_INIT --> CACHE_LOADED_STALE: first cache epoch
+  BOOT_INIT --> LIVE_WARMUP: first live epoch
+
+  CACHE_LOADED_STALE --> LIVE_WARMUP: first live epoch
+  LIVE_WARMUP --> LIVE_READY: second+ live epoch
+
+  BOOT_INIT --> DEGRADED: boot_live_timeout
+  CACHE_LOADED_STALE --> DEGRADED: boot_live_timeout
+  LIVE_WARMUP --> DEGRADED: boot_live_timeout
+
+  DEGRADED --> LIVE_WARMUP: first live epoch after degraded
+  DEGRADED --> LIVE_READY: second+ live epoch after degraded
+```
+
+## Transition Table
+
+| From | To | Trigger | Notes |
+| --- | --- | --- | --- |
+| `BOOT_INIT` | `CACHE_LOADED_STALE` | first cache snapshot applied | cache is exposed as stale bootstrap data |
+| `BOOT_INIT` | `LIVE_WARMUP` | first live semantic update | first confirmed live signal |
+| `CACHE_LOADED_STALE` | `LIVE_WARMUP` | first live semantic update | stale cache begins replacement by live stream |
+| `LIVE_WARMUP` | `LIVE_READY` | second live semantic update | stable live runtime reached |
+| `BOOT_INIT`/`CACHE_LOADED_STALE`/`LIVE_WARMUP` | `DEGRADED` | `boot_live_timeout` elapsed | startup did not reach live-ready in time |
+| `DEGRADED` | `LIVE_WARMUP` | first live semantic update after degraded | recovery started |
+| `DEGRADED` | `LIVE_READY` | second live semantic update after degraded | recovery complete |
+
+## Epoch Semantics
+
+- `cache_epoch` increments when cache-backed semantic payload is applied.
+- `live_epoch` increments when live semantic payload is applied (including live broadcast-derived updates).
+- `cache_epoch` and `live_epoch` are tracked independently.
+- `live_epoch` is authoritative for startup readiness:
+  - `live_epoch = 0`: no live signal yet.
+  - `live_epoch = 1`: warmup only.
+  - `live_epoch >= 2`: live-ready.
+
+## Timeout Semantics
+
+- Runtime bootstrap timeout is controlled by `-boot-live-timeout` (default `2m`).
+- If timeout elapses before live-ready, runtime transitions to `DEGRADED`.
+- `DEGRADED` does not block recovery; later live updates can still move runtime to warmup/live-ready.
+
+## API and Runtime Cross-Links
+
+- GraphQL runtime notes: [`api/graphql.md`](../api/graphql.md#semantic-startup-runtime-contract)
+- Runtime and wiring context: [`architecture/overview.md`](./overview.md#semantic-startup-runtime)
+- HA consumer behavior: [`development/ha-integration.md`](../development/ha-integration.md)


### PR DESCRIPTION
## Summary
- document semantic startup FSM for gateway runtime
- define startup phases (`BOOT_INIT`, `CACHE_LOADED_STALE`, `LIVE_WARMUP`, `LIVE_READY`, `DEGRADED`)
- add transition table, epoch semantics (`cache_epoch` vs `live_epoch`), and timeout behavior
- cross-link runtime behavior from architecture and GraphQL docs

## Validation
- `./scripts/ci_local.sh`

## Links
- Closes #134
- Doc-gate for d3vi1/helianthus-ebusgateway#187
