### PR TITLE
docs: startup source classification for ebusd grab hydration

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -125,6 +125,8 @@ The semantic runtime distinguishes cache bootstrap from live updates during star
 - Cache-backed semantic payload may be published first and treated as stale bootstrap data.
 - Runtime transitions through startup phases (`BOOT_INIT` → `CACHE_LOADED_STALE` → `LIVE_WARMUP` → `LIVE_READY`, with `DEGRADED` timeout fallback).
 - If `-boot-live-timeout` elapses before `LIVE_READY`, runtime enters `DEGRADED` until live epochs recover.
+- Successful `ebusd-tcp` fallback hydration from `grab result all` (zones/DHW) is classified as live runtime data.
+- Energy broadcast updates do not advance startup live epochs and cannot promote phase readiness by themselves.
 
 Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -74,6 +74,7 @@ Gateway semantic publication uses an explicit startup FSM to distinguish cache b
 - startup phases: `BOOT_INIT`, `CACHE_LOADED_STALE`, `LIVE_WARMUP`, `LIVE_READY`, `DEGRADED`
 - readiness criteria: live-ready is reached after at least two live semantic epochs
 - timeout control: `-boot-live-timeout` (default `2m`)
+- source rules: persistent cache preload advances `cache_epoch`; zone/DHW live updates (including successful `ebusd-tcp` grab hydration) advance `live_epoch`; energy broadcasts do not drive startup phase transitions
 
 See full state machine and transition table in [`architecture/startup-semantic-fsm.md`](./startup-semantic-fsm.md).
 

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -39,12 +39,18 @@ stateDiagram-v2
 ## Epoch Semantics
 
 - `cache_epoch` increments when cache-backed semantic payload is applied.
-- `live_epoch` increments when live semantic payload is applied (including live broadcast-derived updates).
+- `live_epoch` increments when live semantic payload is applied from zone/DHW refresh paths.
 - `cache_epoch` and `live_epoch` are tracked independently.
 - `live_epoch` is authoritative for startup readiness:
   - `live_epoch = 0`: no live signal yet.
   - `live_epoch = 1`: warmup only.
   - `live_epoch >= 2`: live-ready.
+
+### Source classification notes
+
+- Persistent semantic snapshot preload (`semantic_cache.json`) is cache-backed and only advances `cache_epoch`.
+- In `ebusd-tcp` fallback mode, successful `grab result all` hydration for zones/DHW is classified as **live** and can advance `live_epoch`.
+- Energy broadcast ingestion updates `energyTotals` but does **not** advance startup `live_epoch` and does not trigger startup phase transitions.
 
 ## Timeout Semantics
 

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -133,6 +133,8 @@ Gateway startup scan tries to reduce bus load by using ebusd's known target list
 When semantic B524 reads time out in `ebusd-tcp` mode, zone inventory/name/state can be recovered
 from ebusd's `grab result all` cache (passive snapshot), so climate entities can still appear without
 forcing additional bus traffic.
+Successful hydration from this path is classified as **live semantic source** for startup phase accounting
+(it is not treated as persistent stale cache preload).
 
 Runtime read/write traffic still uses the configured gateway transport.
 

--- a/development/ha-integration.md
+++ b/development/ha-integration.md
@@ -189,5 +189,7 @@ At setup, integration performs best-effort cleanup of stale `helianthus/*` regis
 - If `energyTotals` is absent, energy entities remain unavailable.
 - In `ebusd-tcp` deployments, zone entities can appear after the first semantic refresh cycle
   (default up to ~1 minute), because fallback discovery may hydrate zones from ebusd `grab result all`.
+- This fallback hydration is treated as live runtime semantic data (not stale cache preload), so startup
+  phase progression can continue when direct B524 reads are unavailable.
 - In `ebusd-tcp` fallback parsing, both B524 selector opcode families (`0x02` and `0x06`) are accepted from `grab result all` lines.
 - If `allowedModes` is absent, zone climate falls back to `off/auto/heat`.


### PR DESCRIPTION
## Summary
- document that successful `ebusd-tcp` `grab result all` hydration for zones/DHW is treated as a live startup source
- clarify that startup phase progression is driven by zone/DHW live updates, not energy broadcast ingestion
- add cross-links in startup FSM, GraphQL contract, HA integration notes, and deployment behavior

## Testing
- `./scripts/ci_local.sh`

Closes #141
