### PR TITLE
Document circuit_state enum mapping (GG=0x02 RR=0x001B)

### DIFF
--- a/protocols/ebus-vaillant-B524-register-map.md
+++ b/protocols/ebus-vaillant-B524-register-map.md
@@ -1059,10 +1059,10 @@ Used by: GG=0x02 RR=0x001B (`circuit_state`, ebusd `Hc{hc}Status`)
 
 | Value | Helianthus | myPyllant | Evidence |
 |-------|-----------|-----------|----------|
-| 0 | STANDBY | STANDBY | Live MCP confirmed: 3 circuits idle, pumps off, flow setpoint=0 |
-| 1 | HEATING | HEATING | Inferred from pump status analogy (`Values_hcpumpmode` heat=1) + myPyllant `CircuitState` enum |
-| 2 | COOLING | COOLING | Inferred from pump status analogy (`Values_hcpumpmode` cool=2) + myPyllant `CircuitState` enum |
-| N | UNKNOWN(N) | — | Safety fallback for unmapped values |
+| 0 | standby | STANDBY | Live MCP confirmed: 3 circuits idle, pumps off, flow setpoint=0 |
+| 1 | heating | HEATING | Inferred from pump status analogy (`Values_hcpumpmode` heat=1) + myPyllant `CircuitState` enum |
+| 2 | cooling | COOLING | Inferred from pump status analogy (`Values_hcpumpmode` cool=2) + myPyllant `CircuitState` enum |
+| N | unknown_N | — | Safety fallback for unmapped values |
 
 **ebusd type:** Plain `UCH` — no enum type annotation in ebusd `Hc1Status` model (`15.700.tsp`).
 


### PR DESCRIPTION
## Summary
- Add circuit state enum values to B524 register map section
- 0=STANDBY (live MCP confirmed), 1=HEATING, 2=COOLING (pump status analogy + myPyllant enum)
- Update register table entry from "Raw state code" to enum reference
- Add `Circuit State Enum` section with evidence sources

Doc-gate for helianthus-ebusgateway#310.

## Test plan
- [ ] Verify enum section renders correctly in markdown
- [ ] Verify register table cross-reference link works

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)