### PR TITLE
docs: add regression notes for slave response and ENS arbitration fixes

### DIFF
--- a/protocols/ebus-overview.md
+++ b/protocols/ebus-overview.md
@@ -100,7 +100,7 @@ Key points:
 
 - **Per-byte echo**: When an initiator drives a symbol onto the bus it will also observe the same symbol (“echo”). An echo mismatch indicates arbitration loss or a collision.
 - **ACK/NAK timing**: `ACK`/`NACK` is exchanged **once per command**, after the initiator sends the command CRC (not after each byte).
-- **Response shape**: In initiator/target transactions the target response begins with a **length byte** and does not repeat source/destination addresses.
+- **Response shape**: In initiator/target transactions the target response begins with a **length byte** and does not repeat source/destination addresses. CRC is computed over `LEN DATA...` only (not including any address bytes). Implementors must **not** attempt to read header bytes (SRC/DST/PB/SB) from the slave response — they are inferred from the initiator telegram. See ebusgo#104 for a regression where phantom header reads caused all master-slave transactions to fail.
 - **SYN** (`0xAA`) is used as an **end-of-message** delimiter and may also appear during idle.
 
 ### Collision Detection Model (Helianthus)

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -116,6 +116,12 @@ During arbitration initiated by the host, adapters **must not** emit `RECEIVED` 
 
 In ebusd “direct” mode, the initiator address byte is emitted as part of arbitration. After a successful `STARTED`, the host continues the telegram by sending `DST`, then `PB SB LEN ...` (i.e., it does not re-send `SRC`).
 
+> **Implementation note — ENS and ENH share arbitration semantics.** Both ENS and ENH adapters transmit the source byte on the wire during START arbitration. Callers must NOT include the source byte in the outgoing telegram payload for either mode. Setting `arbitrationSendsSource=false` for ENS is incorrect and causes a double source byte on the wire. See ebusgo#113.
+
+### Parser state after arbitration
+
+Implementations that use a stateful parser for ENH framing (e.g., two-byte command decoding) **must reset parser state** after arbitration completes (STARTED or FAILED). TCP fragmentation can deliver extra bytes alongside the arbitration response, leaving the parser with a partially-decoded frame. Without a reset, the stale parser state corrupts subsequent echo matching. See ebusgo#113, adapter-proxy#78.
+
 ## INFO
 
 `INFO` requests additional adapter metadata:


### PR DESCRIPTION
## Summary

- Clarify slave response CRC scope in ebus-overview.md (warn against phantom header reads)
- Document ENS/ENH shared arbitration semantics in enh.md
- Add parser state reset requirement after arbitration completion

## Doc-gate

Satisfies doc-gate for:
- ebusgo#104 (slave response format)
- ebusgo#111 (ebusd-tcp alignment)
- ebusgo#113 (arbitration reset + ENS delegation)
- adapter-proxy#78 (parser state reset on timeout)

Fixes #159