### PR TITLE
Document MCP-first BAI boundaries and VWZ-equivalent design contract

### DIFF
--- a/api/mcp.md
+++ b/api/mcp.md
@@ -6,8 +6,27 @@ The MCP server is implemented and served by `cmd/gateway` at `/mcp`.
 
 ## Implemented Surface
 
-- `ebus.devices`: list devices, planes, and methods
-- `ebus.invoke`: invoke a plane method with params
+- Core stable (`ebus.v1.*`)
+  - `ebus.v1.runtime.status.get`
+  - `ebus.v1.registry.devices.list`
+  - `ebus.v1.registry.devices.get`
+  - `ebus.v1.registry.planes.list`
+  - `ebus.v1.registry.methods.list`
+  - `ebus.v1.semantic.zones.get`
+  - `ebus.v1.semantic.dhw.get`
+  - `ebus.v1.semantic.energy_totals.get`
+  - `ebus.v1.semantic.snapshot.get`
+  - `ebus.v1.snapshot.capture`
+  - `ebus.v1.snapshot.drop`
+  - `ebus.v1.rpc.invoke`
+- Legacy aliases
+  - `ebus.devices`
+  - `ebus.invoke`
+
+## Plane Boundary Note
+
+- `scan` is treated as a cross-device discovery layer and is not modeled as a heat-source class plane.
+- Heat-source planes (for class-specific modeling) are documented under architecture decisions and class design docs.
 
 ## MCP-first Usage in Development
 

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -344,3 +344,33 @@ See [MCP-first Development Model](mcp-first-development.md).
 These primitives are part of MCP-first foundation work and are consumed before GraphQL parity rollout.
 
 **Consequences:** Determinism behavior is reusable and testable across layers, invoke safety logic is less error-prone, and parity checks rely on a single canonical normalization path. No eBUS wire/protocol semantics are changed by this decision.
+
+## ADR-025: BAI heat-source modeling boundary and VWZ-equivalent design contract
+
+**Status:** Accepted
+
+**Context:** Helianthus needs deterministic heat-source modeling for Vaillant BAI while preventing domain leakage from controller/regulator semantics. The same design must be reusable for future heat-source classes (for example VWZ heat pumps) without re-inventing contracts each time.
+
+**Decision:**
+
+- BAI modeling is **BAI-only** and excludes EMM/controller semantics.
+- `scan` is a **cross-device discovery layer**, not a BAI plane. BAI planes are:
+  - `registers` (with groups such as `dia1`, `dia2`, `maintenance`, `expert`)
+  - `hcmode`
+  - `errors`
+  - `service`
+- Runtime enforcement must deny cross-domain lookups (`HEAT_SOURCE` cannot read `REGULATOR` registers, and vice versa).
+- Snapshot reads across multiple planes use explicit timeout policy:
+  - total timeout is caller-configurable (default `10s`)
+  - per-plane budget derives from total timeout and selected plane count
+  - default behavior is atomic (`allow_partial=false`)
+  - partial mode is opt-in (`allow_partial=true`) and must return `error_planes`.
+- Poll/read scheduling must include starvation prevention:
+  - queue depth limit (`100`)
+  - aging-based promotion (`15s`)
+  - emergency promotion (`30s`)
+  - FIFO preserved within the same effective priority band.
+- `common_core` must be versioned (`common_core_vN`) and must not regress in-place for stable API contracts.
+- Architecture docs are part of the runtime contract: every heat-source design change must be documented here in a way that enables an equivalent implementation for another heat-source class (VWZ).
+
+**Consequences:** BAI behavior stays deterministic and isolated from regulator behavior, multi-plane reads get explicit and testable timeout semantics, queue starvation is bounded under load, and future VWZ support can reuse the same contract surface with class-specific register catalogs.

--- a/architecture/mcp-first-development.md
+++ b/architecture/mcp-first-development.md
@@ -74,3 +74,30 @@ Canonical decisions are:
 2. MCP v1 contract envelope
 3. Parity gates and cleanup policy
 4. Invoke safety and idempotency
+
+## Heat-Source Class Extension Contract (BAI -> VWZ)
+
+To keep implementations equivalent across heat-source classes, each class design MUST document:
+
+1. Domain boundary:
+- source-class ownership (`HEAT_SOURCE` vs `REGULATOR`)
+- explicit deny rules for cross-domain registers.
+
+2. Plane model:
+- cross-device discovery planes vs class-specific planes
+- stable plane/group naming and ordering.
+
+3. Snapshot policy:
+- total timeout, per-plane budget, and partial mode semantics
+- required response fields for partial failures (`error_planes`, `completed_planes`).
+
+4. Scheduling policy:
+- queue depth limit
+- starvation prevention thresholds
+- FIFO behavior within equal effective priority.
+
+5. Common-core governance:
+- versioned common-core contract (`common_core_vN`)
+- non-regression rule for stable APIs.
+
+No new heat-source class (including VWZ) is considered ready for implementation until these sections are specified in docs with normative behavior (`MUST/SHOULD/MUST NOT`).


### PR DESCRIPTION
## Summary
- add ADR-025 covering BAI scope boundaries, snapshot timeout policy, scheduler anti-starvation requirements, and common-core versioning
- clarify that `scan` is cross-device (not heat-source class plane)
- add explicit documentation requirement so the same architecture can be implemented for VWZ heat sources
- update MCP and MCP-first architecture docs to reflect the new contract

## Local validation
- `bash scripts/ci_local.sh`

## Notes
- This is documentation-only and is intended to gate architecture consistency for subsequent implementation work.
