### PR TITLE
docs: cross-product audit findings — 9 protocol documentation gaps

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -360,9 +360,9 @@ stateDiagram-v2
   [*] --> Idle
   Idle --> WriteFrame: Enqueue + Dequeue
   WriteFrame --> Done: Broadcast
-  WriteFrame --> WaitAck: MasterMaster/MasterSlave
-  WaitAck --> Done: ACK + MasterMaster
-  WaitAck --> WaitResponse: ACK + MasterSlave
+  WriteFrame --> WaitAck: i2i / i2t
+  WaitAck --> Done: ACK + i2i
+  WaitAck --> WaitResponse: ACK + i2t
   WaitResponse --> Done: Response + CRC ok
   WaitAck --> Retry: NACK/Timeout
   WaitResponse --> Retry: Timeout/CRC mismatch

--- a/firmware/pic16f15356-overview.md
+++ b/firmware/pic16f15356-overview.md
@@ -16,6 +16,8 @@ See also:
 
 The current PIC16F15356 firmware tree is a **host-buildable adapter/runtime scaffold** between an ESP host and the eBUS adapter hardware model. It is **not** yet a silicon-complete production image, and all eBUS protocol responsibilities above the adapter framing layer remain delegated to host software.
 
+> **Port note:** The current scaffold firmware uses TCP port 3333 (`PICFW_W5500_EBUSD_PORT`). Production ENH adapters use port 9999 (or a configurable port stored in EEPROM). Clients connecting to this firmware scaffold must use port 3333 instead of the standard 9999.
+
 The firmware handles:
 
 - SYN byte (`0xAA`) detection and forwarding

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -73,6 +73,10 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 **SYN during active waits:** If a `SYN` (`0xAA`) byte is received while waiting for an `ACK`/`NACK` or a target response, it signals end-of-transaction (timeout). All known implementations (ebusgo, ebusd, VRC Explorer) treat SYN during ACK/response wait as a timeout indicator and abort the current transaction. Ignoring SYN and continuing to wait is incorrect -- it causes the receiver to stall past the end of the transaction.
 
+**ENH transport caveat:** On ENH-based transports, the adapter decodes wire escapes before forwarding to the host. The byte 0xAA is therefore valid data, not necessarily a SYN idle marker. SYN detection and bus-idle timeout are handled internally by the adapter hardware/firmware. The host-side SYN guards described above apply only to raw bus access and ebusd-tcp transports.
+
+**Escape-aware SYN counting:** On raw bus transports, the escape sequence `0xA9 0x01` represents the data byte 0xAA and must NOT be counted as SYN. Only a standalone, unescaped `0xAA` outside of an active frame's data region indicates bus idle.
+
 **Early SYN during request collection:** If SYN arrives when only 0 or 1 request bytes have been collected (`requestBytesSeen <= 1`), it indicates a new arbitration cycle rather than a framing error. Implementations should reset collection state and treat the next byte as the start of a new transaction.
 
 ## Transaction Flow (Direct Mode)
@@ -104,6 +108,11 @@ Key points:
 - **ACK/NAK timing**: `ACK`/`NACK` is exchanged **once per command**, after the initiator sends the command CRC (not after each byte).
 - **Response shape**: In initiator/target transactions the target response begins with a **length byte** and does not repeat source/destination addresses. CRC is computed over `LEN DATA...` only (not including any address bytes). Implementors must **not** attempt to read header bytes (SRC/DST/PB/SB) from the target response -- they are inferred from the initiator telegram. See ebusgo#104 for a regression where phantom header reads caused all initiator-target transactions to fail.
 - **SYN** (`0xAA`) is used as an **end-of-message** delimiter and may also appear during idle.
+
+> **NACK retry semantics (per eBUS specification SS7.4):**
+> - **CmdNACK**: If the target NACKs the command (responds with `0xFF` instead of ACK `0x00`), the initiator retries the command portion once WITHOUT re-arbitration. If the retry also receives NACK, the transaction fails.
+> - **ResponseNACK**: If the initiator NACKs the target's response, the target retransmits the response once. If the second response also receives NACK, the transaction fails.
+> - The NACK byte is specifically `0xFF`. Any other non-ACK byte indicates a bus error, not a deliberate NACK.
 
 > **Note:** ENH-based adapters abstract physical SYN detection. The host does not observe raw SYN bytes; the adapter handles arbitration internally and signals transaction boundaries via ENH command framing (STARTED, FAILED, etc.).
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -73,7 +73,7 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 **SYN during active waits:** If a `SYN` (`0xAA`) byte is received while waiting for an `ACK`/`NACK` or a target response, it signals end-of-transaction (timeout). All known implementations (ebusgo, ebusd, VRC Explorer) treat SYN during ACK/response wait as a timeout indicator and abort the current transaction. Ignoring SYN and continuing to wait is incorrect -- it causes the receiver to stall past the end of the transaction.
 
