### PR TITLE
issue-196: register-primary energy ingestion documentation

### DIFF
--- a/architecture/energy-merge.md
+++ b/architecture/energy-merge.md
@@ -9,7 +9,7 @@ Energy data arrives via two paths:
 | Source | Confidence | Origin |
 | --- | --- | --- |
 | **Broadcast** | Low | eBUS bus broadcast events (passive listening) |
-| **Register** | High | Direct B524 register reads from the regulator (active polling) |
+| **Register** | High | Direct B5/16 register reads from the regulator (active polling, 5-minute interval) |
 
 ## Merge Key
 
@@ -59,9 +59,44 @@ The `energyMergeStore` has its own `sync.RWMutex`, separate from the `LiveSemant
 
 These locks are never held simultaneously — `Apply` and `Snapshot` complete before `provider.mu` is acquired.
 
+## Register-Primary Ingestion (B5/16)
+
+The register-primary path reads energy statistics directly from the regulator using the B5/16 protocol:
+
+```text
+Request:  [period, source, usage]
+Response: WORD (little-endian uint16, value in Wh)
+```
+
+### Parameters
+
+| Byte | Name | Values |
+| --- | --- | --- |
+| period | Time range | 0 = today, 1 = current year, 2 = previous year |
+| source | Energy source | 0 = gas, 1 = electricity, 2 = solar |
+| usage | Energy usage | 0 = climate (heating/cooling), 1 = hot_water |
+
+Total: 3 × 3 × 2 = **18 register reads** per refresh cycle.
+
+### Hardware Gating
+
+B5/16 energy stats are only available on devices with hardware version >= 7603. The gateway checks for the `get_energy_stats` method in the controller's registry planes before attempting reads.
+
+### Lifecycle
+
+- Energy register reads are scheduled every 5 minutes (configurable via `-semantic-energy-interval`).
+- The refresh is gated on: controller address known (`controller != 0`) AND regulator capability is `ControllerPresent`.
+- Each successful read calls `ApplyEnergyFromRegister()` with `EnergySourceRegister`, feeding through the merge truth table.
+- Failed reads are logged with a failure count but do not block other reads.
+
+### Source Precedence
+
+Once a register value has been written for a given merge key, broadcast updates for the same key are permanently rejected (until the merge store is reset). This ensures register-primary data integrity even when broadcast traffic is available.
+
 ## Cross-Links
 
 - EnergyTotals types: `graphql/semantic.go`
 - Merge implementation: `graphql/energy_merge.go`
-- Integration: `graphql/semantic_live.go` (`applyEnergy`)
-- Register-primary energy ingestion (future): issue #196
+- Integration: `graphql/semantic_live.go` (`applyEnergyPoint`)
+- Register ingestion: `cmd/gateway/semantic_vaillant.go` (`refreshEnergy`, `readB516Value`)
+- B5/16 protocol template: `helianthus-ebusreg/vaillant/heating/energy.go`


### PR DESCRIPTION
## Summary
- Expanded `architecture/energy-merge.md` with B5/16 register-primary ingestion documentation
- Documents protocol parameters, hardware gating, lifecycle, and source precedence
- Completes doc-gate #137 (energy merge + register ingestion)

## References
- Code PR: d3vi1/helianthus-ebusgateway#214
- Gateway issue: d3vi1/helianthus-ebusgateway#196
- Doc-gate: #137 (complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)