### PR TITLE
Doc-gate: authoritative BAI00 B509 boiler register mapping for GW-2 PASS profile

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -154,22 +154,55 @@ type EnergyBucket {
 
 type BoilerStatus {
   state: BoilerState
+  config: BoilerConfig
   diagnostics: BoilerDiagnostics
 }
 type BoilerState {
-  flowTemperature: Float
-  returnTemperature: Float
-  pumpRunning: Boolean
-  dhwStorageTemperature: Float
-  dhwOutletTemperature: Float
-  flameOn: Boolean
-  currentPowerPercent: Float
+  flowTemperatureC: Float
+  returnTemperatureC: Float
+  centralHeatingPumpActive: Boolean
+  waterPressureBar: Float
+  externalPumpActive: Boolean
+  circulationPumpActive: Boolean
+  gasValveActive: Boolean
+  flameActive: Boolean
+  diverterValvePositionPct: Float
+  fanSpeedRpm: Int
+  targetFanSpeedRpm: Int
+  ionisationVoltageUa: Float
+  dhwWaterFlowLpm: Float
+  dhwDemandActive: Boolean
+  heatingSwitchActive: Boolean
+  storageLoadPumpPct: Float
+  modulationPct: Float
+  primaryCircuitFlowLpm: Float
+  flowTempDesiredC: Float
+  dhwTempDesiredC: Float
+  stateNumber: Int
+  dhwTemperatureC: Float
+  dhwTargetTemperatureC: Float
+}
+type BoilerConfig {
+  dhwOperatingMode: String
+  flowsetHcMaxC: Float
+  flowsetHwcMaxC: Float
+  partloadHcKW: Float
+  partloadHwcKW: Float
 }
 type BoilerDiagnostics {
-  startsCount: Int
-  operatingHours: Int
-  dhwOperatingHours: Int
+  heatingStatusRaw: Int
+  dhwStatusRaw: Int
+  centralHeatingHours: Float
+  dhwHours: Float
+  centralHeatingStarts: Int
+  dhwStarts: Int
+  pumpHours: Float
+  fanHours: Float
+  deactivationsIFC: Int
+  deactivationsTemplimiter: Int
 }
+
+Boiler field provenance is documented in [`protocols/ebus-vaillant-B509-boiler-register-map.md`](../protocols/ebus-vaillant-B509-boiler-register-map.md). The current contract is hybrid: direct BAI00 B509 is authoritative for most boiler fields, while a small set of controller-mirrored B524 values still feed `dhwTemperatureC`, `dhwTargetTemperatureC`, `dhwOperatingMode`, and `heatingStatusRaw`.
 
 type SystemStatus {
   state: SystemState
@@ -501,6 +534,7 @@ The `invoke` mutation validates parameters against the method signature and rout
 ```graphql
 type Mutation {
   invoke(address: Int!, plane: String!, method: String!, params: JSON): InvokeResult!
+  setBoilerConfig(field: String!, value: String!): BoilerConfigMutationResult!
 }
 
 type InvokeResult {
@@ -514,6 +548,11 @@ type InvokeError {
   code: String!
   category: String!
 }
+
+type BoilerConfigMutationResult {
+  success: Boolean!
+  error: String
+}
 ```
 
 ### Behavior
@@ -523,6 +562,8 @@ type InvokeError {
   - Fractional values for integer fields are rejected (`INVALID_PAYLOAD`).
 - **Error mapping**: typed errors are mapped to `code`/`category` (e.g., `TIMEOUT` → `TRANSIENT`, `NO_SUCH_DEVICE` → `DEFINITIVE`).
 - **Result normalization**: `types.Value{Valid:false}` fields are returned as `null` in the JSON result map.
+- **Boiler writes**: `setBoilerConfig` supports `flowsetHcMaxC`, `flowsetHwcMaxC`, `partloadHcKW`, and `partloadHwcKW`. The mutation accepts the value as a string, rejects non-finite input, enforces server-side ranges, and only reports success after B509 ack + read-back confirmation.
+- **Boiler write normalization**: `DATA2c` boiler temperature writes publish the normalized wire value, not the raw input string. `UCH` power-limit writes require whole-number kW.
 
 ### Handler Construction
 

--- a/protocols/ebus-vaillant-B509-boiler-register-map.md
+++ b/protocols/ebus-vaillant-B509-boiler-register-map.md
@@ -1,0 +1,103 @@
+# Vaillant B509 Boiler Register Map (BAI00)
+
+This document is the authoritative public reference for the direct BAI00 boiler registers used by the GW-2 PASS-profile boiler model in Helianthus.
+
+Scope:
+- direct `0xB5 0x09` B509 reads from the physical boiler (`BAI00`)
+- boiler fields exposed through `boilerStatus` in GraphQL and MCP
+- writable boiler config fields exposed through `setBoilerConfig`
+
+This document does not replace the B524 controller register map. The current boiler semantic plane is a hybrid:
+- primary boiler state/config/diagnostics come from direct BAI00 B509 reads
+- a small set of controller-mirrored fields still come from BASV2 B524 and are listed separately below
+
+## Semantic Mapping
+
+Source: `refreshBoilerStatusTier()` in `cmd/gateway/semantic_vaillant.go`
+
+### Fast tier
+
+| Semantic Path | B509 register | Codec / scale | Notes |
+|---------------|---------------|---------------|-------|
+| `state.flowTemperatureC` | `0x1800` | `DATA2c` | Live boiler flow temperature |
+| `state.centralHeatingPumpActive` | `0x4400` | `on/off` | CH pump state |
+| `state.waterPressureBar` | `0x0200` | `DATA2b` | Boiler water pressure |
+| `state.flameActive` | `0x0500` | `on/off` | Burner flame status |
+| `state.gasValveActive` | `0xBB00` | `on/off` | Gas valve state |
+| `state.fanSpeedRpm` | `0x8300` | `UIN` | Fan speed in RPM |
+| `state.modulationPct` | `0x2E00` | `SIN / 10` | Boiler modulation percent |
+| `state.stateNumber` | `0xAB00` | `UCH` | Raw boiler state number |
+| `state.diverterValvePositionPct` | `0x5400` | `UCH` | Diverter valve position percent |
+| `state.dhwDemandActive` | `0x5800` | `on/off` | DHW demand state |
+| `state.dhwWaterFlowLpm` | `0x5500` | `UIN / 100` | DHW water flow in L/min |
+
+### Medium tier
+
+| Semantic Path | B509 register | Codec / scale | Notes |
+|---------------|---------------|---------------|-------|
+| `config.flowsetHcMaxC` | `0x0E04` | `DATA2c` | Primary register for max HC flow setpoint |
+| `config.flowsetHcMaxC` | `0xA500` | `DATA2c` | Fallback register when `0x0E04` is present but undecodable on the target boiler model |
+| `config.flowsetHwcMaxC` | `0x0F04` | `DATA2c` | Max HWC flow setpoint |
+| `config.partloadHcKW` | `0x0704` | `UCH` | Whole-number kW |
+| `config.partloadHwcKW` | `0x0804` | `UCH` | Whole-number kW |
+| `state.storageLoadPumpPct` | `0x9E00` | `percent0` | Storage load pump percent |
+| `state.flowTempDesiredC` | `0x3900` | `DATA2c` | Desired boiler flow temperature |
+| `state.dhwTempDesiredC` | `0xEA03` | `DATA2c` | Desired DHW temperature |
+| `state.circulationPumpActive` | `0x7B00` | `on/off` | Circulation pump state |
+| `state.externalPumpActive` | `0x3F00` | `on/off` | External pump state |
+| `state.heatingSwitchActive` | `0xF203` | `on/off` | Heating switch state |
+| `state.targetFanSpeedRpm` | `0x2400` | `UIN` | Target fan speed in RPM |
+| `state.ionisationVoltageUa` | `0xA400` | `SIN / 10` | Ionisation voltage in uA |
+| `state.primaryCircuitFlowLpm` | `0xFB00` | `UIN / 100` | Primary circuit flow in L/min |
+
+### Slow tier
+
+| Semantic Path | B509 register | Codec / scale | Notes |
+|---------------|---------------|---------------|-------|
+| `diagnostics.centralHeatingHours` | `0x2800` | `Hoursum2` | CH operating hours |
+| `diagnostics.dhwHours` | `0x2200` | `Hoursum2` | DHW operating hours |
+| `diagnostics.centralHeatingStarts` | `0x2900` | `UIN` | CH starts count |
+| `diagnostics.dhwStarts` | `0x2300` | `UIN` | DHW starts count |
+| `diagnostics.pumpHours` | `0x1400` | `Hoursum2` | Pump operating hours |
+| `diagnostics.fanHours` | `0x1B00` | `Hoursum2` | Fan operating hours |
+| `diagnostics.deactivationsIFC` | `0x1F00` | `UCH` | IFC deactivations |
+| `diagnostics.deactivationsTemplimiter` | `0x2000` | `UCH` | Temperature limiter deactivations |
+
+## B524 Provenance Still Used By `boilerStatus`
+
+The PASS-profile boiler contract still merges a small set of controller-side mirrored values from B524:
+
+| Semantic Path | B524 register | Type | Notes |
+|---------------|---------------|------|-------|
+| `state.dhwTemperatureC` | `GG=0x01, RR=0x0005` | `f32` | Mirrored from DHW group on BASV2 |
+| `state.dhwTargetTemperatureC` | `GG=0x01, RR=0x0004` | `f32` | Mirrored from DHW group on BASV2 |
+| `config.dhwOperatingMode` | `GG=0x01, RR=0x0003` | `u16 -> enum string` | Published as decoded GraphQL string |
+| `diagnostics.heatingStatusRaw` | `GG=0x02, II=0x00, RR=0x001B` | `u16` | Controller mirror of circuit/heating status |
+
+Fields currently present in the GraphQL/MCP schema but not populated from a validated direct B509 mapping:
+- `state.returnTemperatureC`
+- `diagnostics.dhwStatusRaw`
+
+## Write Path: `setBoilerConfig`
+
+Supported writable fields:
+
+| GraphQL field | Register selection | Codec | Accepted range | Notes |
+|---------------|--------------------|-------|----------------|-------|
+| `flowsetHcMaxC` | `0x0E04`, fallback `0xA500` | `DATA2c` | `20..80` C | Runtime chooses the first decodable register and confirms by read-back |
+| `flowsetHwcMaxC` | `0x0F04` | `DATA2c` | `30..65` C | Read-back must match encoded payload |
+| `partloadHcKW` | `0x0704` | `UCH` | `0..40` kW | Whole-number kW only |
+| `partloadHwcKW` | `0x0804` | `UCH` | `0..40` kW | Whole-number kW only |
+
+Write semantics:
+- GraphQL accepts the `value` argument as a string and validates it server-side.
+- Non-finite values (`NaN`, `Inf`) are rejected before range validation.
+- `DATA2c` writes are normalized from the encoded wire payload. Example: `55.1` is encoded and published back as `55.0625`, not the original input string.
+- Success requires both a valid B509 write acknowledgement and a matching read-back payload.
+- After a confirmed write, the in-memory boiler snapshot is updated with copy-on-write semantics before the live semantic publish.
+
+## Model-Specific Note
+
+Runtime validation on BAI00 model `0010024604` showed:
+- `0x0E04` may return an undecodable one-byte payload (`0xF0`) for `flowsetHcMaxC`
+- fallback register `0xA500` returns the decodable `DATA2c` value and is therefore used for both read and write confirmation on that model

--- a/protocols/ebus-vaillant-B524-register-map.md
+++ b/protocols/ebus-vaillant-B524-register-map.md
@@ -851,15 +851,23 @@ Source: `refreshDHW()` in `semantic_vaillant.go`
 
 Source: `refreshBoilerStatus()` in `semantic_vaillant.go`
 
-The boiler status plane is a **cross-group composite** — it reads from both GG=0x00 (regulator) and GG=0x02 (heating circuit 0). The BAI boiler does not respond to direct B504 reads from third-party sources — only from its paired controller. The controller mirrors boiler data in its own B524 register space.
+The current PASS-profile boiler status plane is no longer a B524-only composite. Helianthus now prefers direct BAI00 B509 reads for the boiler semantic surface and keeps only a small B524 fallback/mirror set in the controller path.
+
+Authoritative direct-boiler mapping:
+- see [`ebus-vaillant-B509-boiler-register-map.md`](./ebus-vaillant-B509-boiler-register-map.md)
+
+The B524 contribution that still feeds the current boiler semantic contract is:
 
 | Semantic Path | B524 | Type | Notes |
 |---------------|------|------|-------|
-| `state.flow_temperature` | GG=0x00, RR=0x004B | f32 | System flow temp from regulator |
-| `state.pump_running` | GG=0x02, II=0x00, RR=0x001E | bool (u16) | Circuit 0 pump status |
-| `state.circuit_state` (raw) | GG=0x02, II=0x00, RR=0x001B | u16 | Circuit 0 state |
+| `state.dhwTemperatureC` | GG=0x01, RR=0x0005 | f32 | Controller mirror from DHW group |
+| `state.dhwTargetTemperatureC` | GG=0x01, RR=0x0004 | f32 | Controller mirror from DHW group |
+| `config.dhwOperatingMode` | GG=0x01, RR=0x0003 | u16 | Decoded into the public enum string |
+| `diagnostics.heatingStatusRaw` | GG=0x02, II=0x00, RR=0x001B | u16 | Controller-side raw heating status |
 
-Note: `return_temperature` is **not populated** from B524. GG=0x02 RR=0x0008 (`Hc{hc}FlowTemp`) is the circuit flow sensor VF[x], not the boiler return sensor. True return temperature would require direct BAI access (B504) which is not available from third-party sources. Similarly, `dhw_storage_temperature`, `dhw_outlet_temperature`, `flame_on`, `current_power_percent`, `starts_count`, `operating_hours`, `dhw_operating_hours` are not populated from B524.
+Fields currently present in the schema but not populated from a validated source:
+- `state.returnTemperatureC`
+- `diagnostics.dhwStatusRaw`
 
 ### `ebus.v1.semantic.energy_totals.get`
 


### PR DESCRIPTION
## What
Documents the authoritative BAI00 B509 boiler register mappings and write semantics required by the GW-2 PASS-profile boiler contract.

## Why
Gateway PR #290 expands the public boiler GraphQL/MCP contract and enables validated B509-backed writes. That is reverse-engineered protocol knowledge plus public semantic behavior, so doc-gate must land in the same cycle.

## Changes
- adds a dedicated public B509 boiler register map for the PASS-profile semantic surface
- updates `api/graphql.md` for the expanded `boilerStatus` contract and `setBoilerConfig` mutation
- rewrites the old B524-only boiler semantic note to the current hybrid provenance model

## Validation
- doc review against gateway branch `codex/issue/289-gw2-pass-boiler-contract` commit `7a1475e`

Closes #173