### PR TITLE
docs: canonical proxy wire-semantics decisions (#238)

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -4,6 +4,8 @@ This repository documents the current, implemented architecture of the Helianthu
 
 Detailed API contracts live in [`api/graphql.md`](../api/graphql.md), [`api/mcp.md`](../api/mcp.md), and [`api/portal.md`](../api/portal.md).
 
+Canonical proxy wire-semantics scheduling decisions live in [`architecture/proxy-wire-semantics.md`](./proxy-wire-semantics.md).
+
 ## Layered Architecture (Mermaid)
 
 ```mermaid
@@ -309,6 +311,7 @@ flowchart LR
 Planes initiate work (method invocation) or receive broadcast updates, but they do not manage protocol states. The Bus is responsible for the eBUS-level state machine: send, ACK/NACK handling, response read, CRC validation, and retries. The Router sits between the two, translating Plane operations into Bus sends and routing Bus broadcasts back to subscribed Planes.
 
 While waiting for ACK/NACK, the Bus tolerates idle/noise bytes (e.g., repeated `SYN`) and continues until a definitive ACK/NACK or timeout is reached.
+This Bus-layer wording describes generic protocol FSM behavior and must not be read as a proxy handoff rule, where `SYN-while-waiting` is treated as an immediate scheduling timeout boundary (see [`proxy-wire-semantics.md`](./proxy-wire-semantics.md)).
 
 ### eBUS Send/Receive State Machine (Mermaid)
 

--- a/architecture/proxy-wire-semantics.md
+++ b/architecture/proxy-wire-semantics.md
@@ -1,0 +1,63 @@
+# Proxy Wire-Semantics Decisions
+
+Status: Accepted (M0 decision lock for [EPIC #5](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/5))
+Plan package: [PLAN-01 #6](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/6)
+
+This document defines the canonical scheduling and timing semantics for proxy-mediated shared eBUS access.
+
+## Scope and intent
+
+The proxy is expected to behave like multiple independent participants sharing one physical eBUS, while acknowledging that software scheduling over one southbound connection cannot reproduce electrical bit-level simultaneity.
+
+This yields a strict distinction:
+
+- Electrical fidelity: bit-simultaneous arbitration and wired-AND effects on the physical wire.
+- Wire-semantics fidelity: scheduling and timeout behavior observed at frame/symbol boundaries (`START`, `ACK/NACK`, `SYN`, response windows).
+
+Proxy decisions in this workstream target wire-semantics fidelity.
+
+## Decision 1: `SYN-while-waiting` is a timeout boundary
+
+When an active transaction is waiting for:
+
+- command `ACK/NACK`,
+- target response bytes, or
+- response confirmation,
+
+and a `SYN` is observed, the transaction is semantically timed out for scheduling.
+
+Proxy consequence:
+
+- the current exchange is closed immediately for bus scheduling,
+- arbitration may reopen immediately,
+- multi-second host safety timers remain transport/control-path safeguards only and are not authoritative bus handoff timers.
+
+## Decision 2: stale `STARTED` handling for milestone M1
+
+The first proxy milestone uses bounded stale-absorb behavior for `pendingStart`:
+
+- a mismatched stale `STARTED(x)` does not force immediate failure if the expected `STARTED(requested)` arrives within a bounded absorb window,
+- absorb success and absorb expiry are both explicitly counted/logged,
+- no scheduler redesign is implied by this decision; it is an immediate correctness fix with low blast radius.
+
+## Decision 3: generic child-backed local target passthrough is not timing-faithful by default
+
+For a shared real bus, a target response injected too late appears detached from the initiating request to other participants. Because a generic child-backed responder path includes host/proxy scheduling and transport latency, it is not timing-faithful by default.
+
+Policy:
+
+- do not claim strict timing fidelity for generic child-backed local target passthrough,
+- treat strict local target behavior as a separately proven capability,
+- keep this capability behind explicit validation before upgrading fidelity claims.
+
+## Operational implications
+
+- Proxy behavior changes that affect scheduling boundaries require doc-gate updates before merge.
+- Transport/protocol merge gates remain `T01..T88` plus the dedicated proxy-semantics subset (`PX01..PX12`) defined in the matrix lane.
+- Hardware passive proof for strict timing claims remains deferred to the ESERA follow-up milestone and is non-blocking for current code milestones.
+
+## References
+
+- EPIC: [Project-Helianthus/helianthus-execution-plans#5](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/5)
+- Execution plan package: [Project-Helianthus/helianthus-execution-plans#6](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/6)
+- Matrix runbook: [`../development/smoke-matrix.md`](../development/smoke-matrix.md)


### PR DESCRIPTION
## What
Add the canonical wire-semantics decision document and minimal discoverability/clarity links.

## Why
Issue #238 requires M0 doc-gate lock for proxy scheduling semantics and stale START policy.

## Changes
- add architecture/proxy-wire-semantics.md
- add one discoverability link in architecture/overview.md
- add one clarifying sentence in architecture/overview.md to separate generic Bus FSM timeout wording from proxy scheduler timeout boundaries

## Validation
- ./scripts/ci_local.sh (pass)

Closes #238