### PR TITLE
docs: add PIC16F15356 firmware documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Gateway HTTP entrypoints are split by role: `/ui` is the read-only projection br
 | API | [api/graphql.md](api/graphql.md), [api/mcp.md](api/mcp.md), [api/portal.md](api/portal.md) |
 | Deployment | [deployment/full-stack.md](deployment/full-stack.md), [deployment/tinygo-esp32.md](deployment/tinygo-esp32.md) |
 | Development | [development/contributing.md](development/contributing.md), [development/conventions.md](development/conventions.md), [development/ha-integration.md](development/ha-integration.md) |
+| Firmware | [firmware/pic16f15356-overview.md](firmware/pic16f15356-overview.md), [firmware/pic16f15356-fsm.md](firmware/pic16f15356-fsm.md), [firmware/pic16f15356-timing.md](firmware/pic16f15356-timing.md), [firmware/pic16f15356-registers.md](firmware/pic16f15356-registers.md) |
 
 ## Contribution Workflow (Doc-Gate)
 

--- a/firmware/pic16f15356-fsm.md
+++ b/firmware/pic16f15356-fsm.md
@@ -88,9 +88,21 @@ After descriptor processing, if the probe deadline has been reached:
 1. Select variant code from the 7-element rotation table: `{0x01, 0x33, 0x35, 0x36, 0x3A, 0x3B, 0x03}`
 2. Call `dispatch_scan_code(code)` for the selected variant
 3. Re-initialize the scan slot and save context
-4. Advance `scan_dispatch_cursor` modulo 7
+4. Advance `scan_dispatch_cursor` with bounded reset (`if (cursor >= 7) cursor = 0` -- avoids PIC16 software division; no modulo operator)
 5. If cursor wraps to 0: transition to RETRY (full cycle complete)
 6. Otherwise: set probe deadline, transition protocol to VARIANT
