### PR TITLE
W1-I07: Aggregate docs restructure

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -149,6 +149,7 @@ type EnergyCategory {
 type EnergyBucket {
   today: Float
   yearly: [Float!]!
+  monthly: [Float!]!
 }
 
 type BoilerStatus {
@@ -290,16 +291,16 @@ Example:
 query {
   energyTotals {
     gas {
-      dhw { today yearly }
-      climate { today yearly }
+      dhw { today yearly monthly }
+      climate { today yearly monthly }
     }
     electric {
-      dhw { today yearly }
-      climate { today yearly }
+      dhw { today yearly monthly }
+      climate { today yearly monthly }
     }
     solar {
-      dhw { today yearly }
-      climate { today yearly }
+      dhw { today yearly monthly }
+      climate { today yearly monthly }
     }
   }
 }

--- a/api/mcp.md
+++ b/api/mcp.md
@@ -18,6 +18,10 @@ The MCP server is implemented and served by `cmd/gateway` at `/mcp`.
   - `ebus.v1.semantic.boiler_status.get`
   - `ebus.v1.semantic.system.get`
   - `ebus.v1.semantic.circuits.get`
+  - `ebus.v1.semantic.radio_devices.get`
+  - `ebus.v1.semantic.fm5_mode.get`
+  - `ebus.v1.semantic.solar.get`
+  - `ebus.v1.semantic.cylinders.get`
   - `ebus.v1.semantic.snapshot.get`
   - `ebus.v1.snapshot.capture`
   - `ebus.v1.snapshot.drop`


### PR DESCRIPTION
## Summary
- **mcp.md**: Add 4 verified semantic tools (radio_devices, fm5_mode, solar, cylinders)
- **graphql.md**: Add `monthly` field to EnergyBucket type, update query example

Also updated at workspace root (not in git):
- **ARCHITECTURE.md**: Supported Devices (BASV2 fix, VR_71 address, NETX3, Radio Devices), Plane categories (3-tier), Device Discovery (2-phase), Bus.Send() direct path diagram, Error Model (dual-retry, wrapping chain), Future Expansion (vendor deviation)
- **CONVENTIONS.md**: Error classification restructure (bus-internal vs consumer-visible), testing strategy (gateway semantic), fixtures (gateway testdata), package structure (semantic_vaillant.go divergence), error wrapping prefix (gateway.), goroutine map (semantic provider tiers)

## Test plan
- [x] Markdown checks pass
- [x] All 11 semantic planes verified live via MCP snapshot

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)