### PR TITLE
Docs: backfill observe-first protocol caveats and validation notes

### DIFF
--- a/architecture/adversarial-matrix.md
+++ b/architecture/adversarial-matrix.md
@@ -92,6 +92,23 @@ The adversarial report is a JSON artifact consumed by the tester gate:
 
 The summary maintains the invariant: `total == passed + failed + xfailed + blocked + unknown`.
 
+## Observe-First Validation Note
+
+This page documents the current adversarial runtime scenarios only. It does not
+yet freeze dedicated observe-first scenarios, report fields, or proof artifacts
+beyond the thresholds and report format above.
+
+Current factual references:
+
+- bus observability and passive-capability signals:
+  [`observability.md`](./observability.md)
+- transport caveats that decide passive-capable vs unavailable topologies:
+  [`../deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+- canonical end-to-end smoke order:
+  [`../development/end-to-end-smoke.md`](../development/end-to-end-smoke.md)
+- topology matrix runner:
+  [`../development/smoke-matrix.md`](../development/smoke-matrix.md)
+
 ## Cross-Links
 
 - Scenario definitions: `internal/adversarial/scenarios.go`

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -156,9 +156,12 @@ Runtime read/write traffic still uses the configured gateway transport.
 Passive observe-first support is narrower than active startup support.
 
 - `ebusd-tcp` remains `unsupported_or_misconfigured` for passive observe-first.
+  See [`protocols/ebusd-tcp.md`](../protocols/ebusd-tcp.md).
 - Direct adapter-class `enh` / `ens` endpoints over `tcp/:9999` remain
   `unsupported_or_misconfigured` for passive observe-first, including equivalent
   hostname forms that resolve to the same adapter listener.
+  See [`protocols/enh.md`](../protocols/enh.md) and
+  [`protocols/ens.md`](../protocols/ens.md).
 - Proxy-like `enh` / `ens` endpoints on other ports remain passive-capable for
   observe-first, whether they are reached over local loopback or remote northbound
   addresses.

--- a/development/end-to-end-smoke.md
+++ b/development/end-to-end-smoke.md
@@ -47,3 +47,28 @@ Run in order and stop on first failure:
 ## Operational rule
 
 End-to-end smoke is **PASS** only when all three stages pass in sequence with no skipped stage.
+
+## Observe-First Validation Note
+
+This runbook documents only the current end-to-end smoke chain on `main`. It
+does not yet define dedicated observe-first proof artifacts beyond the
+gateway/add-on/integration stages above.
+
+The `helianthus-tinyebus` target-emulation path is a parallel
+timing/observability validation track, not a substitute for the canonical
+gateway/add-on/integration smoke chain.
+
+Current factual references:
+
+- bus observability and passive-capability signals:
+  [`../architecture/observability.md`](../architecture/observability.md)
+- transport caveats that decide passive-capable vs unavailable topologies:
+  [`../deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+- parallel firmware-side target-emulation track:
+  [`target-emulation.md#helianthus-tinyebus`](./target-emulation.md#helianthus-tinyebus)
+
+Related validation surfaces:
+
+- topology matrix runner: [`smoke-matrix.md`](./smoke-matrix.md)
+- runtime adversarial scenarios:
+  [`../architecture/adversarial-matrix.md`](../architecture/adversarial-matrix.md)

--- a/development/smoke-matrix.md
+++ b/development/smoke-matrix.md
@@ -130,6 +130,23 @@ Each command step is logged with command string, timestamps, status, and exit co
 - `blocked-infra`: run blocked by infrastructure precondition (see `infra_reason`).
 - `planned`: dry-run outcome.
 
+## Observe-First Validation Note
+
+This runbook documents the current `T01..T88` transport gate only. It does not
+yet define dedicated observe-first proof artifacts beyond the matrix verdicts
+and expected-failure inventory that already exist on `main`.
+
+Current factual references:
+
+- passive-capability signals and troubleshooting:
+  [`../architecture/observability.md`](../architecture/observability.md)
+- transport caveats that decide passive-capable vs unavailable topologies:
+  [`../deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+- canonical end-to-end smoke order for the matrix `--smoke-command`:
+  [`end-to-end-smoke.md`](./end-to-end-smoke.md)
+- runtime adversarial scenarios that remain outside the transport gate:
+  [`../architecture/adversarial-matrix.md`](../architecture/adversarial-matrix.md)
+
 ## Privacy and secrets
 
 No adapter IPs or credentials are stored in repo artifacts by default. Config files reference environment placeholders (`MATRIX_*`), and command strings must be provided at runtime via local operator context.

--- a/protocols/ebusd-tcp.md
+++ b/protocols/ebusd-tcp.md
@@ -4,6 +4,13 @@ This document describes the ASCII command protocol exposed by the `ebusd` daemon
 
 For gateway transport selection examples using this backend, see `deployment/full-stack.md`.
 
+Observe-first caveat: when the gateway uses `ebusd-tcp`, passive observe-first
+is expected to remain unavailable. The current transport contract and
+troubleshooting signals are documented in
+[`deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+and
+[`architecture/observability.md#troubleshooting-mapping`](../architecture/observability.md#troubleshooting-mapping).
+
 ## Transport
 
 - Connection: plain TCP.

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -7,6 +7,13 @@ See also:
 - `protocols/ens.md` for ebusd’s `ens:` prefix semantics (serial speed selector; equivalent to `enh:` on network transports).
 - `protocols/udp-plain.md` for raw eBUS bytes over UDP without ENH framing.
 
+Observe-first caveat: direct adapter-class ENH/ENS listeners on the adapter port
+(for example `tcp/:9999`) are not the passive-capable observe-first path. The
+current transport contract and troubleshooting signals are documented in
+[`deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+and
+[`architecture/observability.md#troubleshooting-mapping`](../architecture/observability.md#troubleshooting-mapping).
+
 It is a byte-stream protocol where:
 
 - bytes `< 0x80` **may be transferred as-is** (short form),

--- a/protocols/ens.md
+++ b/protocols/ens.md
@@ -19,6 +19,13 @@ When the underlying transport is TCP/UDP (for example `host:9999`), there is no 
 
 If an adapter exposes raw eBUS bytes over UDP without ENH framing, use UDP-PLAIN instead (`protocols/udp-plain.md`).
 
+Observe-first caveat: direct adapter-class `enh:` / `ens:` listeners on the
+adapter port remain `unsupported_or_misconfigured` for passive observe-first.
+Proxy-like ENH/ENS endpoints on other ports are the passive-capable path. See
+[`deployment/full-stack.md#passive-observe-first-transport-contract`](../deployment/full-stack.md#passive-observe-first-transport-contract)
+and
+[`architecture/observability.md#troubleshooting-mapping`](../architecture/observability.md#troubleshooting-mapping).
+
 ## Examples
 
 Serial:


### PR DESCRIPTION
## What
- link the existing passive observe-first caveats between `deployment/full-stack.md` and the relevant transport protocol docs (`ebusd-tcp`, `enh`, `ens`)
- add normalized observe-first validation notes to the canonical end-to-end smoke, matrix runner, and adversarial runtime docs
- record that `helianthus-tinyebus` target emulation is a parallel timing/observability validation track, not part of the canonical gateway/add-on/integration smoke chain

## Why
DOC-03 is a backfill lane. The repo already had the factual caveats and validation surfaces on `main`, but they were not linked consistently enough to keep the observe-first plan auditable. This PR tightens those links without freezing later runtime semantics, proof artifacts, or API contracts.

## Validation
- `./scripts/ci_local.sh`

## Links
- Closes #213
- Does not start DOC-02 API contract freeze work, DOC-04 B555 filename/link migration, or later runtime proof-artifact freezes
