### PR TITLE
Doc-gate: B524 read_timer and read_raw RPC methods

### DIFF
--- a/api/mcp.md
+++ b/api/mcp.md
@@ -37,6 +37,43 @@ The MCP server is implemented and served by `cmd/gateway` at `/mcp`.
 - `managing_device.device_id` and `managing_device.address` are populated only when the gateway has proven ownership evidence for the current topology.
 - `ebus.v1.semantic.system.get` no longer exposes `vr71_circuit_start_index`; that threshold was a gateway heuristic and is not part of the canonical contract.
 
+## RPC Method Reference — Vaillant System Plane
+
+Methods available via `ebus.v1.rpc.invoke` on the `system` plane for Vaillant/Saunier/AWB controllers.
+
+### `read_timer`
+
+Reads per-day weekly schedule timer programs via B524 opcode 0x03.
+
+**Intent:** `READ_ONLY`
+
+| Param    | Type   | Required | Description |
+|----------|--------|----------|-------------|
+| source   | byte   | yes      | Initiator address (gateway = 113) |
+| sel1     | byte   | yes      | Timer selector 1 (controller-specific) |
+| sel2     | byte   | yes      | Timer selector 2 (controller-specific) |
+| sel3     | byte   | yes      | Timer selector 3 (controller-specific) |
+| weekday  | byte   | yes      | Weekday index: 0x00=Mon .. 0x06=Sun |
+
+**Wire format:** `[0x03, SEL1, SEL2, SEL3, WD]`
+
+**Response fields:** `opcode`, `sel1`, `sel2`, `sel3`, `weekday`, `value` (raw timer bytes), `slot_count` (number of time slots). When the controller returns no data, `value` is invalid.
+
+### `read_raw`
+
+Raw opcode passthrough for investigation. Sends caller-provided payload bytes verbatim on B524.
+
+**Intent:** `MUTATE` (requires `allow_dangerous: true` and `idempotency_key`)
+
+| Param   | Type     | Required | Description |
+|---------|----------|----------|-------------|
+| source  | byte     | yes      | Initiator address (gateway = 113) |
+| payload | `[]byte` | yes      | Raw opcode bytes (1–16 bytes) |
+
+**Response fields:** `request_payload` (echo of sent bytes), `response_payload` (controller response), `value` (alias for response_payload). When no response data, `value` is invalid.
+
+**Safety note:** This method is intentionally `readOnly: false` because it can send arbitrary opcodes including mutating ones (e.g. 0x04 timer write). The gateway enforces `allow_dangerous` and idempotency gates.
+
 ## Plane Boundary Note
 
 - `scan` is treated as a cross-device discovery layer and is not modeled as a heat-source class plane.


### PR DESCRIPTION
## Summary
- Adds RPC method reference section to `api/mcp.md`
- Documents `read_timer` (opcode 0x03) and `read_raw` (passthrough) methods
- Includes parameter tables, wire format, response fields, and safety notes

## Test plan
- [x] Documentation accuracy verified against ebusreg PR #108 implementation
- [x] Safety notes reflect `readOnly: false` for `read_raw` (Codex review catch)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)