### PR TITLE
docs: clarify B524 autodetection for descriptor 0.0

### DIFF
--- a/protocols/ebus-vaillant-B524.md
+++ b/protocols/ebus-vaillant-B524.md
@@ -73,6 +73,9 @@ descriptor == NaN
 descriptor == 0.0
   -> weak negative hint only; must not be treated as a universal
      "group absent" or "hole" marker
+  -> still a valid 4-byte directory reply and therefore sufficient
+     transport-level evidence that B524 directory probing is supported
+     at this address
 
 other numeric values
   -> discrete observed descriptor values; often appear as
@@ -86,6 +89,9 @@ Important:
 - In particular, `0.0` is known to be insufficient as an absence marker:
   single-circuit installations without functional modules may still expose
   valid `GG=0x02` and `GG=0x03` registers while the directory descriptor is `0.0`.
+- Autodetection / transport compatibility is a separate question from
+  group-level scan policy: any valid 4-byte directory response counts as
+  evidence that the target speaks B524, even when the descriptor value is `0.0`.
 - Functional-module inventory and hydraulic topology may help corroborate
   discovery decisions, but they do not replace B524 as the primary
   structural source.
@@ -122,6 +128,9 @@ Response payload (4 bytes):
 Discovery rules:
 - Iterate GG upward.
 - Treat only 4-byte responses as candidate directory descriptors.
+- For transport-level compatibility detection / autodetection, any valid
+  4-byte directory response is sufficient evidence that B524 directory
+  probing is supported on that address, even if the descriptor value is `0.0`.
 - Treat `NaN` as the current Helianthus termination policy, backed by lab
   evidence, but not yet as protocol-wide truth.
 - Do not suppress known groups solely because `descriptor == 0.0`.


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: In review
Branch: codex/issue/195-b524-autodetect-zero-descriptor
Last verified (lint/tests): local Docs CI equivalent PASS (markdown files present, markdown whitespace checks PASS, terminology gate PASS).
How to reproduce: checkout this branch, inspect protocols/ebus-vaillant-B524.md, and run the local Docs CI equivalent commands from the workflow.
Next steps: wait for Docs CI, then merge if green.
Notes (no secrets, no private infra): This PR is intentionally opened in parallel with existing docs PR #194 under explicit operator approval on 2026-03-08, to unblock VRC Explorer dependency D1.
```

## Summary
- document that a valid 4-byte B524 directory reply remains transport-level evidence of B524 capability even when `descriptor == 0.0`
- separate autodetection / compatibility from later group-level scan policy decisions
- keep the change limited to the directory descriptor semantics and discovery rules text

## Linked Issue
- Closes #195

## Checklist
- [x] Local Docs CI equivalent
- [ ] GitHub Docs CI
- [x] Smoke test required: NO

## Notes
- Existing docs PR #194 remains open; this second PR is an explicit operator-approved exception to the normal one-PR-per-repo rule.
- This is the external docs dependency D1 needed before VRC Explorer issue I13 can start.