### PR TITLE
issue-194: regulator re-detection and absence grace documentation

### DIFF
--- a/architecture/regulator-detection.md
+++ b/architecture/regulator-detection.md
@@ -60,16 +60,56 @@ The catalog is the `helianthus-ebus-vaillant-productids` dataset, loaded via `he
 
 ## Lifecycle
 
-- Regulator capability is recomputed on every `refreshDiscovery` cycle.
+- Regulator capability is recomputed on every `refreshDiscovery` cycle (default 10 minutes).
+- A faster **regulator recheck loop** (default 60 seconds, configurable via `-semantic-regulator-recheck-interval`) runs independently to detect capability changes between discovery cycles.
 - The computation runs **before** the BASV address lookup, so capability is always current even when no BASV-prefixed device is found in the registry.
 - Capability changes are logged: `semantic_regulator_capability capability=<value>`.
 - The legacy `findDeviceAddressByPrefix("BASV")` call remains for obtaining the controller's eBUS address for B524 polling. It is **not** used for regulator presence decisions.
+
+## Re-Detection and Absence Grace
+
+Regulator presence can change after boot (device power cycle, bus fault, firmware update). The gateway handles this with two mechanisms:
+
+### Inventory-Update Trigger
+
+The recheck loop tracks the total device count in the registry. When the count changes (new device registered or device removed), an immediate full `refreshDiscovery` is enqueued. This ensures that registry changes are reflected without waiting for the next 10-minute discovery cycle.
+
+### Absence Grace FSM
+
+```mermaid
+stateDiagram-v2
+  [*] --> PRESENT
+  PRESENT --> ABSENCE_GRACE: capability != ControllerPresent
+  ABSENCE_GRACE --> ABSENT: grace window expired (default 5min)
+  ABSENCE_GRACE --> PRESENT: capability == ControllerPresent
+  ABSENT --> PRESENT: capability == ControllerPresent
+```
+
+| State | Meaning |
+| --- | --- |
+| `PRESENT` | Regulator confirmed present via catalog lookup |
+| `ABSENCE_GRACE` | Regulator not detected; waiting for grace window before declaring absence |
+| `ABSENT` | Regulator absent after sustained grace period (`WARN_NO_REGULATOR`) |
+
+**Transitions:**
+
+- **PRESENT → ABSENCE_GRACE:** Capability changes from `ControllerPresent` to anything else. Grace timer starts.
+- **ABSENCE_GRACE → ABSENT:** Grace window (`-semantic-regulator-absence-grace`, default 5 minutes) expires with regulator still absent. Logged as `semantic_regulator_absence state=ABSENT`.
+- **ABSENCE_GRACE → PRESENT:** Regulator re-detected within grace window. Grace timer cleared.
+- **ABSENT → PRESENT:** Regulator re-detected after being absent. Full recovery.
+
+**Design notes:**
+
+- The grace window prevents false `WARN_NO_REGULATOR` from transient bus communication failures.
+- Grace expiry is inclusive (`>=`): transition happens at exactly the configured duration.
+- Both `ControllerNone` and `ControllerUnknown` trigger the grace window — the FSM does not distinguish between confirmed-absent and unknown devices.
 
 ## Known Limitations
 
 - **Multi-regulator systems:** If multiple devices report `ControllerPresent`, the first one found wins. Multi-regulator topologies are not supported in v1.
 - **Unknown devices:** Devices with part numbers absent from the catalog produce `ControllerUnknown`. The system does not assume regulator absence from unknown devices — only catalog-confirmed non-regulators produce `ControllerNone`.
 - **Catalog coverage:** Detection quality depends on catalog completeness. New Vaillant products require catalog updates in `helianthus-ebus-vaillant-productids`.
+- **Inventory trigger granularity:** The inventory-update trigger uses device count, not a fingerprint. Device replacements that maintain the same count are not detected as inventory changes.
 
 ## Cross-Links
 


### PR DESCRIPTION
## Summary
- Expanded `architecture/regulator-detection.md` with re-detection lifecycle, inventory-update trigger, and absence grace FSM
- Mermaid state diagram for PRESENT → ABSENCE_GRACE → ABSENT transitions
- Documents configuration flags: `-semantic-regulator-recheck-interval` (60s) and `-semantic-regulator-absence-grace` (5min)

## References
- Code PR: d3vi1/helianthus-ebusgateway#212
- Gateway issue: d3vi1/helianthus-ebusgateway#194
- Doc-gate: #136 (partial — #193 + #194 now complete)

## Test plan
- [ ] Verify doc renders correctly with mermaid diagram on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)