### PR TITLE
docs: add zone presence anti-flapping FSM contract

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -129,8 +129,11 @@ The semantic runtime distinguishes cache bootstrap from live updates during star
 - Energy broadcast updates do not advance startup live epochs and cannot promote phase readiness by themselves.
 - `LIVE_READY` requires live-backed updates for each published semantic stream (zones and/or DHW), not just `live_epoch >= 2`.
 - Persistent semantic preload is read from `-semantic-cache-path` and loaded as stale (`CACHE_LOADED_STALE`) when valid.
+- Zone visibility is hysteresis-based: `N_miss` consecutive misses before removal and `N_hit` consecutive hits before re-introduction (`-semantic-zone-presence-miss-threshold`, `-semantic-zone-presence-hit-threshold`).
+- Transient single-miss/single-hit alternation keeps zones stable and avoids entity flapping.
 
 Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
+Zone lifecycle details are documented in [`architecture/zone-presence-fsm.md`](../architecture/zone-presence-fsm.md).
 
 ### Projection Notes
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -76,9 +76,11 @@ Gateway semantic publication uses an explicit startup FSM to distinguish cache b
 - timeout control: `-boot-live-timeout` (default `2m`)
 - source rules: persistent cache preload advances `cache_epoch`; zone/DHW live updates (including successful `ebusd-tcp` grab hydration) advance `live_epoch`; energy broadcasts do not drive startup phase transitions
 - per-key B524 semantic reads are guarded by a circuit breaker (`closed`/`open`/`half-open`) with suppression and transition telemetry
+- zone publication uses an anti-flapping presence FSM (`ABSENT`, `SUSPECT_RESURRECT`, `PRESENT`, `SUSPECT_MISSING`) with configurable hit/miss hysteresis
 
 See full state machine and transition table in [`architecture/startup-semantic-fsm.md`](./startup-semantic-fsm.md).
 See breaker details in [`architecture/semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md).
+See zone presence details in [`architecture/zone-presence-fsm.md`](./zone-presence-fsm.md).
 
 ## Plane/Provider Model
 

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -78,4 +78,5 @@ stateDiagram-v2
 - GraphQL runtime notes: [`api/graphql.md`](../api/graphql.md#semantic-startup-runtime-contract)
 - Runtime and wiring context: [`architecture/overview.md`](./overview.md#semantic-startup-runtime)
 - Semantic read breaker behavior for B524 polling: [`architecture/semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md)
+- Zone presence hysteresis state machine: [`architecture/zone-presence-fsm.md`](./zone-presence-fsm.md)
 - HA consumer behavior: [`development/ha-integration.md`](../development/ha-integration.md)

--- a/architecture/zone-presence-fsm.md
+++ b/architecture/zone-presence-fsm.md
@@ -1,0 +1,66 @@
+# Zone Presence FSM (Anti-Flapping)
+
+This document defines how `helianthus-ebusgateway` decides whether a semantic zone is present.
+
+The goal is to avoid zone flapping when discovery reads alternate between success and transient failures.
+
+## Inputs
+
+- Discovery probe: B524 `GG=0x03`, register `RR=0x001C` (`zone index`) per instance (`0x00..0x0A`).
+- A probe result is treated as:
+  - **hit** when the request was checked and `RR=0x001C` is not `0xFF`.
+  - **miss** when the request was checked and `RR=0x001C` is `0xFF`.
+  - **unknown** when the request was not checked (timeout/error); unknown does not advance counters.
+
+`ebusd-tcp` fallback hydration (`grab result all`) feeds the same hit path for discovered zones.
+
+## Config Knobs
+
+- `-semantic-zone-presence-miss-threshold` (default `3`)
+- `-semantic-zone-presence-hit-threshold` (default `2`)
+
+Meaning:
+
+- `N_miss`: consecutive misses required before an existing zone is removed.
+- `N_hit`: consecutive hits required before an absent zone is reintroduced.
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> ABSENT
+
+  ABSENT --> SUSPECT_RESURRECT: hit (streak=1)
+  SUSPECT_RESURRECT --> PRESENT: hit and hit_streak >= N_hit
+  SUSPECT_RESURRECT --> ABSENT: miss
+
+  PRESENT --> SUSPECT_MISSING: miss (streak=1)
+  SUSPECT_MISSING --> ABSENT: miss and miss_streak >= N_miss
+  SUSPECT_MISSING --> PRESENT: hit
+
+  PRESENT --> PRESENT: hit
+```
+
+## Transition Rules
+
+| Current | Event | Next | Counter effect | Publish effect |
+| --- | --- | --- | --- | --- |
+| `ABSENT` | hit | `SUSPECT_RESURRECT` or `PRESENT` | `hit_streak++`, `miss_streak=0` | no publish until `PRESENT` |
+| `SUSPECT_RESURRECT` | hit | `SUSPECT_RESURRECT` or `PRESENT` | `hit_streak++`, `miss_streak=0` | publish only when promoted to `PRESENT` |
+| `SUSPECT_RESURRECT` | miss | `ABSENT` | `hit_streak=0` | no zone published |
+| `PRESENT` | hit | `PRESENT` | `miss_streak=0` | zone remains published |
+| `PRESENT` | miss | `SUSPECT_MISSING` or `ABSENT` | `miss_streak++`, `hit_streak=0` | zone remains published until `ABSENT` |
+| `SUSPECT_MISSING` | hit | `PRESENT` | `miss_streak=0` | zone remains published |
+| `SUSPECT_MISSING` | miss | `SUSPECT_MISSING` or `ABSENT` | `miss_streak++`, `hit_streak=0` | remove zone only when promoted to `ABSENT` |
+
+## Publication Contract
+
+- Only `PRESENT` zones are included in semantic zone payloads.
+- `SUSPECT_MISSING` keeps the existing zone published.
+- `ABSENT` removes the zone from published semantic payload.
+- `SUSPECT_RESURRECT` does not publish a new zone until `N_hit` is reached.
+
+This provides hysteresis:
+
+- short outages do not immediately remove zones;
+- single recovery blips do not immediately re-add zones.


### PR DESCRIPTION
## Summary
- document semantic zone presence FSM states (`ABSENT`, `SUSPECT_RESURRECT`, `PRESENT`, `SUSPECT_MISSING`)
- document configurable hysteresis thresholds (`N_miss`, `N_hit`) and CLI flags
- link startup/runtime GraphQL contract docs to the new zone presence FSM page

## Why
- doc-gate for gateway issue #190 (zone presence anti-flapping lifecycle)
- makes startup/runtime semantics testable for adversarial validation

## Validation
- ran `./scripts/ci_local.sh` in `helianthus-docs-ebus`

## Notes
- This is the zone-FSM slice of docs issue #135; DHW stale/expired lifecycle details remain for the #191/#192 follow-up scope.