### PR TITLE
[HVAC-Docs] Correct B524 directory descriptor semantics for 0x00 group discovery

### DIFF
--- a/protocols/ebus-vaillant-B524.md
+++ b/protocols/ebus-vaillant-B524.md
@@ -75,7 +75,7 @@ descriptor == 0.0
      "group absent" or "hole" marker
 
 other numeric values
-  -> descriptor class tags observed in the field; often appear as
+  -> discrete observed descriptor values; often appear as
      discrete integer-like floats (for example 1.0, 3.0, 5.0, 6.0),
      but their semantic meaning is not yet established
 ```
@@ -125,8 +125,8 @@ Discovery rules:
 - Treat `NaN` as the current Helianthus termination policy, backed by lab
   evidence, but not yet as protocol-wide truth.
 - Do not suppress known groups solely because `descriptor == 0.0`.
-- At minimum, core structural groups such as `GG=0x02` (circuits) and
-  `GG=0x03` (zones) remain scan candidates even when the descriptor is `0.0`.
+- Core structural groups `GG=0x02` (circuits) and `GG=0x03` (zones)
+  remain scan candidates even when the descriptor is `0.0`.
 - For unknown groups, the descriptor may be used only as a conservative hint,
   never as a universal proof of absence.
 - Functional-module inventory and hydraulic scheme may be used for


### PR DESCRIPTION
## Summary
- correct B524 directory descriptor semantics for `op=0x00` group discovery
- stop documenting `descriptor == 0.0` as a universal hole/absence marker
- document `NaN` as current Helianthus termination policy rather than protocol-wide truth
- keep known core groups such as `GG=0x02` and `GG=0x03` as scan candidates even when descriptor is `0.0`
- state explicitly that functional-module inventory and hydraulic scheme are corroboration, not the primary structural source
- make the resulting planner/scanner contract explicit: descriptor hints are non-authoritative, register evidence is primary, and core groups remain policy-driven scan candidates

## Why
- closes #191
- aligns the docs with the evidence discussed in `helianthus-vrc-explorer#107`
- incorporates the deep-research findings attached on the issue thread: https://github.com/Project-Helianthus/helianthus-docs-ebus/issues/191#issuecomment-4017307483

## Validation
- `./scripts/ci_local.sh`