-**ENH transport caveat:** On ENH-based transports, the adapter decodes wire escapes before forwarding to the host. The byte 0xAA is therefore valid data, not necessarily a SYN idle marker. SYN detection and bus-idle timeout are handled internally by the adapter hardware/firmware. The host-side SYN guards described above apply only to raw bus access and ebusd-tcp transports.
+**ENH transport caveat:** On ENH-based transports, the adapter decodes wire escapes before forwarding to the host. The byte 0xAA is therefore valid data, not necessarily a SYN idle marker. SYN detection and bus-idle timeout are handled internally by the adapter hardware/firmware. The host-side SYN guards described above apply only to raw bus access (serial or direct TCP connection to the adapter).
 
 **Escape-aware SYN counting:** On raw bus transports, the escape sequence `0xA9 0x01` represents the data byte 0xAA and must NOT be counted as SYN. Only a standalone, unescaped `0xAA` outside of an active frame's data region indicates bus idle.
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -117,6 +117,8 @@ Outcomes:
 - `<STARTED> <initiator>`: arbitration won
 - `<FAILED> <winner>`: arbitration lost (the data byte indicates the winning initiator address)
 
+> **Implementation recommendation:** If the adapter sends repeated STARTED frames with an initiator address that does not match the host's arbitration request, the host should abort arbitration after a configurable threshold (typically 3 mismatches). This prevents infinite arbitration loops when the bus is congested with competing initiators. All three Helianthus implementations (ebusgo, VRC Explorer, adaptermux) enforce this pattern.
+
 ### Arbitration byte visibility
 
 During arbitration initiated by the host, adapters **must not** emit `RECEIVED` notifications for the arbitration bytes they put on the bus. Clients should not rely on echo notifications for those bytes.

--- a/protocols/ens.md
+++ b/protocols/ens.md
@@ -88,4 +88,4 @@ The ENS firmware codec (`codec_ens.c`) is a data-only encoding layer. It cannot 
 - `STARTED` (arbitration grant)
 - `FAILED` (arbitration failure)
 
-These events exist only in the ENH protocol. Clients receiving ENS-encoded streams will never see adapter reset notifications, which means they cannot detect adapter firmware restarts or bus reinitializations. This is the root cause of the ENH/ENS parity gap documented in the audit (PX51, PX58, WS13, WS23).
+These events exist only in the ENH protocol. Clients receiving streams encoded by the firmware `codec_ens.c` layer will never see adapter reset notifications, which means they cannot detect adapter firmware restarts or bus reinitializations. This limitation does not apply to the `ens:` transport prefix (which uses ENH framing at 115200 baud). This is the root cause of the ENH/ENS parity gap documented in the audit (PX51, PX58, WS13, WS23).

--- a/protocols/ens.md
+++ b/protocols/ens.md
@@ -80,3 +80,12 @@ Both the ENS firmware codec and the eBUS wire protocol use `0xA9`/`0xAA` escape 
 - **ENS firmware escaping** is applied on the serial/USB link between the adapter and the host software. It ensures that `0xA9` and `0xAA` bytes in the data stream do not get misinterpreted as framing symbols by the host.
 
 > **Note:** `codec_ens.c` is a firmware-level codec module. The current PIC16F15356 runtime (`runtime.c`) uses ENH only and does not implement bus TX. ENS escape encoding is available as a codec primitive but is not wired into the active runtime path.
