### PR TITLE
docs: issue-191 non-destructive semantic merge semantics

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -131,6 +131,8 @@ The semantic runtime distinguishes cache bootstrap from live updates during star
 - Persistent semantic preload is read from `-semantic-cache-path` and loaded as stale (`CACHE_LOADED_STALE`) when valid.
 - Zone visibility is hysteresis-based: `N_miss` consecutive misses before removal and `N_hit` consecutive hits before re-introduction (`-semantic-zone-presence-miss-threshold`, `-semantic-zone-presence-hit-threshold`).
 - Transient single-miss/single-hit alternation keeps zones stable and avoids entity flapping.
+- Zone/DHW semantic publication uses non-destructive incremental merge: failed attempted fields retain last-known values instead of being wiped by partial snapshots.
+- Freshness is tracked per merged field in runtime state; GraphQL currently exposes merged values and startup phase/state contracts.
 
 Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
 Zone lifecycle details are documented in [`architecture/zone-presence-fsm.md`](../architecture/zone-presence-fsm.md).

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -77,6 +77,7 @@ Gateway semantic publication uses an explicit startup FSM to distinguish cache b
 - source rules: persistent cache preload advances `cache_epoch`; zone/DHW live updates (including successful `ebusd-tcp` grab hydration) advance `live_epoch`; energy broadcasts do not drive startup phase transitions
 - per-key B524 semantic reads are guarded by a circuit breaker (`closed`/`open`/`half-open`) with suppression and transition telemetry
 - zone publication uses an anti-flapping presence FSM (`ABSENT`, `SUSPECT_RESURRECT`, `PRESENT`, `SUSPECT_MISSING`) with configurable hit/miss hysteresis
+- zone/DHW semantic refresh uses non-destructive field-level merge so partial failures keep last-known values and mark freshness internally
 
 See full state machine and transition table in [`architecture/startup-semantic-fsm.md`](./startup-semantic-fsm.md).
 See breaker details in [`architecture/semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md).

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -56,6 +56,28 @@ stateDiagram-v2
 - In `ebusd-tcp` fallback mode, successful `grab result all` hydration for zones/DHW is classified as **live** and can advance `live_epoch`.
 - Energy broadcast ingestion updates `energyTotals` but does **not** advance startup `live_epoch` and does not trigger startup phase transitions.
 
+## Incremental Merge and Freshness Semantics
+
+Zone and DHW updates are merged incrementally, not replaced wholesale.
+
+- Merge is field-granular for zone config/state and DHW state/config slices.
+- For each polling slice, only attempted fields participate in merge decisions.
+- Attempted fields with valid values overwrite previous values and are marked fresh.
+- Attempted fields without valid values keep last-known values and are marked stale.
+- Unattempted fields are left unchanged (no implicit stale transition).
+
+Operational consequences:
+
+- Partial read failures do not wipe previously valid semantic values.
+- Empty/nil partial snapshots do not remove zone or DHW entities by themselves.
+- Zone visibility/removal remains controlled by zone presence hysteresis FSM.
+- Startup phase progression remains driven by stream-level live/cache epochs.
+
+Implementation note:
+
+- Field freshness is currently tracked in runtime semantic state and used for merge/lifecycle decisions.
+- GraphQL currently exposes the merged semantic values; field-level stale flags are not yet separately exposed as API fields.
+
 ## Persistent Cache Schema
 
 - Runtime cache file path is configurable via `-semantic-cache-path` (default `./semantic_cache.json`).


### PR DESCRIPTION
## Summary\n- document field-granular non-destructive merge for zone/DHW semantic refresh\n- clarify that attempted failed fields keep last-known values and are marked stale in runtime freshness tracking\n- link merge semantics into startup/runtime contract docs\n\n## Linked work\n- code issue: d3vi1/helianthus-ebusgateway#191\n- docs track: #135\n\n## Validation\n- documentation-only change