### PR TITLE
Docs: GraphQL energyTotals root parity contract

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -148,8 +148,7 @@ type EnergyCategory {
 }
 type EnergyBucket {
   today: Float
-  thisMonth: Float
-  thisYear: Float
+  yearly: [Float!]!
 }
 
 type BoilerStatus {
@@ -264,6 +263,31 @@ type CircuitProperties {
   heatingCircuitType: Int
   mixerCircuitTypeExternal: Int
   frostProtectionThreshold: Float
+}
+```
+
+### `energyTotals` Root Query
+
+`energyTotals` is available directly on `Query` and returns the same canonical energy aggregate exposed to MCP.
+
+Example:
+
+```graphql
+query {
+  energyTotals {
+    gas {
+      dhw { today yearly }
+      climate { today yearly }
+    }
+    electric {
+      dhw { today yearly }
+      climate { today yearly }
+    }
+    solar {
+      dhw { today yearly }
+      climate { today yearly }
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## What
Documents the live `energyTotals` GraphQL root contract.

## Why
Gateway issue #292 exposes `energyTotals` at the query root. The docs must reflect the implemented root field and the current `today/yearly` energy payload shape.

## Changes
- documents the current `EnergyBucket` shape as `today/yearly`
- adds an explicit `energyTotals` root query example

## Dependencies
- companion to Project-Helianthus/helianthus-ebusgateway#292

Closes #175