+
+### ENS Control Frame Limitation
+
+The ENS firmware codec (`codec_ens.c`) is a data-only encoding layer. It cannot represent adapter control events:
+- `RESETTED` (adapter reset notification)
+- `STARTED` (arbitration grant)
+- `FAILED` (arbitration failure)
+
+These events exist only in the ENH protocol. Clients receiving ENS-encoded streams will never see adapter reset notifications, which means they cannot detect adapter firmware restarts or bus reinitializations. This is the root cause of the ENH/ENS parity gap documented in the audit (PX51, PX58, WS13, WS23).

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -4,6 +4,8 @@ Some Ethernet eBUS adapters expose the wire-level eBUS byte stream over UDP data
 
 This transport is **not** ENH: there is no `<INIT>`, no `<START>` arbitration request, and no ENH command/data framing. The UDP payload is simply a sequence of bytes as observed on / written to the bus.
 
+> **Important:** UDP-plain is a raw byte transport with NO bus arbitration and NO escape encoding/decoding. Bytes are forwarded as-is between the UDP client and the bus. When multiple UDP clients are active simultaneously, bus collisions are possible with no retry mechanism. UDP-plain is intended for single-client diagnostic use, not multi-client production deployments.
+
 ## Semantics
 
 - **Unit of transfer:** UDP datagrams.

--- a/protocols/vaillant/ebus-vaillant-b555-timer-protocol.md
+++ b/protocols/vaillant/ebus-vaillant-b555-timer-protocol.md
@@ -417,8 +417,8 @@ A6 [ZONE] [HC] [DD] [SI] [SC] [Sh] [Sm] [Eh] [Em] [Tlo] [Thi]
 | 0x00 | ACK — frame accepted by controller | Yes |
 | 0x01 | Parameter out of range | Yes — hour ≥ 0x19 rejected; SC > max_slots rejected (e.g., SC=4 on CC with max_slots=3; SC=12 on DHW with max_slots=3); Heating 0xFFFF rejected (Section 12.14) |
 | 0x03 | Timer type unavailable (status=0x03 in A3 config) | Yes — writes to Cooling/Z3/Silent rejected |
-| 0x04 | Multi-slot write error | Observed once in early testing, not reproducible |
-| 0x05 | Multi-slot write error | Observed once in early testing, not reproducible |
+| 0x04 | Timer write rejected (device-specific) | Observed once in early testing, not reproducible. Exact semantics unconfirmed — falls through to "unknown error" in gateway if not explicitly handled. |
+| 0x05 | Timer write rejected (device-specific variant) | Observed once in early testing, not reproducible. Exact semantics unconfirmed — falls through to "unknown error" in gateway if not explicitly handled. |
 | 0x06 | Validation failure (temperature or parameter) | Yes — triggered by: (1) temperature below min or above max (e.g., 34°C on DHW min=35; 66°C on DHW max=65; boundary values accepted); (2) ZONE=0xFF + full-day (00:00-24:00) + explicit temperature on DHW writes, even when temp is in range (Section 12.13). Semantics broader than "temp out of range". |
 
 **Important:** A response of 0x00 means the controller accepted the frame,


### PR DESCRIPTION
## Summary

Cross-product analysis of the consolidated audit report identified 9 documentation gaps in docs-ebus caused by behavioral fixes in other repositories (ebusgo, adaptermux, proxy, PIC firmware).

| Priority | ID | File | Change |
|----------|-----|------|--------|
| P0 | B14 | `architecture/overview.md` | Mermaid FSM `MasterMaster`/`MasterSlave` → `i2i`/`i2t` |
| P1 | B1 | `ebus-overview.md` | ENH transport caveat: 0xAA is valid data on ENH, not SYN |
| P1 | B2 | `enh.md` | STARTED mismatch abort threshold recommendation |
| P1 | B4 | `ebus-overview.md` | NACK retry semantics (CmdNACK 1x, ResponseNACK 1x, NACK=0xFF) |
| P1 | B5 | `ens.md` | ENS control frame limitation (no RESETTED/STARTED/FAILED) |
| P2 | B3 | `ebus-overview.md` | Escape-aware SYN counting on raw transports |
| P2 | B6 | `udp-plain.md` | No-arbitration, no-escape caveat |
| P2 | B9 | `pic16f15356-overview.md` | Scaffold port 3333 vs standard 9999 |
| P2 | B15 | `b555-timer-protocol.md` | Error codes 0x04/0x05 clarified |

## Source findings

Derived from ebusgo (EG47, EG-NEW-01, EG14, EG28, AM1-AM3), proxy (PX51, PX58, PX8/PX9), PIC firmware (PF32), and B555 gateway error map (DOC-R4-04).

## Test plan

- [x] `scripts/ci_local.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)