### PR TITLE
docs: add PX01..PX12 proxy-semantics matrix gate contract (#240)

### DIFF
--- a/development/contributing.md
+++ b/development/contributing.md
@@ -62,8 +62,13 @@ Doc-gate is mandatory for changes that affect implemented architecture, APIs, or
 For eBUS transport/protocol changes, merge readiness requires an additional runtime gate:
 
 - **Scope:** changes in transport/protocol code paths (gateway transport selection, proxy upstream/downstream transport behavior, ebusgo transport implementations, arbitration behavior tied to wire protocol).
-- **Required artifact:** full matrix result (`T01..T88`) with no unexpected failures (`fail`) and no unexpected passes (`xpass`) against the active expected-failure inventory.
-- **Required reference:** PR description must include the `results/index.json` path or attachment reference.
+- **Primary required artifact:** full matrix result (`T01..T88`) with no unexpected failures (`fail`) and no unexpected passes (`xpass`) against the active expected-failure inventory.
+- **Proxy adjunct artifact (when proxy wire-semantics scope applies):** proxy-semantics subset (`PX01..PX12`) with the same no-unexpected-`fail`/`xpass` policy.
+- **Required reference:** PR description must include the primary `results/index.json` path or attachment reference, and for proxy wire-semantics scope it must also include the proxy-semantics artifact index reference.
 - **Expected-failure inventory:** any `xfail` must map to a documented transport limitation (case IDs + reason), and that inventory must be attached in the PR description.
 - **Default policy:** if runtime gate is not satisfied, merge is blocked.
 - **Owner override:** only explicit owner approval may bypass this gate, with a written reason.
+
+Hardware-backed ESERA passive validation remains a deferred follow-up for the
+proxy wire-semantics lane and is not a merge blocker for the current milestone
+set (tracked in [Project-Helianthus/helianthus-docs-ebus#241](https://github.com/Project-Helianthus/helianthus-docs-ebus/issues/241)).

--- a/development/smoke-matrix.md
+++ b/development/smoke-matrix.md
@@ -188,6 +188,66 @@ Current factual references:
 - runtime adversarial scenarios that remain outside the transport gate:
   [`../architecture/adversarial-matrix.md`](../architecture/adversarial-matrix.md)
 
+## Proxy-Semantics Adjunct Gate (`PX01..PX12`)
+
+`T01..T88` remains the primary transport gate. For proxy transport/protocol
+merges, a required adjunct proof subset is evaluated in addition to `T01..T88`:
+
+- `PX01`: stale `STARTED` absorb with matching result inside absorb window
+- `PX02`: stale `STARTED` absorb expiry with bounded fail path
+- `PX03`: `SYN` while waiting for command `ACK` reopens arbitration immediately
+- `PX04`: `SYN` while waiting for target response reopens arbitration immediately
+- `PX05`: lower initiator wins same-boundary competition
+- `PX06`: lower initiator arriving before next round closes beats queued higher
+- `PX07`: requeue-after-timeout by former owner still wins over higher
+- `PX08`: equal-initiator FIFO ordering is preserved
+- `PX09`: local target sees request only from echoed `RECEIVED`, never `SEND`
+- `PX10`: local emulated target response inside responder window remains coherent
+- `PX11`: late local target response is rejected and counted
+- `PX12`: non-owner and non-responder send is rejected during active transaction
+
+### Gate policy with `PX` adjunct
+
+- `T01..T88` verdict remains the primary merge gate for transport/protocol work.
+- `PX01..PX12` is a required adjunct for proxy wire-semantics scope.
+- Merge requires no unexpected `fail` and no unexpected `xpass` across both
+  gate sets.
+- `xfail` must stay bound to a documented expected-failure inventory with case
+  IDs and reasons.
+
+### Expected artifact shape for proxy-semantics proof runs
+
+Proof runs must include an attached artifact bundle shaped as:
+
+```text
+results/
+  index.json
+  proxy-semantics/
+    index.json
+    PX01/
+      verdict.json
+      logs/runner.log
+    PX02/
+      verdict.json
+      logs/runner.log
+    ...
+    PX12/
+      verdict.json
+      logs/runner.log
+```
+
+`proxy-semantics/index.json` must summarize `PX01..PX12` outcomes and expected
+failure annotations used for that run.
+
+### Deferred ESERA passive validation note
+
+The current matrix gate does not require hardware-backed ESERA passive proof
+before merge for this workstream. That validation remains tracked as a deferred
+follow-up in:
+
+- `FOLLOWUP-01` docs lane: [Project-Helianthus/helianthus-docs-ebus#241](https://github.com/Project-Helianthus/helianthus-docs-ebus/issues/241)
+- execution-plan lane: [Project-Helianthus/helianthus-execution-plans#7](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/7)
+
 ## Privacy and secrets
 
 No adapter IPs or credentials are stored in repo artifacts by default. Config files reference environment placeholders (`MATRIX_*`), and command strings must be provided at runtime via local operator context.


### PR DESCRIPTION
## What
Document the proxy-semantics adjunct matrix gate for #240.

## Why
Proxy wire-semantics merges need explicit PX01..PX12 proof rules in addition to T01..T88.

## Acceptance Criteria
- [x] PX01..PX12 documented in matrix/runbook docs
- [x] T01..T88 kept as primary gate, PX subset as required adjunct
- [x] ESERA passive validation noted as deferred
- [x] Expected proxy proof artifact shape linked

## Dependencies
- Depends on #240
