### PR TITLE
docs: fix CRC section self-contradiction (R6 NI-01 CRITICAL)

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -55,17 +55,27 @@ This document records the architectural decisions implemented in the codebase. E
 
 **Consequences:** Callers do not set frame type explicitly; it is derived from addressing rules.
 
-## ADR-006: CRC8 is computed over logical (unescaped) bytes
+## ADR-006: CRC8 accepts logical bytes, expands 0xA9/0xAA internally
 
-**Status:** Corrected (2026-04)
+**Status:** Corrected (2026-04, revised R6)
 
-**Context:** eBUS CRC8 must produce consistent checksums regardless of wire-level escape encoding.
+**Context:** eBUS CRC8 must produce consistent checksums. Two bytes (0xA9=ESC, 0xAA=SYN) have special wire-level meaning and require escape expansion.
 
-**Decision:** CRC computation operates on the logical (unescaped) frame bytes. Escape substitution (`0xA9` -> `0xA9 0x00`, `0xAA` -> `0xA9 0x01`) is applied after CRC computation on transmit, and reversed before CRC verification on receive. The CRC byte itself is also subject to escape encoding on the wire.
+**Decision:** The CRC function's **API accepts logical frame bytes**, but internally expands the two special values before feeding them into the CRC8 polynomial (`0x9B`, init `0x00`):
+- Logical `0xA9` → CRC update with `0xA9, 0x00`
+- Logical `0xAA` → CRC update with `0xA9, 0x01`
+- All other bytes → CRC update directly
 
-**Correction note:** The original ADR-006 incorrectly stated that CRC was computed over escaped symbols. All implementations (ebusgo, ebusd, VRC Explorer) compute CRC over logical bytes. The original wording caused confusion and was the root cause of CRC bugs across multiple codebases (VE16, VE25, EG47). See DOC-NEW-04 in the audit findings.
+Wire-level escape encoding for **transmission** is a separate step applied after CRC computation (the CRC byte itself is also subject to wire escaping). On **receive**, wire escaping is reversed before CRC verification.
 
-**Consequences:** CRC validation is independent of wire-level escape encoding. The same logical frame always produces the same CRC regardless of whether any data bytes happen to require escaping.
+**Correction history:**
+- Original ADR-006 incorrectly stated CRC was computed over escaped symbols.
+- PR #262 correction said "CRC over logical bytes before escape substitution" — still misleading because the CRC function does perform internal expansion.
+- R6 verification (NI-01) identified the self-contradiction. This revision describes the actual implementation: API accepts logical bytes, polynomial applied to wire-expanded form.
+
+**Evidence:** ebusgo `protocol.CRC` (protocol.go:51), VRC Explorer `_crc()`, and ebusd all implement identical internal expansion. See DOC-NEW-04, VE16, VE25, EG47.
+
+**Consequences:** `CRC([0x01, 0xAA])` produces `CRC_update(0x01) → CRC_update(0xA9) → CRC_update(0x01)`, NOT `CRC_update(0x01) → CRC_update(0xAA)`. Implementors must replicate this expansion inside their CRC function.
 
 ## ADR-007: Bus owns ACK/response state machine and retry policy
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -140,11 +140,15 @@ For multi-client/proxy setups, Helianthus collision handling uses a receive-vs-t
 
 ### CRC8
 
-CRC8 is computed over the **logical (unescaped) frame bytes**:
+The CRC8 function accepts **logical frame bytes** (the bytes the application layer works with) and internally **expands** the two special values before feeding them into the polynomial:
+
+- Logical `0xA9` (ESC) → CRC update with `0xA9, 0x00`
+- Logical `0xAA` (SYN) → CRC update with `0xA9, 0x01`
+- All other bytes → CRC update directly
 
 - **CRC8 polynomial:** `0x9B` (init `0x00`).
 
-> **Important:** CRC is always computed over the logical frame bytes, **before** escape substitution. The escaped wire representation is never used for CRC calculation. Confusing logical vs wire bytes was the root cause of CRC bugs across multiple codebases (VE16, VE25, EG47). This supersedes the earlier ADR-006 guidance. ADR-006 incorrectly specified CRC over escaped bytes; all implementations (ebusgo, ebusd, VRC Explorer) compute CRC over logical bytes.
+> **Important:** The CRC function's API accepts logical bytes, but the polynomial is applied to the **wire-expanded form**. This means `CRC([0x01, 0xAA])` internally computes `CRC_update(0x01) → CRC_update(0xA9) → CRC_update(0x01)`, NOT `CRC_update(0x01) → CRC_update(0xAA)`. All three Helianthus implementations (ebusgo `protocol.CRC`, VRC Explorer `_crc()`, ebusd) implement this expansion. Omitting the expansion was the root cause of CRC bugs VE16, VE25, and EG47. This supersedes ADR-006.
 
 CRC8 coverage depends on the direct-mode phase:
 


### PR DESCRIPTION
## Summary

R6 post-fix verification identified that the CRC section in `ebus-overview.md` (written in PR #262) is **self-contradictory** and would cause new implementors to reproduce the exact VE16/VE25/EG47 bug class.

**Problem:** "CRC over logical bytes before escape substitution" implies no expansion occurs. But all implementations internally expand `0xA9→(0xA9,0x00)` and `0xAA→(0xA9,0x01)` before CRC polynomial update.

**Fix:** Rewrote CRC section to describe actual behavior — API accepts logical bytes, polynomial applied to wire-expanded form. Added concrete example: `CRC([0x01, 0xAA])` = `CRC_update(0x01)→CRC_update(0xA9)→CRC_update(0x01)`.

Also revised ADR-006 with full 3-stage correction history.

## R6 findings addressed

| ID | Severity | Status |
|----|----------|--------|
| NI-01 | CRITICAL | FIXED |
| NI-02 | LOW | FIXED (subsumed by NI-01 rewrite) |
| NI-03 | LOW | Current content correct (proxy status is MISSING, accurate) |

## Test plan

- [x] `scripts/ci_local.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)