### PR TITLE
docs: issue-192 DHW stale TTL and expiry lifecycle

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -133,9 +133,11 @@ The semantic runtime distinguishes cache bootstrap from live updates during star
 - Transient single-miss/single-hit alternation keeps zones stable and avoids entity flapping.
 - Zone/DHW semantic publication uses non-destructive incremental merge: failed attempted fields retain last-known values instead of being wiped by partial snapshots.
 - Freshness is tracked per merged field in runtime state; GraphQL currently exposes merged values and startup phase/state contracts.
+- DHW retains last-known values during cache-only/transient gaps until `-semantic-dhw-stale-ttl` is exceeded, then `dhw` is explicitly cleared.
 
 Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
 Zone lifecycle details are documented in [`architecture/zone-presence-fsm.md`](../architecture/zone-presence-fsm.md).
+DHW lifecycle details are documented in [`architecture/dhw-freshness-fsm.md`](../architecture/dhw-freshness-fsm.md).
 
 ### Projection Notes
 

--- a/architecture/dhw-freshness-fsm.md
+++ b/architecture/dhw-freshness-fsm.md
@@ -1,0 +1,60 @@
+# DHW Freshness Lifecycle (Durability + TTL Expiry)
+
+This document defines how `helianthus-ebusgateway` handles DHW semantic durability under transient failures.
+
+Goal: keep valid last-known DHW values during short cache/transient gaps, but avoid indefinite stale-as-healthy publication.
+
+## Inputs
+
+- Live DHW refresh: B524 reads and/or `ebusd-tcp` fallback hydration.
+- Cache-sourced cycle: no live DHW refresh succeeded in the cycle.
+- Runtime setting: `-semantic-dhw-stale-ttl` (default `15m`).
+
+## Lifecycle Semantics
+
+At runtime, DHW publication follows this contract:
+
+1. **Live refresh success**
+   - Merge/update DHW fields.
+   - Mark DHW as live in provider.
+   - Update DHW last-update timestamp.
+
+2. **Cache-sourced cycle with existing DHW and age < TTL**
+   - Keep previously published DHW unchanged.
+   - Do not clear DHW only because current cycle was cache-sourced.
+
+3. **Cache-sourced cycle with age >= TTL**
+   - Expire DHW from semantic runtime state.
+   - Publish DHW removal (`null`) instead of preserving indefinite stale value.
+
+This prevents permanent stale-but-present DHW output.
+
+## Effective State Model
+
+```mermaid
+stateDiagram-v2
+  [*] --> ABSENT
+
+  ABSENT --> PRESENT_LIVE: first live DHW update
+  PRESENT_LIVE --> PRESENT_LIVE: live DHW updates
+
+  PRESENT_LIVE --> PRESENT_STALE_TTL: cache-only cycle and age < TTL
+  PRESENT_STALE_TTL --> PRESENT_LIVE: live DHW update
+  PRESENT_STALE_TTL --> ABSENT: cache-only cycle and age >= TTL
+```
+
+## Publication Contract
+
+- `PRESENT_LIVE`: GraphQL `dhw` object is present with live-backed data.
+- `PRESENT_STALE_TTL`: GraphQL `dhw` remains present with last-known values (durability window).
+- `ABSENT`: GraphQL `dhw` is `null`.
+
+Notes:
+
+- TTL expiry is evaluated on cache-sourced publication paths.
+- Zone presence FSM is independent; DHW lifecycle is separate from zone anti-flap logic.
+
+## Related
+
+- Startup FSM and source classification: [`startup-semantic-fsm.md`](./startup-semantic-fsm.md)
+- GraphQL runtime contract: [`../api/graphql.md`](../api/graphql.md#semantic-startup-runtime-contract)

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -78,10 +78,12 @@ Gateway semantic publication uses an explicit startup FSM to distinguish cache b
 - per-key B524 semantic reads are guarded by a circuit breaker (`closed`/`open`/`half-open`) with suppression and transition telemetry
 - zone publication uses an anti-flapping presence FSM (`ABSENT`, `SUSPECT_RESURRECT`, `PRESENT`, `SUSPECT_MISSING`) with configurable hit/miss hysteresis
 - zone/DHW semantic refresh uses non-destructive field-level merge so partial failures keep last-known values and mark freshness internally
+- DHW publication uses a stale TTL durability window (`-semantic-dhw-stale-ttl`) and expires to absent when cache-only age exceeds TTL
 
 See full state machine and transition table in [`architecture/startup-semantic-fsm.md`](./startup-semantic-fsm.md).
 See breaker details in [`architecture/semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md).
 See zone presence details in [`architecture/zone-presence-fsm.md`](./zone-presence-fsm.md).
+See DHW lifecycle details in [`architecture/dhw-freshness-fsm.md`](./dhw-freshness-fsm.md).
 
 ## Plane/Provider Model
 

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -71,6 +71,7 @@ Operational consequences:
 - Partial read failures do not wipe previously valid semantic values.
 - Empty/nil partial snapshots do not remove zone or DHW entities by themselves.
 - Zone visibility/removal remains controlled by zone presence hysteresis FSM.
+- DHW is durable under transient cache-only cycles and expires after `-semantic-dhw-stale-ttl`.
 - Startup phase progression remains driven by stream-level live/cache epochs.
 
 Implementation note:
@@ -101,4 +102,5 @@ Implementation note:
 - Runtime and wiring context: [`architecture/overview.md`](./overview.md#semantic-startup-runtime)
 - Semantic read breaker behavior for B524 polling: [`architecture/semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md)
 - Zone presence hysteresis state machine: [`architecture/zone-presence-fsm.md`](./zone-presence-fsm.md)
+- DHW durability and expiry lifecycle: [`architecture/dhw-freshness-fsm.md`](./dhw-freshness-fsm.md)
 - HA consumer behavior: [`development/ha-integration.md`](../development/ha-integration.md)


### PR DESCRIPTION
## Summary
- document DHW durability lifecycle under cache-only/transient failures
- specify stale TTL behavior via `-semantic-dhw-stale-ttl` and expiry to absent state
- link DHW lifecycle into startup/runtime docs and GraphQL runtime contract

## Linked
- code issue: d3vi1/helianthus-ebusgateway#192
- docs tracker: #135

## Validation
- documentation-only change
