### PR TITLE
[HVAC-Docs] Document B524 semantic structure discovery contract

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -275,6 +275,11 @@ type CircuitConfig {
 
 `vr71CircuitStartIndex` is intentionally absent from the canonical GraphQL contract. Circuit ownership is modeled explicitly on each `circuits[]` item via `managingDevice`, not through a global FM5 threshold.
 
+The architectural rationale and the full B524 evidence trail for structure/ownership decisions are documented in:
+
+- [`../architecture/semantic-structure-discovery.md`](../architecture/semantic-structure-discovery.md)
+- [`../protocols/ebus-vaillant-B524-structural-decisions.md`](../protocols/ebus-vaillant-B524-structural-decisions.md)
+
 ### `energyTotals` Root Query
 
 `energyTotals` is available directly on `Query` and returns the same canonical energy aggregate exposed to MCP.
@@ -332,6 +337,7 @@ The semantic runtime distinguishes cache bootstrap from live updates during star
 Authoritative startup FSM and transition details are documented in [`architecture/startup-semantic-fsm.md`](../architecture/startup-semantic-fsm.md).
 Zone lifecycle details are documented in [`architecture/zone-presence-fsm.md`](../architecture/zone-presence-fsm.md).
 DHW lifecycle details are documented in [`architecture/dhw-freshness-fsm.md`](../architecture/dhw-freshness-fsm.md).
+Structural family/instance discovery rules are documented in [`../architecture/semantic-structure-discovery.md`](../architecture/semantic-structure-discovery.md) and [`../protocols/ebus-vaillant-B524-structural-decisions.md`](../protocols/ebus-vaillant-B524-structural-decisions.md).
 
 ### Projection Notes
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -85,6 +85,18 @@ See breaker details in [`architecture/semantic-read-circuit-breaker.md`](./seman
 See zone presence details in [`architecture/zone-presence-fsm.md`](./zone-presence-fsm.md).
 See DHW lifecycle details in [`architecture/dhw-freshness-fsm.md`](./dhw-freshness-fsm.md).
 
+## Semantic Structure Discovery
+
+The startup/runtime FSMs above explain **when** semantic payload becomes visible. The separate structural decision graph explains **why a family or instance exists at all**.
+
+- authoritative flow: [`architecture/semantic-structure-discovery.md`](./semantic-structure-discovery.md)
+- authoritative B524 decision catalog: [`protocols/ebus-vaillant-B524-structural-decisions.md`](../protocols/ebus-vaillant-B524-structural-decisions.md)
+
+This split is intentional:
+
+- FSM docs cover publication timing, cache/live transitions, and anti-flapping behavior;
+- the structural decision catalog covers source registers, evaluation rules, gates, and ownership/subordination fields.
+
 ## Plane/Provider Model
 
 The registry layer treats each physical eBUS device as a **DeviceEntry** discovered via a 0x07/0x04 identification scan. A single physical device may be observed on multiple eBUS addresses (alias faces). The registry resolves these to one canonical DeviceEntry with:

--- a/architecture/semantic-structure-discovery.md
+++ b/architecture/semantic-structure-discovery.md
@@ -1,0 +1,161 @@
+# Semantic Structure Discovery (B524)
+
+This page documents how `helianthus-ebusgateway` discovers **semantic structure** from Vaillant B524 and decides what semantic families and instances exist before publishing them.
+
+This is intentionally different from:
+
+- runtime freshness/publication FSMs such as startup, zone presence, and read breaker behavior;
+- state derivation such as zone operating mode, HVAC action, or DHW preset;
+- direct-boiler B509 semantics.
+
+Phase 1 scope is **B524 structure discovery only** and is documented in **proven-only** style:
+
+- direct register-backed rules are documented as `PROVEN`;
+- naming-prefix or synthetic rules are documented as `HEURISTIC`;
+- anything without enough evidence is documented as `UNKNOWN`.
+
+The authoritative decision catalog is [`protocols/ebus-vaillant-B524-structural-decisions.md`](../protocols/ebus-vaillant-B524-structural-decisions.md).
+
+## What Counts as a Structural Decision
+
+A structural decision answers one of these questions:
+
+- does this semantic family exist at all?
+- how many instances exist?
+- which instances are active vs. absent?
+- which published fields define semantic ownership or parent selection?
+- which gate must be satisfied before a family is exposed?
+
+Examples:
+
+- how many zones are published;
+- whether a cylinder instance is real or only config-shaped noise;
+- whether circuits belong to the regulator or the FM5 module;
+- whether the gateway is allowed to expose `solar` and `cylinders` at all.
+
+## Flow Overview
+
+```mermaid
+flowchart TD
+  A["Registry discovery / controller precondition"] --> B["refreshDiscovery()"]
+  B --> C["Zone presence FSM"]
+  C --> D["publishZones()"]
+
+  A --> E["refreshSystem()"]
+  A --> F["refreshRadioDevices()"]
+  A --> G["refreshCircuits()"]
+
+  E --> H["publishSystem()"]
+  F --> I["publishRadioDevices()"]
+  G --> J["publishCircuits()"]
+
+  E --> K["refreshFM5Semantic()"]
+  F --> K
+  K --> L["publishFM5Semantic()"]
+  L --> J
+
+  B --> M["refreshConfig()"]
+  B --> N["refreshState()"]
+  M --> D
+  N --> D
+  N --> O["associatedCircuit / roomTemperatureZoneMapping"]
+  O --> D
+```
+
+Operational reading:
+
+1. Gateway first needs a controller candidate.
+2. `refreshDiscovery()` probes zone presence and drives the zone presence FSM.
+3. `refreshConfig()` and `refreshState()` enrich already-present zone entries with names and structural config.
+4. `refreshSystem()` provides the system properties needed by later structural rules.
+5. `refreshRadioDevices()` provides remote inventory/evidence.
+6. `refreshFM5Semantic()` evaluates whether FM5-backed families can be interpreted at all.
+7. `refreshCircuits()` publishes circuit instances, and `publishCircuits()` attaches explicit `managingDevice`.
+8. `publishFM5Semantic()` gates `solar` and `cylinders`, then republishes circuits so ownership downgrades/upgrades stay coherent.
+
+## Controlling FSMs
+
+These FSMs control whether structural decisions become visible or stay suppressed:
+
+- Startup publication FSM: [`startup-semantic-fsm.md`](./startup-semantic-fsm.md)
+- Zone presence hysteresis FSM: [`zone-presence-fsm.md`](./zone-presence-fsm.md)
+- Per-register read breaker: [`semantic-read-circuit-breaker.md`](./semantic-read-circuit-breaker.md)
+
+Their roles are different:
+
+- the startup FSM controls when payloads are considered cache vs. live;
+- the zone presence FSM decides whether a zone instance remains published;
+- the read breaker suppresses repeated failing reads and therefore affects whether enough evidence exists for a structural rule to fire.
+
+## Structural Decision Classes
+
+### 1. Preconditions
+
+These decide whether B524 structure discovery can run at all.
+
+- controller present
+- registry evidence for FM5 hardware
+
+### 2. Family/Instance Discovery
+
+These decide how many items exist.
+
+- zone instances from `GG=0x03 RR=0x001C`
+- circuit instances from `GG=0x02 RR=0x0002`
+- radio device instances from `GG=0x09/0x0A/0x0C`
+- cylinder instances from `GG=0x05 RR=0x0004`
+
+### 3. Structural Attachments
+
+These do not create families, but define how published entities relate to each other.
+
+- `roomTemperatureZoneMapping`
+- `associatedCircuit`
+- `circuits[].managingDevice`
+- `radio_devices[].slot_mode`
+
+### 4. Family Gates
+
+These decide whether a whole semantic family may be published.
+
+- `fm5SemanticMode`
+- `solar`
+- `cylinders`
+
+## Current Anti-Pattern Removed
+
+`vr71CircuitStartIndex` was a synthetic threshold that compressed circuit ownership into a single global number. It did not come from a direct bus truth and could mis-model real topologies.
+
+The canonical structural contract is now:
+
+- `circuits[].managingDevice`
+
+That change is the model for future cleanup:
+
+- structure should be documented as explicit evidence-backed contract;
+- synthetic convenience thresholds should either be marked `HEURISTIC` or removed.
+
+## Out of Scope for Phase 1
+
+These remain outside this document and the B524 structural decision catalog:
+
+- zone mode/preset/HVAC action derivation
+- DHW operating mode derivation
+- energy merge behavior
+- boiler/B509 semantic rules
+- HA-specific entity naming or registry migration behavior
+
+## Audit Rule
+
+For B524 structure discovery, no rule should remain “only in code”.
+
+Each structural rule in `semantic_vaillant.go` must end up in one of these buckets:
+
+- cataloged as `PROVEN`
+- cataloged as `HEURISTIC`
+- cataloged as `UNKNOWN`
+- explicitly declared out of scope for Phase 1
+
+The decision catalog is the authoritative reference for the rule-by-rule contract:
+
+- [`protocols/ebus-vaillant-B524-structural-decisions.md`](../protocols/ebus-vaillant-B524-structural-decisions.md)

--- a/protocols/ebus-vaillant-B524-register-map.md
+++ b/protocols/ebus-vaillant-B524-register-map.md
@@ -777,6 +777,13 @@ Instanced (II=0x00-0x0A). 15 registers per instance. Uses the shared remote-devi
 
 ## Semantic Plane Mapping
 
+The raw register tables below document what exists on the wire. The separate structural decision catalog documents how gateway code turns those raw values into semantic families, instance counts, gates, and ownership fields:
+
+- architecture flow: [`../architecture/semantic-structure-discovery.md`](../architecture/semantic-structure-discovery.md)
+- structural decision catalog: [`./ebus-vaillant-B524-structural-decisions.md`](./ebus-vaillant-B524-structural-decisions.md)
+
+This is where decisions such as zone publication, `associatedCircuit`, FM5 gating, and circuit `managingDevice` are documented as contract rather than left implicit in code.
+
 This section maps B524 registers to Helianthus MCP semantic plane fields. Only registers actively read by the gateway's semantic poller are listed.
 
 ### `ebus.v1.semantic.system.get`

--- a/protocols/ebus-vaillant-B524-structural-decisions.md
+++ b/protocols/ebus-vaillant-B524-structural-decisions.md
@@ -1,0 +1,216 @@
+# Vaillant B524 Structural Decision Catalog
+
+This page documents the **implemented structural decisions** in `helianthus-ebusgateway` for B524-backed semantic discovery.
+
+Each entry records:
+
+- the source of evidence;
+- how the gateway evaluates that evidence;
+- what public semantic effect the decision has;
+- whether the rule is `PROVEN`, `HEURISTIC`, or `UNKNOWN`.
+
+This document is authoritative for Phase 1 structural discovery and complements, rather than replaces, the raw register map:
+
+- raw register catalog: [`ebus-vaillant-B524-register-map.md`](./ebus-vaillant-B524-register-map.md)
+- architecture flow: [`../architecture/semantic-structure-discovery.md`](../architecture/semantic-structure-discovery.md)
+
+## Evidence Status Meanings
+
+| Status | Meaning |
+| --- | --- |
+| `PROVEN` | Backed directly by current registers and implemented behavior |
+| `HEURISTIC` | Implemented rule is not directly proven by registers; gateway currently uses a convenience or naming rule |
+| `UNKNOWN` | Gateway intentionally avoids inventing a stronger claim |
+
+## B524-SD-01 — Controller Presence Gates B524 Structure Discovery
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Enables or disables B524-backed structure discovery for zones, circuits, radio devices, FM5, solar, and cylinders |
+| Source registers | None |
+| Reference | Not a B524 register rule; source is registry discovery |
+| Evaluation rule | `refreshDiscovery()` uses `findDeviceAddressByPrefix(p.reg, "BASV")`; when not found, controller becomes `0`, B524-backed families are cleared/reset, and FM5 mode becomes `ABSENT` |
+| Fallback / unknown behavior | Prefix match on `BASV` is a naming heuristic, not a protocol proof of controller role |
+| Published effect | `zones`, `circuits`, and `radioDevices` publish as empty/cache-backed; `fm5SemanticMode` becomes `ABSENT`; `solar` and `cylinders` are cleared |
+| Evidence status | `HEURISTIC` |
+| Code anchors | `refreshDiscovery()`, `findDeviceAddressByPrefix()` |
+
+## B524-SD-02 — Zone Instance Discovery
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines which zone instances exist and are eligible for publication |
+| Source registers | `GG=0x03 RR=0x001C` (`zone_index`) |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance) |
+| Evaluation rule | `refreshDiscovery()` probes instances `0x00..0x0A`; any readable non-`0xFF` index marks the instance as present |
+| Fallback / unknown behavior | If direct probes yield no present zones, gateway may hydrate zone presence from `ebusd grab`; that fallback is not a B524-native proof path |
+| Published effect | Present instances enter the zone presence FSM and can become `zones[]` entries; absent instances are not published |
+| Evidence status | `PROVEN` for direct B524 probes, `HEURISTIC` for `ebusd grab` fallback |
+| Code anchors | `refreshDiscovery()`, `reconcileDiscoveryPresence()` |
+
+## B524-SD-03 — Zone Publication Is Controlled by Zone Presence FSM
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Prevents transient probe misses from adding/removing zone instances immediately |
+| Source registers | Primary source remains `GG=0x03 RR=0x001C` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance), [`../architecture/zone-presence-fsm.md`](../architecture/zone-presence-fsm.md) |
+| Evaluation rule | `markZonePresentLocked()` and `markZoneMissingLocked()` apply hit/miss hysteresis before creating or deleting `p.zones[instance]` |
+| Fallback / unknown behavior | Thresholds are runtime configuration, not protocol data |
+| Published effect | `zones[]` reflects stable semantic presence, not one-shot probe results |
+| Evidence status | `PROVEN` for the implemented FSM behavior |
+| Code anchors | `applyZonePresenceProbes()`, `markZonePresentLocked()`, `markZoneMissingLocked()` |
+
+## B524-SD-04 — Zone Name Resolution and Fallback
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines `zones[].name` |
+| Source registers | `GG=0x03 RR=0x0016` (`name`), `RR=0x0017` (`name_prefix`), `RR=0x0018` (`name_suffix`) |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance) |
+| Evaluation rule | `refreshConfig()` prefers `RR=0x0016`; otherwise it composes `prefix + suffix`; `publishZones()` falls back to `Zone N` if the merged name is still blank |
+| Fallback / unknown behavior | `Zone N` is a local publication fallback, not a protocol-provided name |
+| Published effect | Every published zone has a stable display name even when no B524 name string is available |
+| Evidence status | `PROVEN` for register reads, `HEURISTIC` for `Zone N` fallback |
+| Code anchors | `refreshConfig()`, `composeZoneName()`, `publishZones()` |
+
+## B524-SD-05 — Room Temperature Zone Mapping
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Defines `zones[].config.roomTemperatureZoneMapping` and feeds later attachment decisions |
+| Source registers | `GG=0x03 RR=0x0013` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance), [`ebus-vaillant-B524-register-map.md#zmapping--zone-room-temperature-sensor-mapping`](./ebus-vaillant-B524-register-map.md#zmapping--zone-room-temperature-sensor-mapping) |
+| Evaluation rule | `refreshState()` reads the raw value; `publishZones()` exposes the decoded integer via `decodeRoomTemperatureZoneMapping()` |
+| Fallback / unknown behavior | Missing or undecodable values are published as absent rather than synthesized |
+| Published effect | Consumers receive explicit zone-to-room-sensor mapping data instead of guessing |
+| Evidence status | `PROVEN` |
+| Code anchors | `refreshState()`, `decodeRoomTemperatureZoneMapping()`, `publishZones()` |
+
+## B524-SD-06 — Associated Circuit Derivation for Zones
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Defines `zones[].config.associatedCircuit` |
+| Source registers | Primary source `GG=0x03 RR=0x0013`; supporting lookup `GG=0x02 RR=0x0002` for circuit type on the resolved circuit instance |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x03--zones-multi-instance), [`ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance) |
+| Evaluation rule | `resolveAssociatedCircuitInstance()` maps `roomTemperatureZoneMapping` values `1..0x20` to zero-based circuit instances and falls back to the zone instance for `nil`, `0`, `0xFF`, or out-of-range values |
+| Fallback / unknown behavior | Falling back to the zone instance is a local convenience rule and may not reflect physical topology on every installation |
+| Published effect | `associatedCircuit` is explicit in the semantic contract and is available to consumers without re-derivation |
+| Evidence status | `PROVEN` for the mapping value, `HEURISTIC` for the fallback-to-zone-instance branch |
+| Code anchors | `refreshState()`, `resolveAssociatedCircuitInstance()`, `publishZones()` |
+
+## B524-SD-07 — Circuit Instance Discovery
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines which heating circuit instances exist and whether they are active or inactive |
+| Source registers | `GG=0x02 RR=0x0002` (`circuit_type`) |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance), [`ebus-vaillant-B524-register-map.md#mctype--circuit-type`](./ebus-vaillant-B524-register-map.md#mctype--circuit-type) |
+| Evaluation rule | `refreshCircuits()` probes instances `0x00..0x0A`; readable `0x0000`, `0x00FF`, and `0xFFFF` are treated as inactive, any other value creates/keeps an active circuit snapshot |
+| Fallback / unknown behavior | No synthetic circuit count is invented if type reads never succeed |
+| Published effect | `circuits[]` contains only active discovered instances |
+| Evidence status | `PROVEN` |
+| Code anchors | `refreshCircuits()`, `mergeCircuitSnapshotNonDestructive()`, `publishCircuits()` |
+
+## B524-SD-08 — Circuit Ownership via `managingDevice`
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Defines `circuits[].managingDevice` instead of using a global FM5 threshold |
+| Source registers | `GG=0x00 RR=0x0036` (`system_scheme`), `GG=0x00 RR=0x002F` (`module_configuration_vr71`) plus the evaluated `fm5SemanticMode` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x00--systemregulator`](./ebus-vaillant-B524-register-map.md#gg0x00--systemregulator), [`ebus-vaillant-B524-register-map.md#ebusv1semanticcircuitsget`](./ebus-vaillant-B524-register-map.md#ebusv1semanticcircuitsget) |
+| Evaluation rule | `deriveCircuitManagingDevice()` emits `FUNCTION_MODULE / VR_71 / 0x26` only when `systemScheme == 1`, `moduleConfigurationVR71 == 2`, and `fm5SemanticMode == INTERPRETED`; otherwise it emits `UNKNOWN` |
+| Fallback / unknown behavior | Gateway intentionally does not guess another owner for unproven topologies |
+| Published effect | GraphQL/MCP/Portal expose explicit per-circuit ownership; HA can parent circuits without global threshold heuristics |
+| Evidence status | `PROVEN` for the current live tuple, `UNKNOWN` for all other tuples |
+| Code anchors | `refreshSystem()`, `deriveCircuitManagingDevice()`, `publishCircuits()` |
+
+## B524-SD-09 — Radio Device Inclusion and `slot_mode`
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines which remote/radio devices appear in `radioDevices[]` and how they are classified |
+| Source registers | `GG=0x09/0x0A/0x0C RR=0x0001`, `0x0002`, `0x0004`, `0x0023`, with supporting telemetry reads such as `0x0019`, `0x0025`, `0x000F`, `0x0007` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x09--radio-sensors-vrc7xx-multi-instance-dual-opcode`](./ebus-vaillant-B524-register-map.md#gg0x09--radio-sensors-vrc7xx-multi-instance-dual-opcode), [`ebus-vaillant-B524-register-map.md#gg0x0a--radio-sensors-vr92-multi-instance-dual-opcode`](./ebus-vaillant-B524-register-map.md#gg0x0a--radio-sensors-vr92-multi-instance-dual-opcode), [`ebus-vaillant-B524-register-map.md#gg0x0c--remote-accessories-vr71fm5-multi-instance-remote-only`](./ebus-vaillant-B524-register-map.md#gg0x0c--remote-accessories-vr71fm5-multi-instance-remote-only) |
+| Evaluation rule | `refreshRadioDevices()` always includes connected `0x09/0x0A` slots; for `0x0C` it also includes disconnected entries when `hasRemoteIdentityEvidence()` succeeds; disconnected `0x0C` entries become `slot_mode = "inventory"` |
+| Fallback / unknown behavior | `hasRemoteIdentityEvidence()` accepts non-empty firmware or non-zero/non-`0xFFFF` hardware as identity evidence, which is stronger than pure connection state but still heuristic as a “real device” proof |
+| Published effect | `radioDevices[]` contains both active remotes and inventory-evidenced FM5-related accessories, with enough metadata for consumer-side parent resolution |
+| Evidence status | `PROVEN` for connected slots, `HEURISTIC` for inventory inclusion |
+| Code anchors | `refreshRadioDevices()`, `hasRemoteIdentityEvidence()`, `publishRadioDevices()` |
+
+## B524-SD-10 — FM5 Semantic Mode
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines whether FM5-backed families are absent, partially evidenced, or fully interpretable |
+| Source registers | `GG=0x00 RR=0x002F` (`module_configuration_vr71`), radio inventory/evidence from `GG=0x09/0x0A/0x0C`, plus solar/cylinder readability checks in `GG=0x04` and `GG=0x05` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x00--systemregulator`](./ebus-vaillant-B524-register-map.md#gg0x00--systemregulator), [`ebus-vaillant-B524-register-map.md#gg0x04--solar-circuit`](./ebus-vaillant-B524-register-map.md#gg0x04--solar-circuit), [`ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance) |
+| Evaluation rule | `deriveFM5SemanticMode()` returns `INTERPRETED` only when controller is reachable, `module_configuration_vr71 <= 2`, solar is readable, and cylinders are readable; if not interpreted but FM5 evidence exists, mode is `GPIO_ONLY`; otherwise `ABSENT` |
+| Fallback / unknown behavior | `module_configuration_vr71 <= 2` is currently used as the family gate; broader meaning on other controller profiles is not yet proven |
+| Published effect | Controls `fm5SemanticMode` and gates publication of `solar`, `cylinders`, and FM5-backed circuit ownership |
+| Evidence status | `PROVEN` for the implemented decision tree, `UNKNOWN` for unvalidated controller tuples |
+| Code anchors | `refreshFM5Semantic()`, `deriveFM5SemanticMode()`, `publishFM5Semantic()` |
+
+## B524-SD-11 — Solar Family Publication Gate
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines whether the `solar` family is published at all |
+| Source registers | `GG=0x04 RR=0x0001`, `0x0002`, `0x0003`, `0x0007`, `0x0008`, `0x0009`, `0x000B`, gated by FM5 mode |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x04--solar-circuit`](./ebus-vaillant-B524-register-map.md#gg0x04--solar-circuit), [`ebus-vaillant-B524-register-map.md#ebusv1semanticsolarget`](./ebus-vaillant-B524-register-map.md#ebusv1semanticsolarget) |
+| Evaluation rule | `publishFM5Semantic()` publishes `solar` only when `fm5SemanticMode == INTERPRETED`; otherwise it clears the family |
+| Fallback / unknown behavior | No partial solar contract is exposed for `GPIO_ONLY` |
+| Published effect | `solar` is either fully present or absent |
+| Evidence status | `PROVEN` |
+| Code anchors | `readSolarSnapshot()`, `publishFM5Semantic()` |
+
+## B524-SD-12 — Cylinder Family Gate
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines whether `cylinders[]` may be published at all |
+| Source registers | Cylinder family reads come from `GG=0x05`, but family publication is gated by `fm5SemanticMode` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance), [`ebus-vaillant-B524-register-map.md#ebusv1semanticcylindersget`](./ebus-vaillant-B524-register-map.md#ebusv1semanticcylindersget) |
+| Evaluation rule | `publishFM5Semantic()` publishes cylinder instances only when `fm5SemanticMode == INTERPRETED`; otherwise it clears the family |
+| Fallback / unknown behavior | No synthetic “potential cylinders” family is exposed when FM5 is not interpreted |
+| Published effect | `cylinders[]` is absent outside interpreted FM5 mode |
+| Evidence status | `PROVEN` |
+| Code anchors | `refreshFM5Semantic()`, `publishFM5Semantic()` |
+
+## B524-SD-13 — Individual Cylinder Instance Publication
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Determines whether a specific cylinder instance is real enough to appear in `cylinders[]` |
+| Source registers | `GG=0x05 RR=0x0004` (`temperatureC`), with optional config from `RR=0x0001..0x0003` |
+| Reference | [`ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance`](./ebus-vaillant-B524-register-map.md#gg0x05--cylinders-multi-instance), [`ebus-vaillant-B524-register-map.md#ebusv1semanticcylindersget`](./ebus-vaillant-B524-register-map.md#ebusv1semanticcylindersget) |
+| Evaluation rule | `hasLiveCylinderEvidence()` requires a decodable `temperatureC`; config-only payloads do not create a cylinder instance |
+| Fallback / unknown behavior | Gateway does not publish “config-only cylinders” as maybe-present |
+| Published effect | `Cylinder 2`-style ghost instances do not appear unless live temperature evidence exists |
+| Evidence status | `PROVEN` |
+| Code anchors | `readCylinderSnapshots()`, `hasLiveCylinderEvidence()`, `publishFM5Semantic()` |
+
+## B524-SD-14 — Structural Subordination Contract
+
+| Field | Value |
+| --- | --- |
+| Semantic effect | Defines the public fields that consumers should use for hierarchy/parenting decisions |
+| Source registers | Composite of SD-05, SD-08, SD-09, SD-10, SD-11, and SD-13 |
+| Reference | See the source decision entries above |
+| Evaluation rule | Gateway publishes structure-bearing fields instead of hidden thresholds: `roomTemperatureZoneMapping`, `associatedCircuit`, `radioDevices[]`, `fm5SemanticMode`, `circuits[].managingDevice`, and gated `solar`/`cylinders` |
+| Fallback / unknown behavior | Consumer-specific parent trees remain consumer behavior; this catalog documents the semantic contract they must consume |
+| Published effect | GraphQL/MCP/Portal expose enough structure for consumers such as HA to build explainable parent-child hierarchy without inventing local thresholds |
+| Evidence status | `PROVEN` as a contract statement built from the decisions above |
+| Code anchors | `publishZones()`, `publishCircuits()`, `publishRadioDevices()`, `publishFM5Semantic()` |
+
+## Explicit Out of Scope
+
+These are intentionally **not** structural decisions for Phase 1:
+
+- zone operating mode / preset / HVAC action
+- DHW mode derivation
+- energy merge semantics
+- direct-boiler B509 logic
+
+If a future decision touches instance discovery, family gating, or parent/ownership fields, it should be added here instead of remaining implicit in code.


### PR DESCRIPTION
## What
Document the B524-driven semantic structure discovery flow and add an auditable catalog of structural decisions (source registers, evaluation rule, and published effect).

## Why
The gateway already makes many structural semantic decisions in code, but the docs did not expose the contract behind them. This PR adds a proven-only architectural flow and a decision catalog so heuristics, unknown branches, and public semantic effects are all visible and reviewable.

## Changes
- add `architecture/semantic-structure-discovery.md` for the refresh/evaluation/publication flow
- add `protocols/ebus-vaillant-B524-structural-decisions.md` as the authoritative decision catalog
- cross-link `architecture/overview.md`, `api/graphql.md`, and `protocols/ebus-vaillant-B524-register-map.md` to the new references
- explicitly mark non-register-backed branches as `HEURISTIC` or `UNKNOWN`

## Validation
- `./scripts/ci_local.sh`
- manual coverage audit of structural functions in `semantic_vaillant.go` against the new catalog

## Dependencies
- follows merged explicit circuit ownership cleanup (`gateway#303` / `gateway#304`)

Closes #185
