### PR TITLE
docs: update energy-merge.md for B5.24 VRC register reads

### DIFF
--- a/architecture/energy-merge.md
+++ b/architecture/energy-merge.md
@@ -9,7 +9,7 @@ Energy data arrives via two paths:
 | Source | Confidence | Origin |
 | --- | --- | --- |
 | **Broadcast** | Low | eBUS bus broadcast events (passive listening) |
-| **Register** | High | Direct B5/16 register reads from the boiler (BAI device, active polling, 5-minute interval) |
+| **Register** | High | Direct B5/24 register reads from the VRC controller (BASV2 device, active polling, 5-minute interval) |
 
 ## Merge Key
 
@@ -59,33 +59,44 @@ The `energyMergeStore` has its own `sync.RWMutex`, separate from the `LiveSemant
 
 These locks are never held simultaneously — `Apply` and `Snapshot` complete before `provider.mu` is acquired.
 
-## Register-Primary Ingestion (B5/16)
+## Register-Primary Ingestion (B5/24)
 
-The register-primary path reads energy statistics directly from the boiler (BAI device) using the B5/16 protocol:
+The register-primary path reads cumulative energy totals from the VRC controller (BASV2 device) using the B5/24 extended register protocol:
 
 ```text
-Request:  [period, source, usage]
-Response: IEEE 754 float32 LE (value in Wh, converted to kWh)
+Request:  B5.24 read selector [opcode=0x02, op=0x00, group=0x00, instance=0x00, addr_lo, addr_hi]
+Response: ULG (unsigned 32-bit LE integer, value in kWh)
 ```
 
-### Parameters
+### Registers
 
-| Byte | Name | Values |
+| Addr | TSP Name | Channel | Usage |
+| --- | --- | --- | --- |
+| 0x56 | PrFuelSumHc | gas | climate |
+| 0x57 | PrEnergySumHc | electricity | climate |
+| 0x58 | PrEnergySumHwc | electricity | hot_water |
+| 0x59 | PrFuelSumHwc | gas | hot_water |
+
+These are cumulative all-time totals from the VRC 720f TSP (15.720). Solar registers are not available.
+
+Total: **4 register reads** per refresh cycle.
+
+### Merge Key Mapping
+
+Each register value is written to 3 merge keys:
+
+| Period | YearKind | Value |
 | --- | --- | --- |
-| period | Time range | 0 = today, 1 = current year, 2 = previous year |
-| source | Energy source | 0 = gas, 1 = electricity, 2 = solar |
-| usage | Energy usage | 0 = climate (heating/cooling), 1 = hot_water |
+| year | current | all-time total from VRC |
+| year | previous | 0 (lock) |
+| day | (empty) | 0 (lock) |
 
-Total: 3 × 3 × 2 = **18 register reads** per refresh cycle.
-
-### Hardware Gating
-
-B5/16 energy stats are only available on devices with hardware version >= 7603. The gateway checks for the `get_energy_stats` method in the target device's (BAI) registry planes before attempting reads.
+The zero-locks for `day` and `year/previous` prevent broadcast double-counting, since the all-time total already includes those periods. The ULG sentinel `0xFFFFFFFF` is rejected as invalid.
 
 ### Lifecycle
 
 - Energy register reads are scheduled every 5 minutes (configurable via `-semantic-energy-interval`).
-- The refresh is gated on: BAI device discovered (via `findDeviceAddressByPrefix`) AND regulator capability is `ControllerPresent`.
+- The refresh is gated on: VRC controller discovered (`p.controller != 0`).
 - Each successful read calls `ApplyEnergyFromRegister()` with `EnergySourceRegister`, feeding through the merge truth table.
 - Failed reads are logged with a failure count but do not block other reads.
 
@@ -93,10 +104,14 @@ B5/16 energy stats are only available on devices with hardware version >= 7603. 
 
 Once a register value has been written for a given merge key, broadcast updates for the same key are permanently rejected (until the merge store is reset). This ensures register-primary data integrity even when broadcast traffic is available.
 
+### Historical Note
+
+Prior to PR #232, the gateway attempted B5/16 register reads from the BAI device. BAI responds to B5/16 but returns 0 kWh (boilers don't store cumulative energy). The VRC controller stores energy data via B5/24 registers, not B5/16.
+
 ## Cross-Links
 
 - EnergyTotals types: `graphql/semantic.go`
 - Merge implementation: `graphql/energy_merge.go`
 - Integration: `graphql/semantic_live.go` (`applyEnergyPoint`)
-- Register ingestion: `cmd/gateway/semantic_vaillant.go` (`refreshEnergy`, `readB516Value`)
-- B5/16 protocol template: `helianthus-ebusreg/vaillant/heating/energy.go`
+- Register ingestion: `cmd/gateway/semantic_vaillant.go` (`refreshEnergy`, `readB524Uint32LE`)
+- VRC energy TSP: `helianthus-ebus-vaillant-productids` (15.720.tsp, opcodes 0x4E–0x5D)


### PR DESCRIPTION
## Summary

- Update register-primary section: B5.24 VRC reads replace B5.16 BAI reads
- Document register map (0x56–0x59), ULG type, zero-lock mapping, sentinel rejection
- Add historical note about B5.16 BAI approach

Doc-gate for ebusgateway PR #232.
Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)