+
+### Implementation Notes
+
+The monolithic `picfw_runtime_protocol_state_dispatch` function was decomposed into sub-handlers to reduce cyclomatic complexity:
+
+- `dispatch_flags_retry` -- handles the RETRY flag path (PENDING/READY/RETRY states)
+- `dispatch_flags_scan` -- handles the SCAN flag path (validates flags + state)
+- `dispatch_common_tail` -- shared tail for both paths (seed restore, state transitions)
+
+State validation (`is_valid_protocol_state`) is inlined directly into `set_protocol_state` rather than being a separate function. This saves one hardware stack level on the frozen call path (see [overview](pic16f15356-overview.md#frozen-call-path)).
+
+Similarly, `picfw_runtime_continue_scan_fsm` was split into `continue_fsm_phase_retry`, `continue_fsm_process_pass_descriptors`, and `continue_fsm_variant_dispatch`.
 
 ## Scan Slot Sub-Phase FSM
 

--- a/firmware/pic16f15356-fsm.md
+++ b/firmware/pic16f15356-fsm.md
@@ -140,6 +140,7 @@ The ENH parser decodes the 2-byte enhanced protocol encoding from the host UART 
 stateDiagram-v2
     [*] --> IDLE
     IDLE --> IDLE : byte < 0x80 (short form, emit immediately)
+    IDLE --> IDLE : byte 0x80-0xBF (PARSE_ERROR — invalid as first byte)
     IDLE --> PENDING : byte >= 0xC0 (latch as byte1)
     PENDING --> IDLE : byte 0x80-0xBF (decode byte1+byte2, emit frame)
     PENDING --> PENDING : byte >= 0xC0 (re-sync: replace byte1)

--- a/firmware/pic16f15356-fsm.md
+++ b/firmware/pic16f15356-fsm.md
@@ -45,8 +45,7 @@ stateDiagram-v2
     VARIANT --> VARIANT : Next variant code cycle
     SCAN --> RETRY : Error (shift failure / merge_pending)
     VARIANT --> RETRY : Variant cycle complete (cursor wraps to 0)
-    RETRY --> IDLE : Retry deadline expires + protocol_state_dispatch
-    IDLE --> SCAN : run_scan_fsm (re-enter scan)
+    RETRY --> SCAN : Retry deadline expires + run_scan_fsm (scan phase resets to IDLE internally)
 ```
 
 ## Scan Phase FSM

--- a/firmware/pic16f15356-fsm.md
+++ b/firmware/pic16f15356-fsm.md
@@ -1,0 +1,179 @@
+# PIC16F15356 Firmware State Machines
+
+This document describes all state machines in the PIC16F15356 eBUS adapter firmware.
+
+See also:
+
+- [`firmware/pic16f15356-overview.md`](pic16f15356-overview.md) for the firmware architecture.
+- [`protocols/enh.md`](../protocols/enh.md) for the Enhanced adapter protocol encoding.
+
+## Protocol State FSM
+
+The protocol state FSM governs the top-level runtime lifecycle. It determines whether the firmware is idle, initializing, scanning, or recovering from an error.
+
+States are defined in `picfw_protocol_state_t`:
+
+| Value | Name | Description |
+|---|---|---|
+| 0 | IDLE | No active session, waiting for host INIT |
+| 1 | PENDING | INIT received, negotiation in progress |
+| 2 | ARMED | Defined but unused in current firmware |
+| 3 | READY | Session active, processing commands |
+| 5 | VARIANT | Scan variant dispatch in progress |
+| 6 | OFFSET_SCAN | Offset scan mode (reserved) |
+| 7 | SCAN | Active scan pass running |
+| 8 | RETRY | Error recovery, waiting for retry deadline |
+
+Note: value 4 is intentionally absent. ARMED (2) is defined in the enum but not used in the current firmware implementation.
+
+Each state transition also carries a flags byte (`protocol_state_flags`):
+
+| Value | Name | Meaning |
+|---|---|---|
+| `0x00` | FLAGS_IDLE | Normal operation |
+| `0x01` | FLAGS_RETRY | Retry recovery active |
+| `0x03` | FLAGS_SCAN | Scan window active |
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> PENDING : REQ_INIT received
+    PENDING --> READY : Successful init / protocol_state_dispatch
+    READY --> SCAN : run_scan_pass (scan window start)
+    READY --> READY : INFO / START / SEND commands
+    SCAN --> VARIANT : Variant dispatch (probe deadline reached)
+    VARIANT --> VARIANT : Next variant code cycle
+    SCAN --> RETRY : Error (shift failure / merge_pending)
+    VARIANT --> RETRY : Variant cycle complete (cursor wraps to 0)
+    RETRY --> IDLE : Retry deadline expires + protocol_state_dispatch
+    IDLE --> SCAN : run_scan_fsm (re-enter scan)
+```
+
+## Scan Phase FSM
+
+The scan phase FSM manages the lifecycle of a single scan pass within the scan engine. It runs inside the protocol state SCAN/VARIANT umbrella.
+
+States are defined in `picfw_runtime_scan_phase_t`:
+
+| Value | Name | Description |
+|---|---|---|
+| 0 | IDLE | No scan pass active |
+| 1 | PRIMED | Scan pass initialized, waiting for pass deadline |
+| 2 | PASS | Pass deadline reached, processing descriptors |
+| 3 | RETRY | Descriptor processing failed, waiting for retry deadline |
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> PRIMED : run_scan_pass (initialize slot, save context, set deadlines)
+    PRIMED --> PASS : finalize_scan_pass (pass deadline reached)
+    PASS --> PASS : shift_scan_masks_by_delta + load_descriptor_block (success)
+    PASS --> RETRY : merge_pending_scan_masks (shift failure)
+    RETRY --> IDLE : retry deadline expires + protocol_state_dispatch
+    IDLE --> PRIMED : run_scan_fsm (next cycle)
+```
+
+### Descriptor Loading Path in PASS
+
+When the scan phase reaches PASS:
+
+1. `shift_scan_masks_by_delta(delta=1)` -- attempt to shift scan masks by one position
+2. On success: `load_descriptor_block()` -- read 8 bytes (data + mask), merge with seed, validate
+3. On failure: `merge_pending_scan_masks()` -- fallback merge, transition to RETRY
+
+### Variant Dispatch in PASS
+
+After descriptor processing, if the probe deadline has been reached:
+
+1. Select variant code from the 7-element rotation table: `{0x01, 0x33, 0x35, 0x36, 0x3A, 0x3B, 0x03}`
+2. Call `dispatch_scan_code(code)` for the selected variant
+3. Re-initialize the scan slot and save context
+4. Advance `scan_dispatch_cursor` modulo 7
+5. If cursor wraps to 0: transition to RETRY (full cycle complete)
+6. Otherwise: set probe deadline, transition protocol to VARIANT
+
+## Scan Slot Sub-Phase FSM
+
+The scan slot sub-phase tracks the lifecycle of a single scan slot operation within a scan pass. It is a simple linear progression.
+
+States are defined in `picfw_runtime_scan_sub_phase_t`:
+
+| Value | Name | Description |
+|---|---|---|
+| 0 | RESET | Slot not yet probed |
+| 1 | PROBED | Register window probed, data available |
+| 2 | POLLING | Actively polling descriptor data |
+| 3 | COMPLETE | Slot processing finished |
+
+```mermaid
+stateDiagram-v2
+    [*] --> RESET
+    RESET --> PROBED : probe_register_window (data available)
+    PROBED --> POLLING : poll_scan_slot (data remaining)
+    POLLING --> COMPLETE : poll_scan_slot (all data consumed)
+    PROBED --> COMPLETE : poll_scan_slot (no data remaining)
+    COMPLETE --> [*]
+```
+
+## ENH Parser FSM
+
+The ENH parser decodes the 2-byte enhanced protocol encoding from the host UART stream. It is implemented in `picfw_enh_parser_t` with two fields: `pending` (boolean) and `byte1` (latched first byte).
+
+| State | Condition | Description |
+|---|---|---|
+| IDLE | `pending == false` | Waiting for first byte |
+| PENDING | `pending == true` | First byte latched, waiting for second byte |
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> IDLE : byte < 0x80 (short form, emit immediately)
+    IDLE --> PENDING : byte >= 0xC0 (latch as byte1)
+    PENDING --> IDLE : byte 0x80-0xBF (decode byte1+byte2, emit frame)
+    PENDING --> PENDING : byte >= 0xC0 (re-sync: replace byte1)
+    PENDING --> IDLE : byte < 0x80 (error: discard pending, emit short form)
+```
+
+### Decoding
+
+Given `byte1` (bits `1 1 C C C C D D`) and `byte2` (bits `1 0 D D D D D D`):
+
+- Command = `(byte1 >> 2) & 0x0F`
+- Data = `(byte1 & 0x03) << 6 | (byte2 & 0x3F)`
+
+### Host Parser Timeout
+
+If 64 ms elapses between `byte1` and `byte2`, the parser resets to IDLE and emits `ERROR_HOST`. This prevents a stale partial frame from corrupting subsequent decoding.
+
+## Startup State Machine
+
+The startup state machine tracks the firmware lifecycle from power-on through live operation and degraded mode.
+
+States are defined in `picfw_startup_state_t`:
+
+| Value | Name | Description |
+|---|---|---|
+| 0 | BOOT_INIT | Bootloader has handed off to application entry point |
+| 1 | CACHE_LOADED_STALE | Scan descriptors loaded from EEPROM cache (may be stale) |
+| 2 | LIVE_WARMUP | First live scan cycle in progress, accumulating fresh data |
+| 3 | LIVE_READY | Live scan data validated, adapter fully operational |
+| 4 | DEGRADED | Error detected (queue overflow, parse error), operating in reduced mode |
+
+```mermaid
+stateDiagram-v2
+    [*] --> BOOT_INIT
+    BOOT_INIT --> CACHE_LOADED_STALE : EEPROM cache loaded
+    CACHE_LOADED_STALE --> LIVE_WARMUP : First scan pass starts
+    LIVE_WARMUP --> LIVE_READY : Scan data validated
+    LIVE_READY --> DEGRADED : Error (queue overflow / TX overflow / parse error)
+    DEGRADED --> BOOT_INIT : REQ_INIT (full re-initialization)
+```
+
+### Degraded Mode Triggers
+
+The firmware transitions to DEGRADED when:
+
+- Event queue overflow (`dropped_events` counter increments)
+- Host TX queue overflow (`dropped_tx_bytes` counter increments)
+- Descriptor parse error (`last_error` set to `ERROR_PARSE`)
+- Variant dispatch failure (unsupported scan code)

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -156,6 +156,52 @@ This pattern is explicitly permitted by R8 (DETERMINISM.md). Mutable function po
 
 All register values and code paths were recovered from Ghidra decompilation of the original production `combined.hex` image (76 functions, 10K decompiled lines). The firmware was then re-implemented as a clean-room C codebase, cross-validated against a Go reference oracle (`helianthus-tinyebus`) for bit-exact parity.
 
+## Original Firmware Issues
+
+Ghidra decompilation of the production `combined.hex` revealed systemic issues in the original PIC firmware. These findings motivated the clean-room reimplementation and the determinism rules enforced by this project. Issues are classified by severity: P0 (critical, data loss or corruption), P1 (significant, degraded operation), P2 (latent, long-term instability).
+
+### P0 -- Critical
+
+**FAILED-to-START race bypasses minimum inter-scan delay.** When a new START command arrives before a FAILED response is fully consumed, one code path transitions directly to READY, bypassing the mandatory 0x3C (60 ms) minimum delay. The scan engine then samples the transceiver in a transient window, producing false "no signal" reports. Under START flooding, this cascades into lost SYNs and violent degradation. *Addressed by: bounded deadline enforcement in `normalize_scan_delay()` with `SCAN_MIN_DELAY` floor clamping.*
+
+**ISR and mainline reentrancy on shared FSMs.** The low-priority ISR enters protocol and scan logic directly (`continue_scan_fsm`, flush path) instead of only latching bytes into FIFOs. Mainline simultaneously processes the same state and cursors. The ISR observes partially updated state and makes decisions on incoherent data -- classic torn-state reentrancy. *Addressed by: strict ISR/mainline separation. ISR only latches into ring buffer FIFOs (R4/WCET < 60 cycles). All protocol processing runs in the mainline superloop.*
+
+**Fail-open on invalid protocol codes.** Protocol codes that should be rejected are routed to READY instead of a reject/fault path. A corrupted or malicious response can artificially validate the FSM. *Addressed by: explicit state validation inlined into `set_protocol_state()` (switch on valid enum values, default rejects). XOR-encoded diagnostic return codes on every rejection path.*
+
+**Deadline comparison is wrap-unsafe.** Absolute tick values are compared byte-by-byte (lexicographic) rather than modularly. On counter wrap-around, a deadline can appear expired too early or not at all. *Addressed by: `picfw_deadline_reached_u32()` using modular subtraction (`(int32_t)(now - deadline) >= 0`), which is wrap-safe for intervals < 2^31.*
+
+### P1 -- Significant
+
+**Incomplete state reset in `set_protocol_state_pending()`.** Only a subset of protocol state is reset. Saved deadlines, merged windows, and latches remain stale, explaining paths that reuse old timing state after a rapid FAILED-to-START transition. *Addressed by: `picfw_runtime_seed_scan_state()` performs a full reset of all scan-related fields on INIT.*
+
+**Backoff timing collapses under noise.** On some deadline expirations, the firmware halves timing windows instead of stabilizing, becoming more aggressive under stress. *Addressed by: `post_merge_validate()` enforces floor and ceiling on all scan window parameters. Window limit, delay, and merged values are clamped to validated ranges on every merge cycle.*
+
+**"No signal" detection lacks debounce.** A single LOW sample on the signal-detect pin immediately triggers a "no signal" path, producing false negatives during frame transitions. *Addressed by: the reimplementation delegates signal detection entirely to the Go gateway, which has proper debounce and hysteresis.*
+
+**Self-DoS via busy-wait loops.** `service_timed_loop()` and related paths use spin loops. Under command flooding, CPU time is consumed by polling instead of UART servicing, causing the firmware to lose determinism at peak stress. *Addressed by: R3 (all loops bounded by constants), no spin-wait patterns. The mainline superloop processes a fixed event budget per step (`STEP_EVENT_BUDGET = 8`).*
+
+**Critical sections too narrow and inconsistent.** Interrupt masking covers small fragments, not full atomic updates of shared state. Shared state is mutated outside the protected window. *Addressed by: eliminating shared mutable state between ISR and mainline. ISR writes to FIFO tail (atomic push); mainline reads from FIFO head (atomic pop). No shared cursor or state variable.*
+
+**Non-atomic multi-byte updates.** 16/32-bit values are written and read byte-by-byte on the 8-bit MCU without coherent protection, allowing readers to observe mixed old/new bytes. *Addressed by: all multi-byte deadline/timestamp writes happen in mainline only (never ISR). The ISR only increments single-byte counters and pushes single bytes to FIFOs.*
+
+**Buffer cursors lack hard bounds.** Some cursors grow with only soft thresholds, risking wrap or RAM overwrite if producers outrun consumers. *Addressed by: R10 (power-of-2 ring buffers with bitmask indexing). All buffer capacities have `_Static_assert` enforcement. Overflow increments a diagnostic counter and transitions to DEGRADED -- no silent corruption.*
+
+**Flush path is reentrant.** The message output path runs in both ISR and mainline with incomplete serialization, causing frame interleaving and dropped output. *Addressed by: output drain is mainline-only (`hal_drain_host_tx`). ISR never touches the TX queue. The TX queue is a single-producer (mainline enqueue) / single-consumer (mainline drain) ring buffer.*
+
+**Weak descriptor validation.** The firmware accepts "plausible" descriptor blocks and derives seeds, masks, and deadlines from them. A malicious peer can inject values that pass superficial validation but poison the scheduler. *Addressed by: `post_merge_validate()` clamps all derived values to validated ranges. `SCAN_WINDOW_LIMIT_FLOOR` (240 ms), `SCAN_DELAY_THRESHOLD` (120 ms), and `SCAN_MERGED_THRESHOLD` (210 ms) enforce hard bounds on descriptor-derived timing.*
+
+### P2 -- Latent
+
+**State leak (sticky latches).** There is no dynamic allocation (`malloc/free`), but sticky flags/latches are set and not cleared on all paths, causing cumulative degradation over long uptime. *Addressed by: `picfw_runtime_init()` performs a full zero-init of all runtime state. INIT command triggers a complete re-initialization cycle.*
+
+**Multiple READY encodings.** Several `state + flags` combinations represent effectively the same READY condition, creating "weird machine" behavior where logically equivalent transitions have different side effects. *Addressed by: the reimplementation uses a single canonical `set_protocol_state(READY, FLAGS_IDLE)` path. State validation rejects any state value not in the defined enum.*
+
+**Weak recovery after malicious input.** Parsers and FSMs do not perform hard resets after errors or partial sequences, allowing residual state to poison subsequent frames. *Addressed by: the ENH parser resets to IDLE after every complete frame and on every error (conservative reset policy). The scan FSM transitions to DEGRADED on any unrecoverable error, requiring a full INIT to resume.*
+
+### Assessment
+
+The original firmware was not designed for strict real-time determinism. The dominant failure modes are not memory leaks but state leaks, ISR/mainline races, wrap-unsafe comparisons, fail-open logic, busy-wait self-DoS, and cursor drift. Under normal traffic it may appear acceptable; under flood, jitter, line noise, or long uptime, it becomes fragile and amplifies its own failures. Every determinism rule in this project traces back to at least one of these findings.
+
 ## Related Firmware Documents
 
 - [State Machines](pic16f15356-fsm.md) -- protocol FSM, scan phase FSM, ENH parser, startup states

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -55,7 +55,7 @@ graph TD
 | Layer | Role | Implementation |
 |---|---|---|
 | **Application** | ISR dispatcher, mainline superloop, clock switch | `pic16f15356_app` |
-| **Runtime** | Protocol FSM, ENH/ENS codec, scan engine, descriptor merge, status emission, diagnostics | `runtime.c` (1830 lines) |
+| **Runtime** | Protocol FSM, ENH/ENS codec, scan engine, descriptor merge, status emission, diagnostics | `runtime.c` (~1920 lines) |
 | **HAL** | ISR byte latch into FIFOs, TMR0 tick management, UART baud rate switching | `pic16f15356_hal` |
 | **Bootloader** | STX-framed protocol, flash write, EEPROM read/write, 10 commands, CRC16-CCITT verification | `picboot` |
 
@@ -75,13 +75,56 @@ graph TD
 | Boot | `0x0000`--`0x03FF` | 1 KB | Bootloader image, reset vector, clock-switch helper |
 | App | `0x0400`--`0x3FFF` | 15 KB | Application image, ISR dispatcher, runtime, HAL |
 | EEPROM | 256 bytes | 256 B | Persistent configuration |
-| RAM | 2048 bytes | 2 KB | Runtime state (`picfw_runtime_t` <= 600 bytes), stack, FIFOs |
+| RAM | 2048 bytes | 2 KB | Runtime state (612 bytes combined static footprint), stack, FIFOs |
 
-The `picfw_runtime_t` struct is statically asserted to fit within 600 bytes, leaving headroom for the hardware call stack (16 levels) and local variables.
+The combined static footprint (`picfw_runtime_t` + `picfw_pic16f15356_hal_t`) is 612 bytes (39.8% of the 1536-byte budget -- 75% of 2048). `_Static_assert` guards enforce the struct size limit and power-of-2 ring buffer capacities at compile time.
 
 ## Determinism
 
-All code paths have bounded, predictable execution time. No recursion, no dynamic allocation, no floating point, all loops bounded by constants. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set.
+All code paths have bounded, predictable execution time. 15 determinism rules are enforced automatically by 12 mandatory CI checks (`make check-all`) and a pre-commit hook. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set and check commands.
+
+### Rule Summary
+
+| ID | Rule | Threshold | Enforcement |
+|----|------|-----------|-------------|
+| R1 | No recursion (direct or mutual) | -- | Call graph cycle detection |
+| R2 | No malloc/calloc/realloc/free | -- | Pattern scan |
+| R3 | All loops bounded by constant | -- | AST pattern analysis |
+| R4 | ISR-context WCET | < 60 cycles | Naming pattern + source heuristic |
+| R5 | No `__delay` in critical paths | -- | Skipped (HAL simulation model) |
+| R6 | No float/double/math.h | -- | Pattern scan |
+| R7 | No variable-length arrays | -- | Pattern scan (with R2) |
+| R8 | Cyclomatic complexity | < 10 per function (peak: 9) | Decision point counting |
+| R9 | Hardware timers for temporal decisions | -- | Manual code review |
+| R10 | Ring buffers power-of-2 + bitmask | -- | Buffer size + indexing scan |
+| STACK | Call depth limit | < 13 of 16 HW levels | Call graph DFS |
+| GUARD | Header include guards | -- | Pattern scan |
+| RAM | Static struct footprint | < 75% of 2 KB (612 / 1536) | Host sizeof budget check |
+| WCET | ISR-context functions | < 60 cycles (peak: 51) | Source heuristic (`*_isr_*`) |
+| CONST | Function pointer arrays | Must be `const` | Qualifier scan |
+
+### Frozen Call Path
+
+The deepest mainline call chain is exactly 13 levels, running through the scan FSM retry path:
+
+```
+app_mainline_service -> mainline_service -> runtime_step ->
+  service_periodic_status -> try_emit_variant -> emit_periodic_variant ->
+    continue_scan_window -> continue_scan_fsm -> continue_fsm_phase_retry ->
+      protocol_state_dispatch -> dispatch_flags_retry ->
+        set_protocol_state_ready -> set_protocol_state
+```
+
+Budget: 13 mainline + 3 ISR (`app_isr_host_rx -> isr_latch_host_rx -> byte_fifo_push`) = 16 hardware stack levels. Zero margin. New function extractions on this path are prohibited.
+
+### Dispatch Table Architecture
+
+The bootloader uses `const` dispatch tables instead of large `switch/case` cascades:
+
+- `PICBOOT_COMMAND_HANDLERS[11]` -- `static const` function pointer array with O(1) command dispatch. Protected by `_Static_assert` on array size and a NULL guard at dispatch time.
+- `PICBOOT_VALIDATION_RULES[11]` -- `static const` struct array with per-command validation rules (`min_data_len`, `max_data_len`, `needs_even`). Protected by `_Static_assert`.
+
+This pattern is explicitly permitted by R8 (DETERMINISM.md). Mutable function pointer dispatch remains prohibited.
 
 ## Provenance
 

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -1,0 +1,94 @@
+# PIC16F15356 eBUS Adapter Firmware
+
+This document describes the architecture and scope of the PIC16F15356 firmware used in Helianthus eBUS adapter v3.x hardware.
+
+See also:
+
+- [`protocols/enh.md`](../protocols/enh.md) for the Enhanced adapter protocol encoding.
+- [`protocols/ens.md`](../protocols/ens.md) for the high-speed serial variant.
+- [`architecture/overview.md`](../architecture/overview.md) for the gateway-level architecture.
+
+## Scope
+
+The PIC16F15356 firmware is a **transparent UART bridge** between an ESP host (running the Go gateway) and the eBUS wire. It is **not** an eBUS node. All eBUS protocol responsibilities (CRC-8, frame escaping, arbitration decisions, retransmission) are delegated to the Go gateway running on the ESP host.
+
+The firmware handles:
+
+- SYN byte (`0xAA`) detection and forwarding
+- ENH/ENS encoding and decoding between PIC and host
+- Bus byte forwarding with arbitration echo suppression
+- Scan window management and descriptor processing
+- Periodic status emission (snapshot and variant frames)
+- Host parser timeout enforcement (64 ms)
+- Bootloader for flash and EEPROM updates via STX-framed commands
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph PIC16F15356["PIC16F15356 Firmware"]
+        APP["Application<br/><i>pic16f15356_app</i><br/>ISR + mainline wrapper"]
+        RT["Runtime<br/>Protocol FSM + ENH/ENS codec<br/>Scan engine + Descriptor merge<br/>Status emission + Diagnostics"]
+        HAL["HAL<br/><i>pic16f15356_hal</i><br/>ISR latch FIFOs + TMR0 tick<br/>UART mode switching"]
+        BOOT["Bootloader<br/><i>picboot</i><br/>STX frames + Flash/EEPROM<br/>10 commands + CRC16-CCITT"]
+        APP --> RT
+        RT --> HAL
+        BOOT -.->|reset handoff| APP
+    end
+
+    subgraph ESP["ESP8266 D1 mini"]
+        TINY["helianthus-tinyebus<br/>Go oracle + northbound bridge"]
+    end
+
+    subgraph BUS["eBUS Wire"]
+        BOILER["Boiler BAI00 @ 0x08"]
+        VRC["Controller VRC700 @ 0x15"]
+    end
+
+    ESP <-->|"ENH/ENS 9600 / 115200 baud"| PIC16F15356
+    HAL <-->|"UART RX/TX byte forwarding"| BUS
+    BOILER --- VRC
+```
+
+### Layer Responsibilities
+
+| Layer | Role | Implementation |
+|---|---|---|
+| **Application** | ISR dispatcher, mainline superloop, clock switch | `pic16f15356_app` |
+| **Runtime** | Protocol FSM, ENH/ENS codec, scan engine, descriptor merge, status emission, diagnostics | `runtime.c` (1830 lines) |
+| **HAL** | ISR byte latch into FIFOs, TMR0 tick management, UART baud rate switching | `pic16f15356_hal` |
+| **Bootloader** | STX-framed protocol, flash write, EEPROM read/write, 10 commands, CRC16-CCITT verification | `picboot` |
+
+## Protocol Layers
+
+| Layer | Scope | Owner |
+|---|---|---|
+| Physical | eBUS transceiver, 2400 baud, differential signaling | External hardware |
+| Data link | CRC-8, frame escaping (`ESC=0xA9` / `SYN=0xAA`), arbitration decisions | Host gateway (Go) |
+| Adapter | ENH/ENS encoding, SYN forwarding, scan windows, status emission | This firmware (PIC) |
+| Application | Scan/status interpretation, INFO queries, feature negotiation | Host gateway (Go) |
+
+## Memory Map
+
+| Region | Address Range | Size | Content |
+|---|---|---|---|
+| Boot | `0x0000`--`0x03FF` | 1 KB | Bootloader image, reset vector, clock-switch helper |
+| App | `0x0400`--`0x3FFF` | 15 KB | Application image, ISR dispatcher, runtime, HAL |
+| EEPROM | 256 bytes | 256 B | Persistent configuration |
+| RAM | 2048 bytes | 2 KB | Runtime state (`picfw_runtime_t` <= 600 bytes), stack, FIFOs |
+
+The `picfw_runtime_t` struct is statically asserted to fit within 600 bytes, leaving headroom for the hardware call stack (16 levels) and local variables.
+
+## Determinism
+
+All code paths have bounded, predictable execution time. No recursion, no dynamic allocation, no floating point, all loops bounded by constants. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set.
+
+## Provenance
+
+All register values and code paths were recovered from Ghidra decompilation of the original production `combined.hex` image (76 functions, 10K decompiled lines). The firmware was then re-implemented as a clean-room C codebase, cross-validated against a Go reference oracle (`helianthus-tinyebus`) for bit-exact parity.
+
+## Related Firmware Documents
+
+- [State Machines](pic16f15356-fsm.md) -- protocol FSM, scan phase FSM, ENH parser, startup states
+- [Timing Model](pic16f15356-timing.md) -- clock, TMR0, UART baud rates, scan deadlines
+- [Register Configuration](pic16f15356-registers.md) -- oscillator, timer, EUSART, interrupt, descriptor addresses

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -30,7 +30,7 @@ graph TD
         APP["Application<br/><i>pic16f15356_app</i><br/>ISR + mainline wrapper"]
         RT["Runtime<br/>Protocol FSM + ENH/ENS codec<br/>Scan engine + Descriptor merge<br/>Status emission + Diagnostics"]
         HAL["HAL<br/><i>pic16f15356_hal</i><br/>ISR latch FIFOs + TMR0 tick<br/>UART mode switching"]
-        BOOT["Bootloader<br/><i>picboot</i><br/>STX frames + Flash/EEPROM<br/>10 commands + CRC16-CCITT"]
+        BOOT["Bootloader<br/><i>picboot</i><br/>STX frames + Flash/EEPROM<br/>11 commands + CRC16-CCITT"]
         APP --> RT
         RT --> HAL
         BOOT -.->|reset handoff| APP
@@ -55,9 +55,9 @@ graph TD
 | Layer | Role | Implementation |
 |---|---|---|
 | **Application** | ISR dispatcher, mainline superloop, clock switch | `pic16f15356_app` |
-| **Runtime** | Protocol FSM, ENH/ENS codec, scan engine, descriptor merge, status emission, diagnostics | `runtime.c` (~1920 lines) |
+| **Runtime** | Protocol FSM, ENH/ENS codec, scan engine, descriptor merge, status emission, diagnostics | `runtime.c` (~1935 lines) |
 | **HAL** | ISR byte latch into FIFOs, TMR0 tick management, UART baud rate switching | `pic16f15356_hal` |
-| **Bootloader** | STX-framed protocol, flash write, EEPROM read/write, 10 commands, CRC16-CCITT verification | `picboot` |
+| **Bootloader** | STX-framed protocol, flash write, EEPROM read/write, 11 commands, CRC16-CCITT verification | `picboot` |
 
 ## Protocol Layers
 
@@ -81,7 +81,7 @@ The combined static footprint (`picfw_runtime_t` + `picfw_pic16f15356_hal_t`) is
 
 ## Determinism
 
-All code paths have bounded, predictable execution time. 15 determinism rules are enforced automatically by 12 mandatory CI checks (`make check-all`) and a pre-commit hook. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set and check commands.
+All code paths have bounded, predictable execution time. 15 determinism rules are defined; 13 are enforced automatically by 12 mandatory CI checks (`make check-all`) and a pre-commit hook. R5 is skipped (HAL simulation model uses no `__delay_ms`), and R9 (hardware timers) requires manual code review. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set and check commands.
 
 ### Why Determinism
 

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -83,6 +83,32 @@ The combined static footprint (`picfw_runtime_t` + `picfw_pic16f15356_hal_t`) is
 
 All code paths have bounded, predictable execution time. 15 determinism rules are enforced automatically by 12 mandatory CI checks (`make check-all`) and a pre-commit hook. See [DETERMINISM.md](https://github.com/Project-Helianthus/helianthus-ebus-adapter-pic/blob/main/DETERMINISM.md) for the full rule set and check commands.
 
+### Why Determinism
+
+The eBUS adapter firmware must behave as a transparent, jitter-free UART bridge. eBUS master-master arbitration is bit-level at 2400 baud: if the adapter introduces more than ~10 us of jitter in byte forwarding, it loses arbitration and corrupts the bus. There is no retry mechanism -- a missed window means dropped frames and broken heating control.
+
+This constraint drives every architectural decision:
+
+- **No recursion, no dynamic allocation, no VLAs** (R1, R2, R7) -- stack depth and RAM usage must be statically provable. On PIC16F15356 with 2 KB RAM and a 16-level hardware call stack, any unpredictable growth is fatal.
+- **All loops bounded by constants** (R3) -- unbounded iteration produces unbounded execution time. Every loop has a compile-time-visible upper bound or a provably-decreasing guard.
+- **No floating point** (R6) -- PIC16F has no FPU. Software float emulation is non-deterministic in cycle count and consumes ~1 KB of ROM.
+- **Cyclomatic complexity < 10** (R8) -- high-CC functions have deep nesting and many execution paths, making WCET analysis intractable. The threshold ensures every function is small enough to reason about exhaustively. Monolithic dispatchers were replaced with `const` lookup tables (O(1) dispatch, constant WCET).
+- **ISR WCET < 60 cycles** (R4/WCET) -- the ISR fires every 500 us (TMR0 period). At 8 MHz instruction clock, 60 cycles = 7.5 us -- well under the 500 us period and the 10 us jitter budget. ISR functions only latch bytes into ring buffer FIFOs; all protocol processing happens in the mainline superloop. This separation guarantees the ISR never blocks.
+- **Call depth < 13** (STACK) -- PIC16F15356 has a 16-level hardware call stack (not software, not growable). 3 levels are reserved for the deepest ISR chain (`app_isr_host_rx -> isr_latch_host_rx -> byte_fifo_push`), leaving 13 for mainline. The deepest mainline chain (scan FSM retry path) uses exactly 13 -- zero margin. This is a frozen path: new function extractions here are prohibited.
+- **Power-of-2 ring buffers with bitmask indexing** (R10) -- the PIC16F has no hardware divider. Modulo (`%`) on a non-power-of-2 value compiles to a software division routine (~30 cycles). Bitmask (`& (CAP - 1)`) is a single AND instruction (~1 cycle). For ISR-context FIFO push/pop, this 30x speedup is the difference between meeting and missing the WCET budget.
+- **RAM budget < 75%** (RAM) -- the combined static footprint of `picfw_runtime_t` + `picfw_pic16f15356_hal_t` is tracked by a compiled C program using `sizeof`. Host compiler alignment differs from XC8, but relative growth is tracked: if a struct grows 32 bytes on the host, it grew similarly on PIC. The 25% headroom covers the hardware call stack, local variables, and compiler temporaries.
+- **Const dispatch enforcement** (CONST) -- function pointer arrays must be `const` (placed in ROM by XC8). Mutable function pointer dispatch is prohibited because it introduces runtime-dependent branching that defeats WCET analysis. The `const` qualifier is both a correctness guarantee (table cannot be corrupted) and a ROM/RAM optimization.
+
+### Self-Testing
+
+Every determinism rule has an automated check script (pure Python 3, zero pip dependencies) that produces a `PASS`/`FAIL` verdict. The checks are validated in both directions:
+
+- **Good code must pass** -- all 12 checks are run against `runtime/src` and `bootloader/src` (22 positive tests).
+- **Bad code must fail** -- synthetic violations in `tests/fixtures/bad_example.c` trigger each check (10 negative tests).
+- **Total: 31 self-tests** via `bash tests/test_checks.sh`, ensuring the checks themselves do not silently regress.
+
+The `NOLINT(determinism)` comment suppression mechanism allows intentional exceptions (e.g., a loop with a provably-constant bound that the checker cannot statically verify), documented inline at the suppression site.
+
 ### Rule Summary
 
 | ID | Rule | Threshold | Enforcement |

--- a/firmware/pic16f15356-registers.md
+++ b/firmware/pic16f15356-registers.md
@@ -47,7 +47,7 @@ The TMR0 ISR is triggered when:
 1. `PIE0.TMR0IE` (Timer 0 interrupt enable) is set, **and**
 2. `PIR0.TMR0IF` (Timer 0 interrupt flag) is set
 
-The ISR dispatcher at `CODE:0412` checks up to 4 pending/enable bit pairs in sequence to determine which peripheral triggered the interrupt.
+The ISR dispatcher at `CODE:0412` checks up to 3 pending/enable bit pairs in sequence to determine which peripheral triggered the interrupt.
 
 ### ISR Latch Model
 
@@ -107,7 +107,7 @@ SP1BRGL is located at SFR address `0x11B` in bank `0x02`.
 
 ### ISR Dispatcher
 
-The ISR entry point at `CODE:0412` checks up to 4 peripheral interrupt pending/enable bit pairs in priority order:
+The ISR entry point at `CODE:0412` checks 3 peripheral interrupt pending/enable bit pairs in priority order:
 
 ```mermaid
 flowchart TD

--- a/firmware/pic16f15356-registers.md
+++ b/firmware/pic16f15356-registers.md
@@ -74,7 +74,7 @@ All ring buffers use power-of-2 capacities with bitmask indexing (`& (CAP - 1u)`
 |---|---|---|
 | SP1BRGL | `0x40` | Low byte of SPBRG |
 | SP1BRGH | `0x03` | High byte of SPBRG |
-| Combined SPBRG | `0x0340` (832) | Baud = 32 MHz / (4 * 833) = ~9615 |
+| Combined SPBRG | `0x0340` (832) | Baud = 32 MHz / (4 * 833) = ~9604 |
 
 ### High-Speed Baud (115200)
 
@@ -113,19 +113,17 @@ The ISR entry point at `CODE:0412` checks up to 4 peripheral interrupt pending/e
 flowchart TD
     ISR["ISR Entry<br/><code>CODE:0412</code>"] --> TMR{"PIR0.TMR0IF<br/>&&<br/>PIE0.TMR0IE?"}
     TMR -->|Yes| TMR_H["isr_latch_tmr0<br/>~24 cycles"]
-    TMR -->|No| RX{"PIR3.RC1IF<br/>&&<br/>PIE3.RC1IE?"}
-    RX -->|Yes| RX_H["isr_latch_bus_rx<br/>~36 cycles"]
-    RX -->|No| TX{"PIR3.TX1IF<br/>&&<br/>PIE3.TX1IE?"}
-    TX -->|Yes| TX_H["isr_latch_host_rx<br/>~36 cycles"]
-    TX -->|No| OTHER{"Additional<br/>peripheral pairs?"}
-    OTHER -->|No| RET["RETFIE"]
+    TMR -->|No| BUS{"PIR3.RC1IF<br/>&&<br/>PIE3.RC1IE?"}
+    BUS -->|Yes| BUS_H["isr_latch_bus_rx<br/>~36 cycles"]
+    BUS -->|No| HOST{"Host RX<br/>peripheral?"}
+    HOST -->|Yes| HOST_H["isr_latch_host_rx<br/>~36 cycles"]
+    HOST -->|No| RET["RETFIE"]
     TMR_H --> RET
-    RX_H --> RET
-    TX_H --> RET
-    OTHER -->|Yes| OTH_H["implementation-<br/>specific handler"] --> RET
+    BUS_H --> RET
+    HOST_H --> RET
 ```
 
-Each handler clears the interrupt flag and latches received data into the appropriate ring buffer FIFO.
+The first two checks are confirmed from the binary (TMR0 timer and EUSART1 receive for bus bytes). The host RX interrupt source depends on the hardware configuration -- the PIC may use a second EUSART, MSSP SPI, or another peripheral for host communication. The exact PIR/PIE pair for the host channel has not been fully recovered from the original binary. No TX interrupt handler exists; transmit is polled.
 
 ## Descriptor Address Computation
 
@@ -159,13 +157,15 @@ The final descriptor cursor is: `(addr_hi << 8) | addr_lo`.
 
 ### Known Descriptor Bases
 
-| Slot | addr_lo | addr_hi | Cursor |
-|---|---|---|---|
-| `0x01` | `0x28` | `0x24` | `0x0264` |
-| `0x03` | `0x68` | `0x24` | `0x0260` |
-| `0x06` | `0xC8` | `0x24` | `0x0268` |
+The firmware uses a pre-computed lookup table (`scan_descriptor_base_for_slot()`) rather than the general formula above. The lookup values were extracted from the original binary:
 
-Note: the bases in the table above are the values returned by `scan_descriptor_base_for_slot()`, which uses a lookup table rather than the computed formula. For the default slot (`0x06`), the lookup returns `0x0268`.
+| Slot | Cursor | High Byte | Low Byte |
+|---|---|---|---|
+| `0x01` | `0x0264` | `0x02` | `0x64` |
+| `0x03` | `0x0260` | `0x02` | `0x60` |
+| `0x06` | `0x0268` | `0x02` | `0x68` |
+
+The general formula (addr_lo / addr_hi computation above) describes the algorithm recovered from `initialize_scan_slot_full()` in Ghidra. The lookup table entries may have been pre-computed from a different revision of that algorithm or hand-tuned in the original firmware.
 
 ### Cursor Advancement
 

--- a/firmware/pic16f15356-registers.md
+++ b/firmware/pic16f15356-registers.md
@@ -51,7 +51,20 @@ The ISR dispatcher at `CODE:0412` checks up to 4 pending/enable bit pairs in seq
 
 ### ISR Latch Model
 
-The ISR only latches received bytes into ring buffer FIFOs. All protocol processing (ENH decoding, scan FSM, status emission) happens in the mainline superloop. This ensures the ISR has bounded, minimal execution time.
+The ISR only latches received bytes into ring buffer FIFOs. All protocol processing (ENH decoding, scan FSM, status emission) happens in the mainline superloop. This ensures the ISR has bounded, minimal execution time (peak: 51 cycles, budget: 60).
+
+### Ring Buffer Capacities
+
+All ring buffers use power-of-2 capacities with bitmask indexing (`& (CAP - 1u)`) instead of modulo. This eliminates software division on PIC16F (no hardware divider) and is enforced by `_Static_assert` at compile time.
+
+| Buffer | Capacity | Type | Use |
+|--------|----------|------|-----|
+| `ISR_LATCH_CAP` | 16 | Ring (FIFO) | ISR byte FIFOs (`host_rx`, `bus_rx`, `host_tx`) |
+| `EVENT_QUEUE_CAP` | 32 | Ring (queue) | Runtime event queue |
+| `HOST_TX_CAP` | 128 | Ring (queue) | Host TX byte queue |
+| `DESCRIPTOR_DATA_CAP` | 64 | Linear | Descriptor data buffer (sequential, not ring) |
+
+`HOST_TX_CAP` was 96 in the original firmware binary. Changed to 128 (nearest power-of-2 up) to enable correct bitmask indexing -- `& 95` (0x5F) is not a valid ring buffer mask, while `& 127` (0x7F) is. `DESCRIPTOR_DATA_CAP` was 48; changed to 64 for power-of-2 alignment (this is a linear buffer, but consistency avoids false positives from the R10 checker).
 
 ## EUSART1 Registers
 

--- a/firmware/pic16f15356-registers.md
+++ b/firmware/pic16f15356-registers.md
@@ -107,16 +107,25 @@ SP1BRGL is located at SFR address `0x11B` in bank `0x02`.
 
 ### ISR Dispatcher
 
-The ISR entry point at `CODE:0412` checks up to 4 peripheral interrupt pending/enable bit pairs. The dispatcher structure:
+The ISR entry point at `CODE:0412` checks up to 4 peripheral interrupt pending/enable bit pairs in priority order:
 
-```text
-1. Check PIR0.TMR0IF && PIE0.TMR0IE  (Timer 0)
-2. Check PIR3.RC1IF && PIE3.RC1IE    (EUSART1 receive)
-3. Check PIR3.TX1IF && PIE3.TX1IE    (EUSART1 transmit)
-4. Check additional peripheral pairs  (implementation-specific)
+```mermaid
+flowchart TD
+    ISR["ISR Entry<br/><code>CODE:0412</code>"] --> TMR{"PIR0.TMR0IF<br/>&&<br/>PIE0.TMR0IE?"}
+    TMR -->|Yes| TMR_H["isr_latch_tmr0<br/>~24 cycles"]
+    TMR -->|No| RX{"PIR3.RC1IF<br/>&&<br/>PIE3.RC1IE?"}
+    RX -->|Yes| RX_H["isr_latch_bus_rx<br/>~36 cycles"]
+    RX -->|No| TX{"PIR3.TX1IF<br/>&&<br/>PIE3.TX1IE?"}
+    TX -->|Yes| TX_H["isr_latch_host_rx<br/>~36 cycles"]
+    TX -->|No| OTHER{"Additional<br/>peripheral pairs?"}
+    OTHER -->|No| RET["RETFIE"]
+    TMR_H --> RET
+    RX_H --> RET
+    TX_H --> RET
+    OTHER -->|Yes| OTH_H["implementation-<br/>specific handler"] --> RET
 ```
 
-Each check is a conditional branch: if both the interrupt flag and its enable bit are set, the corresponding handler runs. The handler clears the flag and latches any received data into the appropriate FIFO.
+Each handler clears the interrupt flag and latches received data into the appropriate ring buffer FIFO.
 
 ## Descriptor Address Computation
 

--- a/firmware/pic16f15356-registers.md
+++ b/firmware/pic16f15356-registers.md
@@ -1,0 +1,174 @@
+# PIC16F15356 Register Configuration
+
+This document catalogs all PIC16F15356 SFR (Special Function Register) configurations recovered from the original firmware binary via Ghidra decompilation.
+
+See also:
+
+- [`firmware/pic16f15356-timing.md`](pic16f15356-timing.md) for computed timing values derived from these registers.
+
+## Oscillator Registers
+
+| Register | Value | Meaning |
+|---|---|---|
+| OSCCON1 | `0x60` | NOSC = HFINTOSC (110), NDIV = 1:1 (0000) |
+| OSCFRQ | `0x06` | HFINTOSC frequency = 32 MHz |
+
+### CONFIG1 Fuses
+
+| Field | Value | Meaning |
+|---|---|---|
+| RSTOSC | `110` | Reset oscillator = HFINTOSC at 1 MHz |
+| FEXTOSC | `100` | External oscillator = OFF |
+| CONFIG1 word | `0x3FEC` | Combined fuse value |
+
+### Clock-Switch Helpers
+
+Two independent copies of the clock-switch helper exist in the binary:
+
+| Copy | Address | Context |
+|---|---|---|
+| Bootloader | `CODE:0399` | Switches clock before bootloader UART init |
+| Application | `CODE:3E84` | Switches clock at application entry after reset handoff |
+
+Both copies write identical values (`OSCCON1=0x60`, `OSCFRQ=0x06`) and produce identical 32 MHz runtime configuration.
+
+## Timer 0 Registers
+
+| Register | Value | Meaning |
+|---|---|---|
+| T0CON0 | `0x80` | Timer enabled (T0EN=1), 8-bit mode (T016BIT=0) |
+| T0CON1 | `0x44` | Clock source = Fosc/4 (T0CS=010), prescaler = 1:16 (T0CKPS=0100) |
+| TMR0H | `0xF9` | Period register (counts 0 to 249, total 250 counts) |
+
+### ISR Trigger
+
+The TMR0 ISR is triggered when:
+
+1. `PIE0.TMR0IE` (Timer 0 interrupt enable) is set, **and**
+2. `PIR0.TMR0IF` (Timer 0 interrupt flag) is set
+
+The ISR dispatcher at `CODE:0412` checks up to 4 pending/enable bit pairs in sequence to determine which peripheral triggered the interrupt.
+
+### ISR Latch Model
+
+The ISR only latches received bytes into ring buffer FIFOs. All protocol processing (ENH decoding, scan FSM, status emission) happens in the mainline superloop. This ensures the ISR has bounded, minimal execution time.
+
+## EUSART1 Registers
+
+### Default Baud (9600)
+
+| Register | Value | Meaning |
+|---|---|---|
+| SP1BRGL | `0x40` | Low byte of SPBRG |
+| SP1BRGH | `0x03` | High byte of SPBRG |
+| Combined SPBRG | `0x0340` (832) | Baud = 32 MHz / (4 * 833) = ~9615 |
+
+### High-Speed Baud (115200)
+
+| Register | Value | Meaning |
+|---|---|---|
+| SP1BRGL | `0x44` | Low byte of SPBRG |
+| SP1BRGH | `0x00` | High byte of SPBRG |
+| Combined SPBRG | `0x0044` (68) | Baud = 32 MHz / (4 * 69) = ~115,942 |
+
+### Common EUSART1 Registers
+
+| Register | Value | Bit Fields |
+|---|---|---|
+| TX1STA | `0x24` | TXEN=1 (transmit enabled), SYNC=0 (async), BRGH=1 (high baud rate) |
+| RC1STA | `0x90` | SPEN=1 (serial port enabled), CREN=1 (continuous receive) |
+| BAUD1CON | `0x08` | BRG16=1 (16-bit baud rate generator enabled) |
+
+### Bank Address
+
+SP1BRGL is located at SFR address `0x11B` in bank `0x02`.
+
+## Interrupt Configuration
+
+### Global Interrupt Control
+
+| Register | Bits | State |
+|---|---|---|
+| INTCON | GIE | Enabled (global interrupt enable) |
+| INTCON | PEIE | Enabled (peripheral interrupt enable) |
+
+### ISR Dispatcher
+
+The ISR entry point at `CODE:0412` checks up to 4 peripheral interrupt pending/enable bit pairs. The dispatcher structure:
+
+```text
+1. Check PIR0.TMR0IF && PIE0.TMR0IE  (Timer 0)
+2. Check PIR3.RC1IF && PIE3.RC1IE    (EUSART1 receive)
+3. Check PIR3.TX1IF && PIE3.TX1IE    (EUSART1 transmit)
+4. Check additional peripheral pairs  (implementation-specific)
+```
+
+Each check is a conditional branch: if both the interrupt flag and its enable bit are set, the corresponding handler runs. The handler clears the flag and latches any received data into the appropriate FIFO.
+
+## Descriptor Address Computation
+
+The scan engine computes descriptor memory addresses from a slot ID using the following formula:
+
+### Address Low Byte
+
+```text
+addr_lo = (slot_id * 0x20) + 8
+```
+
+### Address High Byte
+
+```text
+addr_hi = bit_reverse_5(slot_id[7:3]) | 0x24
+```
+
+Where `bit_reverse_5` extracts bits 7 through 3 of `slot_id` and reverses their order into bits 4 through 0:
+
+```text
+bit7 -> bit4
+bit6 -> bit3
+bit5 -> bit2
+bit4 -> bit1
+bit3 -> bit0
+```
+
+An additional carry correction is applied: if `slot_id * 0x20` overflows byte range (i.e., `0xF7 < (slot_id * 0x20) & 0xFF`), `addr_hi` is incremented by 1.
+
+The final descriptor cursor is: `(addr_hi << 8) | addr_lo`.
+
+### Known Descriptor Bases
+
+| Slot | addr_lo | addr_hi | Cursor |
+|---|---|---|---|
+| `0x01` | `0x28` | `0x24` | `0x0264` |
+| `0x03` | `0x68` | `0x24` | `0x0260` |
+| `0x06` | `0xC8` | `0x24` | `0x0268` |
+
+Note: the bases in the table above are the values returned by `scan_descriptor_base_for_slot()`, which uses a lookup table rather than the computed formula. For the default slot (`0x06`), the lookup returns `0x0268`.
+
+### Cursor Advancement
+
+The descriptor cursor advances by `0x2C` (44 bytes) per recompute cycle in `recompute_scan_masks_tail()`. This stride covers one complete descriptor block (8 bytes data + mask) plus alignment padding.
+
+## Scan Mask Seed
+
+The scan mask seed is a fixed 32-bit constant used to initialize the scan mask at each slot initialization:
+
+```text
+SCAN_MASK_SEED_DEFAULT = 0x00060101
+```
+
+Byte breakdown:
+
+| Byte | Position | Value |
+|---|---|---|
+| lo | `[7:0]` | `0x01` |
+| b1 | `[15:8]` | `0x01` |
+| b2 | `[23:16]` | `0x06` |
+| hi | `[31:24]` | `0x00` |
+
+## Determinism Notes
+
+- All register values in this document were recovered from Ghidra decompilation of the original `combined.hex` binary image. They have **not** been measured on live silicon.
+- Two copies of the clock-switch helper exist (bootloader at `CODE:0399` and application at `CODE:3E84`). Both produce identical results. This redundancy exists because the bootloader and application are independently linked images sharing the same flash.
+- The 921,600 baud bootloader register path has **not yet been recovered** from the binary. The bootloader fast-mode baud rate is documented in the host-side contract (`ebuspicloader`) but the specific SPBRG value for 921,600 baud at 32 MHz has not been extracted.
+- The descriptor address computation formula was recovered from the decompiled `initialize_scan_slot_full()` function and cross-validated against the Go reference oracle (`helianthus-tinyebus`).

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -109,11 +109,23 @@ All scan timing constants are defined in `runtime.h` and `runtime.c`. Values are
 
 ### Scan Timing Diagram
 
-```text
-|--- SCAN_PASS_DELAY (200ms) ---|--- descriptor processing ---|--- SCAN_PROBE_DELAY (400ms) per variant ---|
-|                                |                              |                                            |
-run_scan_pass           finalize_scan_pass              variant dispatch cycle (7 codes)
-                        (PRIMED -> PASS)                (PASS -> VARIANT -> ... -> RETRY)
+```mermaid
+sequenceDiagram
+    participant SE as Scan Engine
+
+    Note over SE: run_scan_pass<br/>(IDLE → PRIMED)
+    SE->>SE: SCAN_PASS_DELAY (200 ms)
+    Note over SE: finalize_scan_pass<br/>(PRIMED → PASS)
+    SE->>SE: Descriptor processing<br/>(shift + load + merge)
+
+    loop 7 variant codes (0x01, 0x33, 0x35, 0x36, 0x3A, 0x3B, 0x03)
+        SE->>SE: dispatch_scan_code
+        SE->>SE: SCAN_PROBE_DELAY (400 ms)
+    end
+
+    Note over SE: Cursor wraps to 0<br/>(PASS → RETRY)
+    SE->>SE: SCAN_RETRY_DELAY (100 ms)
+    Note over SE: protocol_state_dispatch<br/>(RETRY → IDLE)
 ```
 
 ### Delay Floor Enforcement

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -128,6 +128,29 @@ All scan delays are clamped to a minimum of `SCAN_MIN_DELAY` (60 ms) by `normali
 
 If the ENH parser receives `byte1` of an encoded pair but `byte2` does not arrive within 64 ms, the parser resets and emits `ERROR_HOST`. This prevents stale partial frames from corrupting subsequent decoding.
 
+## ISR WCET Budget
+
+All ISR-context functions must complete within 60 instruction cycles (7.5 us at 8 MHz instruction clock). This budget is enforced by `check_wcet_isr.py`, which identifies ISR-context functions by naming pattern (`*_isr_*`) and transitively marks their callees.
+
+| Function | Own Cost | Callee Cost | ISR Overhead | Total |
+|----------|----------|-------------|--------------|-------|
+| `byte_fifo_push` | ~15 | -- | -- | ~15 (transitive callee) |
+| `event_queue_push` | ~18 | -- | -- | ~18 (transitive callee) |
+| `isr_latch_tmr0` | ~16 | -- | +8 | ~24 |
+| `isr_latch_host_rx` | ~13 | fifo_push ~15 | +8 | ~36 |
+| `isr_latch_bus_rx` | ~13 | fifo_push ~15 | +8 | ~36 |
+| `isr_enqueue_host_byte` | ~14 | queue_push ~18 | +8 | ~40 |
+| `isr_enqueue_bus_byte` | ~14 | queue_push ~18 | +8 | ~40 |
+| `app_isr_tmr0` | ~9 | latch_tmr0 ~24 | +8 | ~41 |
+| **`app_isr_host_rx`** | ~7 | latch_host_rx ~36 | +8 | **~51 (peak)** |
+| **`app_isr_bus_rx`** | ~7 | latch_bus_rx ~36 | +8 | **~51 (peak)** |
+
+ISR overhead (+8 cycles) accounts for the PIC16 interrupt context save and restore (CALL + RETFIE). Estimates use a source-level heuristic: `if` = 3 cycles, assignment = 2, function call = 4, etc. Actual XC8-compiled cycle counts will differ but the relative ordering is preserved.
+
+### Ring Buffer Optimization
+
+All ring buffer index operations use bitmask arithmetic (`& (CAP - 1u)`) instead of modulo (`% CAP`). On PIC16F15356 (no hardware divider), this saves ~40 instruction cycles per push/pop operation -- critical for ISR-context functions where every cycle counts toward the 60-cycle budget.
+
 ## Bootloader Baud Rates
 
 The bootloader (separate from the application runtime) supports two transfer speeds:

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -1,0 +1,154 @@
+# PIC16F15356 Timing Model
+
+This document describes the clock, timer, UART, and scan timing configuration of the PIC16F15356 eBUS adapter firmware.
+
+See also:
+
+- [`firmware/pic16f15356-overview.md`](pic16f15356-overview.md) for the firmware architecture.
+- [`protocols/enh.md`](../protocols/enh.md) for the Enhanced adapter protocol encoding.
+
+## Clock Configuration
+
+The PIC16F15356 uses the internal high-frequency oscillator (HFINTOSC) in two modes:
+
+| Phase | Clock Source | Frequency | Configuration |
+|---|---|---|---|
+| Reset | HFINTOSC | 1 MHz | CONFIG1 = `0x3FEC` (RSTOSC=110, FEXTOSC=100) |
+| Runtime | HFINTOSC | 32 MHz | OSCCON1 = `0x60`, OSCFRQ = `0x06` |
+
+The clock switch from 1 MHz to 32 MHz is performed by a helper function that exists in two identical copies: one in the bootloader region (`CODE:0399`) and one in the application region (`CODE:3E84`). Both produce identical results.
+
+### Instruction Cycle
+
+| Parameter | Value |
+|---|---|
+| System clock (Fosc) | 32 MHz |
+| Instruction clock (Fosc/4) | 8 MHz |
+| Instruction cycle time | 125 ns |
+
+## TMR0 Configuration
+
+Timer 0 provides the ISR heartbeat that drives the entire firmware timing model.
+
+| Register | Value | Meaning |
+|---|---|---|
+| T0CON1 | `0x44` | Clock source = Fosc/4, prescaler = 1:16 |
+| T0CON0 | `0x80` | Timer enabled, 8-bit mode |
+| TMR0H | `0xF9` | Period register (250 counts, since `0xF9 + 1 = 250`) |
+
+### ISR Interval
+
+```text
+ISR period = (TMR0H + 1) * prescaler / instruction_clock
+           = 250 * 16 / 8,000,000
+           = 500 microseconds
+```
+
+### Scheduler Tick
+
+The ISR increments a subtick counter. Every 200 subticks, the scheduler fires:
+
+```text
+Scheduler tick = ISR period * divider
+               = 500 us * 200
+               = 100,000 us
+               = 100 ms
+```
+
+| Parameter | Value |
+|---|---|
+| ISR period | 500 microseconds |
+| Software divider | 200 subticks |
+| Scheduler tick | 100 ms |
+
+All scan delays, deadlines, and status emission periods are expressed in terms of this 100 ms scheduler tick.
+
+## EUSART1 Configuration
+
+The firmware supports two UART baud rates for host communication:
+
+| Mode | SPBRG | BRGH | BRG16 | Actual Baud | Target Baud | Error |
+|---|---|---|---|---|---|---|
+| Default | `0x0340` (832) | 1 | 1 | ~9615 | 9600 | +0.16% |
+| High-speed | `0x0044` (68) | 1 | 1 | ~115,942 | 115200 | +0.64% |
+
+Baud rate formula (async, BRGH=1, BRG16=1):
+
+```text
+Baud = Fosc / (4 * (SPBRG + 1))
+```
+
+### EUSART1 Register Values
+
+| Register | Value | Meaning |
+|---|---|---|
+| BAUD1CON | `0x08` | BRG16 = 1 (16-bit baud rate generator) |
+| RC1STA | `0x90` | Serial port enabled (SPEN=1), continuous receive (CREN=1) |
+| TX1STA | `0x24` | Transmit enabled (TXEN=1), BRGH=1, asynchronous mode |
+| SP1BRGL/SP1BRGH | `0x0340` or `0x0044` | Baud rate generator value |
+
+## Scan Timing
+
+All scan timing constants are defined in `runtime.h` and `runtime.c`. Values are in milliseconds unless noted.
+
+| Constant | Value (hex) | Value (decimal) | Description |
+|---|---|---|---|
+| `SCAN_PASS_DELAY` | -- | 200 ms | Delay before scan pass finalization (2 scheduler ticks) |
+| `SCAN_RETRY_DELAY` | -- | 100 ms | Delay before scan retry (1 scheduler tick) |
+| `SCAN_PROBE_DELAY` | -- | 400 ms | Delay between variant probes (4 scheduler ticks) |
+| `SCAN_MIN_DELAY` | `0x3C` | 60 ms | Floor for all scan delays (eBUS minimum idle time) |
+| `SCAN_DEFAULT_TICK` | `0x0140` | 320 ms | Default protocol tick interval |
+| `SCAN_DEFAULT_DEADLINE` | `0x01A4` | 420 ms | Default scan deadline |
+| `SCAN_DEFAULT_WINDOW_LIMIT` | `0x0156` | 342 ms | Default scan window limit |
+| `SCAN_DEFAULT_SEED` | `0x02A4` | 676 ms | Default scan seed value |
+| `SCAN_DEFAULT_MERGED_WINDOW` | `0x01A8` | 424 ms | Default merged window value |
+| `SCAN_WINDOW_LIMIT_FLOOR` | `0xF0` | 240 ms | Minimum allowed window limit |
+| `SCAN_DELAY_THRESHOLD` | `0x78` | 120 ms | Delay validation threshold |
+| `SCAN_MERGED_THRESHOLD` | `0xD2` | 210 ms | Merged window validation threshold |
+| `SCAN_WINDOW_DELTA_DEFAULT` | `0x2E` | 46 ms | Default scan window delta |
+
+### Scan Timing Diagram
+
+```text
+|--- SCAN_PASS_DELAY (200ms) ---|--- descriptor processing ---|--- SCAN_PROBE_DELAY (400ms) per variant ---|
+|                                |                              |                                            |
+run_scan_pass           finalize_scan_pass              variant dispatch cycle (7 codes)
+                        (PRIMED -> PASS)                (PASS -> VARIANT -> ... -> RETRY)
+```
+
+### Delay Floor Enforcement
+
+All scan delays are clamped to a minimum of `SCAN_MIN_DELAY` (60 ms) by `normalize_scan_delay()`. This ensures the eBUS has minimum idle time between transmissions. Zero delay (initial state) is also clamped to 60 ms.
+
+## Host Parser Timeout
+
+| Parameter | Value |
+|---|---|
+| Timeout | 64 ms (`PICFW_RUNTIME_HOST_RX_TIMEOUT_MS`) |
+
+If the ENH parser receives `byte1` of an encoded pair but `byte2` does not arrive within 64 ms, the parser resets and emits `ERROR_HOST`. This prevents stale partial frames from corrupting subsequent decoding.
+
+## Bootloader Baud Rates
+
+The bootloader (separate from the application runtime) supports two transfer speeds:
+
+| Mode | Baud Rate | Status |
+|---|---|---|
+| Slow / legacy | 115,200 | Documented in host-side contract |
+| Fast | 921,600 | Documented in host-side contract |
+
+Note: the 921,600 baud register values have not yet been recovered from the bootloader binary. The bootloader uses the same HFINTOSC 32 MHz clock after its own clock-switch helper runs.
+
+## eBUS Timing Reference
+
+These values describe the eBUS wire protocol timing. They are **not implemented in the PIC firmware** -- all eBUS protocol timing is delegated to the Go gateway on the ESP host.
+
+| Parameter | Value |
+|---|---|
+| Baud rate | 2400 |
+| Bit time | 416.7 microseconds |
+| SYN timeout | 50 ms |
+| Arbitration window | Within 1 bit-time (~417 microseconds) |
+| Arbitration jitter tolerance | ~10 microseconds |
+
+The 10 microsecond jitter tolerance is why the firmware enforces strict determinism: any jitter in byte forwarding can cause lost arbitration and bus corruption.

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -130,9 +130,10 @@ All scan delays are clamped to a minimum of `SCAN_MIN_DELAY` (60 ms) by `normali
 
 | Parameter | Value |
 |---|---|
-| Timeout | 64 ms (`PICFW_RUNTIME_HOST_RX_TIMEOUT_MS`) |
+| Configured timeout | 64 ms (`PICFW_RUNTIME_HOST_RX_TIMEOUT_MS`) |
+| Effective timeout | 100 ms (next scheduler tick) |
 
-If the ENH parser receives `byte1` of an encoded pair but `byte2` does not arrive within 64 ms, the parser resets and emits `ERROR_HOST`. This prevents stale partial frames from corrupting subsequent decoding.
+If the ENH parser receives `byte1` of an encoded pair but `byte2` does not arrive in time, the parser resets and emits `ERROR_HOST`. The deadline is set as `now_ms + 64`, but since `now_ms` advances in 100 ms steps, the timeout effectively fires on the next scheduler tick after the deadline passes -- between 100 ms and 200 ms after `byte1`, depending on where in the tick cycle the first byte arrived. The 64 ms constant is inherited from the original firmware binary; on the 100 ms timebase it acts as a "fire on next tick" sentinel rather than a precise 64 ms window.
 
 ## ISR WCET Budget
 

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -110,22 +110,14 @@ All scan timing constants are defined in `runtime.h` and `runtime.c`. Values are
 ### Scan Timing Diagram
 
 ```mermaid
-sequenceDiagram
-    participant SE as Scan Engine
-
-    Note over SE: run_scan_pass<br/>(IDLE → PRIMED)
-    SE->>SE: SCAN_PASS_DELAY (200 ms)
-    Note over SE: finalize_scan_pass<br/>(PRIMED → PASS)
-    SE->>SE: Descriptor processing<br/>(shift + load + merge)
-
-    loop 7 variant codes (0x01, 0x33, 0x35, 0x36, 0x3A, 0x3B, 0x03)
-        SE->>SE: dispatch_scan_code
-        SE->>SE: SCAN_PROBE_DELAY (400 ms)
-    end
-
-    Note over SE: Cursor wraps to 0<br/>(PASS → RETRY)
-    SE->>SE: SCAN_RETRY_DELAY (100 ms)
-    Note over SE: protocol_state_dispatch<br/>(RETRY → IDLE)
+flowchart LR
+    A["run_scan_pass<br/>IDLE → PRIMED"] -->|"200 ms<br/>PASS_DELAY"| B["finalize_scan_pass<br/>PRIMED → PASS"]
+    B --> C["Descriptor<br/>shift + load + merge"]
+    C --> D["Variant 1<br/><code>0x01</code>"]
+    D -->|"400 ms<br/>PROBE_DELAY"| E["Variant 2..7<br/><code>0x33 0x35 0x36<br/>0x3A 0x3B 0x03</code>"]
+    E -->|"cursor wraps"| F["RETRY<br/>PASS → RETRY"]
+    F -->|"100 ms<br/>RETRY_DELAY"| G["dispatch<br/>RETRY → IDLE"]
+    G -.->|"next cycle"| A
 ```
 
 ### Delay Floor Enforcement

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -69,7 +69,7 @@ The firmware supports two UART baud rates for host communication:
 
 | Mode | SPBRG | BRGH | BRG16 | Actual Baud | Target Baud | Error |
 |---|---|---|---|---|---|---|
-| Default | `0x0340` (832) | 1 | 1 | ~9615 | 9600 | +0.16% |
+| Default | `0x0340` (832) | 1 | 1 | ~9604 | 9600 | +0.04% |
 | High-speed | `0x0044` (68) | 1 | 1 | ~115,942 | 115200 | +0.64% |
 
 Baud rate formula (async, BRGH=1, BRG16=1):

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -61,7 +61,9 @@ Scheduler tick = ISR period * divider
 | Software divider | 200 subticks |
 | Scheduler tick | 100 ms |
 
-The scheduler tick (100 ms) drives periodic status emission and coarse scan phase delays (`SCAN_PASS_DELAY` = 200 ms = 2 ticks, `SCAN_RETRY_DELAY` = 100 ms = 1 tick, `SCAN_PROBE_DELAY` = 400 ms = 4 ticks). However, fine-grained scan timing -- window limits, merged thresholds, seed-derived delays -- operates in milliseconds, not tick multiples. These values (e.g., 60 ms floor, 342 ms window limit, 46 ms delta) are compared against `now_ms` timestamps, which accumulate from the scheduler tick but are not quantized to it.
+The runtime clock (`now_ms`) advances by exactly 100 ms on each scheduler tick (`runtime_now_ms += SCHEDULER_PERIOD_MS`). All deadline comparisons use this 100 ms-stepped counter, so the effective timing resolution is 100 ms regardless of the constant's precision.
+
+Coarse phase delays are exact tick multiples: `SCAN_PASS_DELAY` = 200 ms = 2 ticks, `SCAN_RETRY_DELAY` = 100 ms = 1 tick, `SCAN_PROBE_DELAY` = 400 ms = 4 ticks. Fine-grained constants like `SCAN_MIN_DELAY` (60 ms), `SCAN_WINDOW_LIMIT_FLOOR` (240 ms), and `SCAN_WINDOW_DELTA_DEFAULT` (46 ms) represent target thresholds defined with sub-tick precision, but they are resolved at 100 ms granularity when compared against `now_ms`. For example, a 60 ms floor effectively triggers at the next 100 ms boundary.
 
 ## EUSART1 Configuration
 

--- a/firmware/pic16f15356-timing.md
+++ b/firmware/pic16f15356-timing.md
@@ -61,7 +61,7 @@ Scheduler tick = ISR period * divider
 | Software divider | 200 subticks |
 | Scheduler tick | 100 ms |
 
-All scan delays, deadlines, and status emission periods are expressed in terms of this 100 ms scheduler tick.
+The scheduler tick (100 ms) drives periodic status emission and coarse scan phase delays (`SCAN_PASS_DELAY` = 200 ms = 2 ticks, `SCAN_RETRY_DELAY` = 100 ms = 1 tick, `SCAN_PROBE_DELAY` = 400 ms = 4 ticks). However, fine-grained scan timing -- window limits, merged thresholds, seed-derived delays -- operates in milliseconds, not tick multiples. These values (e.g., 60 ms floor, 342 ms window limit, 46 ms delta) are compared against `now_ms` timestamps, which accumulate from the scheduler tick but are not quantized to it.
 
 ## EUSART1 Configuration
 


### PR DESCRIPTION
## Summary

- Add `firmware/` directory with 4 comprehensive documentation files for the agentic PIC16F15356 eBUS adapter firmware
- Add Firmware row to README.md Documentation Map table

### New files

| File | Content |
|------|---------|
| `firmware/pic16f15356-overview.md` | Architecture (Mermaid), protocol layers, memory map, provenance |
| `firmware/pic16f15356-fsm.md` | 5 FSMs with Mermaid stateDiagram-v2: Protocol State, Scan Phase, Scan Slot, ENH Parser, Startup |
| `firmware/pic16f15356-timing.md` | Clock, TMR0, EUSART baud rates, scan deadlines, host timeout, eBUS wire reference |
| `firmware/pic16f15356-registers.md` | Oscillator, Timer0, EUSART1, interrupt, descriptor addresses, scan mask seed |

All values recovered from Ghidra decompilation of original `combined.hex`. Cross-references to `protocols/enh.md` and `protocols/ens.md`.

## Test plan

- [x] Verify Mermaid diagrams render correctly on GitHub
- [x] Verify all cross-reference links resolve
- [x] Verify timing values match `platform_model.h` in firmware repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)