### PR TITLE
docs(enh): align ENS/ENH invariants and shared conformance tests

### DIFF
--- a/architecture/enh-ens-conformance-tests.md
+++ b/architecture/enh-ens-conformance-tests.md
@@ -10,7 +10,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ## Scope: ENH/ENS in This Document
 
-In this document and its referenced invariants, `ENH` and `ENS` refer to the **ebusd transport prefixes** (`enh:` on TCP, `ens:` as a serial-baud alias equivalent to `enh:` on network transports). This is NOT the firmware data-only ENS codec (`codec_ens.c`) described in [ens.md §Disambiguation](ens.md#disambiguation). Conformance tests in this catalog apply to the transport protocol, not to the firmware codec layer.
+In this document and its referenced invariants, `ENH` and `ENS` refer to the **ebusd transport prefixes** (`enh:` on TCP, `ens:` as a serial-baud alias equivalent to `enh:` on network transports). This is NOT the firmware data-only ENS codec (`codec_ens.c`) described in [ens.md §Disambiguation](../protocols/ens.md#disambiguation). Conformance tests in this catalog apply to the transport protocol, not to the firmware codec layer.
 
 ## Timeout Glossary
 
@@ -58,7 +58,7 @@ XR rows below reference these symbols explicitly. Implementations MAY expose the
 
 **Invariant:** An encoded ENH request with an undefined command nibble (defined request nibbles are 0x0-0x3) MUST be rejected by the adapter with an explicit error signal, not silently dropped.
 
-**Falsifiable:** Send encoded `0xD0 0x80` to the adapter as a request. Adapter MUST emit `ERROR_HOST` or `FAILED` (see [enh.md §Unknown Command Contract](enh.md#unknown-command-contract) for variant handling); the host MUST NOT see a generic timeout.
+**Falsifiable:** Send encoded `0xD0 0x80` to the adapter as a request. Adapter MUST emit `ERROR_HOST` or `FAILED` (see [enh.md §Unknown Command Contract](../protocols/enh.md#unknown-command-contract) for variant handling); the host MUST NOT see a generic timeout.
 
 ### XR_ENH_ParserReset_AfterReadTimeout
 
@@ -82,13 +82,9 @@ XR rows below reference these symbols explicitly. Implementations MAY expose the
 
 ### XR_INFO_FrameLength_AndSerialAccess
 
-**Invariant:** The first byte of an INFO response is the payload length `N` (the INFO ID is not echoed — it is known from the request). The host reads exactly `N` data bytes after the length byte. Concurrent INFO requests on the same session MUST use one of the following deterministic policies (no stealing, no undefined behavior):
+**Invariant:** The first byte of an INFO response is the payload length `N` (the INFO ID is not echoed — it is known from the request). The host reads exactly `N` data bytes after the length byte. Per the primary spec ([enh.md §INFO Concurrency](../protocols/enh.md#info-concurrency)), concurrent INFO requests on the same session MUST be either **serialized** (queue the second request until the first completes) or **rejected** (explicit error to the second requester). Evict-old (cancelling the first request to admit a newer one) is NOT conformant — it is a documented deviation and must be flagged as such in the matrix.
 
-- **Serialize**: queue the second request until the first completes.
-- **Reject**: return an explicit error to the second requester.
-- **Evict-old**: cancel the first request with an explicit error to its caller, then start the second. The first requester MUST NOT silently time out — it MUST be notified of the eviction.
-
-**Falsifiable:** (a) Send INFO request for ID 0x00. Verify response starts with length byte, followed by exactly that many data bytes. (b) Issue two INFO requests concurrently. The implementation MUST produce one of the three policies above; the first requester MUST NOT silently receive timeout or corrupted data without an explicit cancellation signal.
+**Falsifiable:** (a) Send INFO request for ID 0x00. Verify response starts with length byte, followed by exactly that many data bytes. (b) Issue two INFO requests concurrently. The implementation MUST either complete the first requester's response (serialize) or return an explicit error to the second (reject). Any implementation that cancels the first request to admit the second fails this invariant.
 
 ## Arbitration
 
@@ -133,19 +129,19 @@ XR rows below reference these symbols explicitly. Implementations MAY expose the
 
 | Test Name | Primary Spec | ebusgo | VRC Explorer | adaptermux | proxy |
 |-----------|-------------|--------|--------------|------------|-------|
-| XR_INIT_TimeoutFailOpen_Bounded | [enh.md §INIT](enh.md#init-timeout-invariant) | ✅ | ❌ deviation (TransportTimeout = fail-closed) | ✅ | ✅ |
-| XR_UpstreamLoss_GracefulShutdown_NoHang | [enh.md §Errors](enh.md#errors) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
-| XR_START_ReconnectWait_BoundedDeadline | [enh.md §START](enh.md#start--started--failed) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
-| XR_ENH_UnknownCommand_ExplicitError_AdapterToHost | [enh.md §Unknown Command](enh.md#unknown-command-contract) | ⚠️ partial (`transport_recovery` subcase expects silent discard) | ⚠️ alias (no same-name test) | — | — |
-| XR_ENH_UnknownCommand_ExplicitError_HostToAdapter | [enh.md §Unknown Command](enh.md#unknown-command-contract) | — | — | — | ✅ |
-| XR_INFO_RESETTED_CachePolicy_Explicit | [enh-info-reference.md](enh-info-reference.md) | ✅ | N/A (no INFO cache) | ⚠️ alias (`XR_INFO_CACHE_SNAPSHOT`) | — |
-| XR_INFO_FrameLength_AndSerialAccess | [enh.md §INFO](enh.md#info-frame-length-and-interleaving) | ✅ (serialize) | — | ⚠️ alias (serialize) | ⚠️ partial (evict-old policy — see invariant) |
-| XR_ENH_ParserReset_AfterReadTimeout | [enh.md §Parser](enh.md#parser-reset-after-read-timeout) | ✅ | ✅ | — | ✅ |
-| XR_ENH_0xAA_DataNotSYN | [ebus-overview.md §SYN](../ebus-services/ebus-overview.md#acknack-symbols) | ✅ | ✅ | — | ✅ |
-| XR_START_RequestStart_WriteAll_NoDoubleSend | [enh.md §START](enh.md#start--started--failed) | ✅ | ✅ | — | ✅ |
-| XR_START_Cancel_ReleasesOwnership | [enh.md §START](enh.md#start--started--failed) | ✅ | — | ⚠️ alias (`XR_BLOCKING_ARB_DEADLINE`) | ✅ |
-| XR_Arbitration_Fairness_NoStarvation | [enh.md §START](enh.md#start--started--failed) | ✅ | — | ⚠️ alias | — |
-| XR_UDP_LeaseTTL_CapRefresh_Bounded | [udp-plain.md §Ownership](udp-plain.md#ownership-lease-ttl) | — | — | — | ✅ |
+| XR_INIT_TimeoutFailOpen_Bounded | [enh.md §INIT](../protocols/enh.md#init-timeout-invariant) | ✅ | ❌ deviation (TransportTimeout = fail-closed) | ✅ | ✅ |
+| XR_UpstreamLoss_GracefulShutdown_NoHang | [enh.md §Errors](../protocols/enh.md#errors) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
+| XR_START_ReconnectWait_BoundedDeadline | [enh.md §START](../protocols/enh.md#start--started--failed) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
+| XR_ENH_UnknownCommand_ExplicitError_AdapterToHost | [enh.md §Unknown Command](../protocols/enh.md#unknown-command-contract) | ⚠️ partial (`transport_recovery` subcase expects silent discard) | ⚠️ alias (no same-name test) | — | — |
+| XR_ENH_UnknownCommand_ExplicitError_HostToAdapter | [enh.md §Unknown Command](../protocols/enh.md#unknown-command-contract) | — | — | — | ✅ |
+| XR_INFO_RESETTED_CachePolicy_Explicit | [enh-info-reference.md](../protocols/enh-info-reference.md) | ✅ | N/A (no INFO cache) | ⚠️ alias (`XR_INFO_CACHE_SNAPSHOT`) | — |
+| XR_INFO_FrameLength_AndSerialAccess | [enh.md §INFO](../protocols/enh.md#info-frame-length-and-interleaving) | ✅ (serialize) | — | ⚠️ alias (serialize) | ❌ deviation (evict-old policy — non-conformant) |
+| XR_ENH_ParserReset_AfterReadTimeout | [enh.md §Parser](../protocols/enh.md#parser-reset-after-read-timeout) | ✅ | ✅ | — | ✅ |
+| XR_ENH_0xAA_DataNotSYN | [ebus-overview.md §SYN](../protocols/ebus-services/ebus-overview.md#acknack-symbols) | ✅ | ✅ | — | ✅ |
+| XR_START_RequestStart_WriteAll_NoDoubleSend | [enh.md §START](../protocols/enh.md#start--started--failed) | ✅ | ✅ | — | ✅ |
+| XR_START_Cancel_ReleasesOwnership | [enh.md §START](../protocols/enh.md#start--started--failed) | ✅ | — | ⚠️ alias (`XR_BLOCKING_ARB_DEADLINE`) | ✅ |
+| XR_Arbitration_Fairness_NoStarvation | [enh.md §START](../protocols/enh.md#start--started--failed) | ✅ | — | ⚠️ alias | — |
+| XR_UDP_LeaseTTL_CapRefresh_Bounded | [udp-plain.md §Ownership](../protocols/udp-plain.md#ownership-lease-ttl) | — | — | — | ✅ |
 
 **Notes:**
 - `XR_ENH_UnknownCommand_ExplicitError_AdapterToHost` was split from a single bidirectional invariant because proxy currently covers only the host→adapter direction. ebusgo's `transport_recovery` subcase expects silent discard on the adapter→host path; this is marked `⚠️ partial` until the live read path returns explicit errors.

--- a/architecture/enh-ens-conformance-tests.md
+++ b/architecture/enh-ens-conformance-tests.md
@@ -68,9 +68,9 @@ XR rows below reference these symbols explicitly. Implementations MAY expose the
 
 ### XR_ENH_0xAA_DataNotSYN
 
-**Invariant:** A logical `0xAA` byte in payload data (inside a RECEIVED frame, register value, or protocol response) is treated as data, not as a SYN/boundary marker.
+**Invariant:** A logical `0xAA` byte in payload data (a register value or protocol payload) is treated as data at the logical layer, not as a SYN/boundary marker. On ENH, the adapter forwards raw wire bytes without decoding escapes — so a logical `0xAA` payload byte arrives over the wire as the escape pair `RECEIVED(0xA9) RECEIVED(0x01)`, which the host-side escape decoder reassembles into logical `0xAA`. A bare `RECEIVED(0xAA)` is always a raw-wire SYN boundary, not a data byte.
 
-**Falsifiable:** Send a RECEIVED frame containing payload byte `0xAA`. Host must deliver the byte as data. Frame boundary detection must not trigger.
+**Falsifiable:** Feed the host's ENH event stream the sequence `RECEIVED(0xA9) RECEIVED(0x01)` inside an active frame's data region. The host's escape decoder MUST emit logical `0xAA` as a data byte in the decoded frame payload, and MUST NOT treat the sequence as a frame boundary or bus-idle marker.
 
 ## INFO and Feature Discovery
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -77,6 +77,10 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 **Escape-aware SYN counting:** On raw bus transports, the escape sequence `0xA9 0x01` represents the data byte 0xAA and must NOT be counted as SYN. Only a standalone, unescaped `0xAA` outside of an active frame's data region indicates bus idle.
 
+**0xAA data vs boundary scoping:** The byte `0xAA` serves as SYN (bus idle marker / frame boundary) ONLY at the raw eBUS wire layer and within raw byte-stream transports. At the logical protocol layer (inside frame payloads, register values, or ENH-decoded data), `0xAA` is a valid data byte with no special meaning. Implementations MUST NOT interpret a logical `0xAA` in payload data as a frame boundary or bus idle signal.
+
+**Invariant name:** `XR_ENH_0xAA_DataNotSYN`
+
 **Early SYN during request collection:** If SYN arrives when only 0 or 1 request bytes have been collected (`requestBytesSeen <= 1`), it indicates a new arbitration cycle rather than a framing error. Implementations should reset collection state and treat the next byte as the start of a new transaction.
 
 ## Transaction Flow (Direct Mode)

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -77,7 +77,9 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 **Escape-aware SYN counting:** On raw bus transports, the escape sequence `0xA9 0x01` represents the data byte 0xAA and must NOT be counted as SYN. Only a standalone, unescaped `0xAA` outside of an active frame's data region indicates bus idle.
 
-**0xAA data vs boundary scoping:** The byte `0xAA` serves as SYN (bus idle marker / frame boundary) ONLY at the raw eBUS wire layer and within raw byte-stream transports. At the logical protocol layer (inside frame payloads, register values, or ENH-decoded data), `0xAA` is a valid data byte with no special meaning. Implementations MUST NOT interpret a logical `0xAA` in payload data as a frame boundary or bus idle signal.
+**0xAA data vs boundary scoping:** The byte `0xAA` serves as SYN (bus idle marker / frame boundary) ONLY at the raw eBUS wire layer and within raw byte-stream transports. At the logical protocol layer (inside frame payloads, register values, or ENH-decoded data), `0xAA` has no wire-boundary or idle meaning — it is a valid data byte. Implementations MUST NOT interpret a logical `0xAA` in payload data as a frame boundary or bus idle signal.
+
+Exception: in ENH `START` requests, a logical `0xAA` in the initiator-address field is a protocol-level cancel sentinel for a running arbitration (see [enh.md §START](../enh.md#start--started--failed)). This is a command-level convention, not a wire-boundary meaning.
 
 **Invariant name:** `XR_ENH_0xAA_DataNotSYN`
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -120,7 +120,7 @@ Key points:
 > - **ResponseNACK**: If the initiator NACKs the target's response, the target retransmits the response once. If the second response also receives NACK, the transaction fails.
 > - The NACK byte is specifically `0xFF`. Any other non-ACK byte indicates a bus error, not a deliberate NACK.
 
-> **Note:** ENH-based adapters abstract physical SYN detection. The host does not observe raw SYN bytes; the adapter handles arbitration internally and signals transaction boundaries via ENH command framing (STARTED, FAILED, etc.).
+> **Note:** ENH-based adapters forward raw wire bytes (including SYN `0xAA`) as `RECEIVED` events — they do NOT abstract SYN detection away from the host (verified against PIC firmware `runtime.c:1835-1841`; see the ENH transport caveat in the SYN handling section above). Arbitration is signalled separately via ENH control frames (`STARTED`, `FAILED`) that are distinct from the `RECEIVED` byte stream, but raw SYN bytes remain visible to the host on the `RECEIVED` channel.
 
 ### Initiator-to-Initiator (i2i) Transactions
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -73,7 +73,7 @@ Broadcast frames do not receive ACK/NACK or responses.
 
 **SYN during active waits:** If a `SYN` (`0xAA`) byte is received while waiting for an `ACK`/`NACK` or a target response, it signals end-of-transaction (timeout). All known implementations (ebusgo, ebusd, VRC Explorer) treat SYN during ACK/response wait as a timeout indicator and abort the current transaction. Ignoring SYN and continuing to wait is incorrect -- it causes the receiver to stall past the end of the transaction.
 
-**ENH transport caveat:** On ENH-based transports, the adapter decodes wire escapes before forwarding to the host. The byte 0xAA is therefore valid data, not necessarily a SYN idle marker. SYN detection and bus-idle timeout are handled internally by the adapter hardware/firmware. The host-side SYN guards described above apply only to raw bus access (serial or direct TCP connection to the adapter).
+**ENH transport caveat:** On ENH-based transports, the adapter forwards raw eBUS wire bytes via `RECEIVED` events **without decoding wire escapes** (verified against PIC firmware `runtime.c:1835-1841`). Therefore `RECEIVED(0xAA)` is always a SYN boundary (raw wire `0xAA` = SYN). A logical data byte `0xAA` arrives as two separate events: `RECEIVED(0xA9)` followed by `RECEIVED(0x01)`, and the host-side escape decoder reassembles them into the logical `0xAA`. Host SYN guards apply to the `RECEIVED` event stream — `RECEIVED(0xAA)` signals bus idle; the escape-expanded `RECEIVED(0xA9) RECEIVED(0x01)` pair does not.
 
 **Escape-aware SYN counting:** On raw bus transports, the escape sequence `0xA9 0x01` represents the data byte 0xAA and must NOT be counted as SYN. Only a standalone, unescaped `0xAA` outside of an active frame's data region indicates bus idle.
 

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -1,0 +1,110 @@
+# ENH/ENS Shared Conformance Test Catalog
+
+<!-- legacy-role-mapping:begin -->
+> Legacy role mapping (for cross-referencing older materials): `master` -> `initiator`, `slave` -> `target`. Helianthus documentation uses `initiator`/`target`.
+<!-- legacy-role-mapping:end -->
+
+This document defines canonical cross-repo (XR) conformance test names for ENH and ENS transport behavior. Each test name is a contract: any implementation claiming ENH/ENS conformance MUST pass these tests or document an explicit deviation.
+
+These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502, ebusgo PRs #131-134, and VRC Explorer PRs #245-250/follow-up.
+
+## INIT and Connection Lifecycle
+
+### XR_INIT_TimeoutFailOpen_Bounded
+
+**Invariant:** If RESETTED is not received within the INIT timeout, the connection proceeds with `init_confirmed=false` and `features=unknown`. The host MUST NOT hang or assume optional features. Fail-closed (abort) is permitted only for explicit adapter errors or transport hard failures.
+
+**Falsifiable:** Mock adapter that never sends RESETTED. Host must complete INIT within timeout and report `init_confirmed=false`.
+
+### XR_UpstreamLoss_GracefulShutdown_NoHang
+
+**Invariant:** If the upstream transport (TCP connection to adapter) is lost during an active session, the host shuts down gracefully within a bounded deadline. No goroutine/thread hangs indefinitely.
+
+**Falsifiable:** Close the TCP connection mid-transaction. All pending operations must return errors within 2x the configured timeout.
+
+### XR_START_ReconnectWait_BoundedDeadline
+
+**Invariant:** If a reconnect is triggered during or after START/arbitration, the reconnect attempt is bounded by a configurable deadline. The host does not retry indefinitely.
+
+**Falsifiable:** Mock adapter that accepts TCP but never responds to INIT. Reconnect must fail within the configured deadline.
+
+## ENH Command Handling
+
+### XR_ENH_UnknownCommand_ExplicitError
+
+**Invariant:** An ENH byte whose high nibble does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
+
+**Falsifiable:** Inject byte `0xB0` (undefined command 0xB) into the ENH stream. Host must emit a transport error, not a timeout.
+
+### XR_ENH_ParserReset_AfterReadTimeout
+
+**Invariant:** A read timeout that interrupts a partially received ENH frame resets the parser state. The next frame is parsed from a clean state.
+
+**Falsifiable:** Send first byte of a two-byte encoded sequence, then delay beyond read timeout. Send a valid RECEIVED frame. Host must decode the RECEIVED frame correctly, not as a continuation of the interrupted sequence.
+
+### XR_ENH_0xAA_DataNotSYN
+
+**Invariant:** A logical `0xAA` byte in payload data (inside a RECEIVED frame, register value, or protocol response) is treated as data, not as a SYN/boundary marker.
+
+**Falsifiable:** Send a RECEIVED frame containing payload byte `0xAA`. Host must deliver the byte as data. Frame boundary detection must not trigger.
+
+## INFO and Feature Discovery
+
+### XR_INFO_RESETTED_CachePolicy_Explicit
+
+**Invariant:** Cached INFO data is invalidated on every RESETTED event. INFO responses received before RESETTED are not used after RESETTED.
+
+**Falsifiable:** Query INFO ID 0x00, receive response, then receive RESETTED. Query INFO ID 0x00 again. Host must re-query the adapter, not return stale cached data.
+
+### XR_INFO_FrameLength_AndSerialAccess
+
+**Invariant:** INFO responses have explicit length (`1 + N` bytes). Concurrent INFO requests on the same session are serialized or rejected; a new request does not steal the response channel.
+
+**Falsifiable:** Issue two INFO requests concurrently. The first requester must receive its complete response; the second must either wait or receive an explicit error.
+
+## Arbitration
+
+### XR_START_RequestStart_WriteAll_NoDoubleSend
+
+**Invariant:** The START request (source address byte) is written exactly once per arbitration attempt. The write is atomic (all bytes in a single write call).
+
+**Falsifiable:** Mock transport that counts write calls during START. Exactly one write call must occur per START attempt.
+
+### XR_START_Cancel_ReleasesOwnership
+
+**Invariant:** If the host cancels an in-progress arbitration (e.g., context cancelled), bus ownership is released cleanly. No pending STARTED response is left unhandled.
+
+**Falsifiable:** Start arbitration, cancel context before STARTED arrives, then start a new arbitration. The new arbitration must succeed without stale STARTED interference.
+
+### XR_Arbitration_Fairness_NoStarvation
+
+**Invariant:** Under contention (multiple pending bus requests), no single request is starved indefinitely. A fairness mechanism (e.g., priority queue, round-robin, or bounded retry) ensures all requests eventually get bus access.
+
+**Falsifiable:** Queue 10 requests with equal priority. Mock adapter grants STARTED to each in turn. All 10 must complete within `10 x single_request_timeout`.
+
+## UDP-PLAIN
+
+### XR_UDP_LeaseTTL_CapRefresh_Bounded
+
+**Invariant:** Bus ownership acquired via UDP-PLAIN is bounded by a maximum TTL. If idle SYN is not observed within the TTL after STARTED, ownership is released unconditionally. Non-SYN traffic does not refresh the lease.
+
+**Falsifiable:** Mock adapter sends STARTED then only RECEIVED frames (no SYN). Ownership must be released after TTL expires.
+
+---
+
+## Cross-Reference
+
+| Test Name | Primary Spec | Implementing Repos |
+|-----------|-------------|-------------------|
+| XR_INIT_TimeoutFailOpen_Bounded | enh.md INIT | ebusgo, VRC Explorer, proxy, adaptermux |
+| XR_UpstreamLoss_GracefulShutdown_NoHang | enh.md Errors | ebusgo, VRC Explorer, proxy |
+| XR_START_ReconnectWait_BoundedDeadline | enh.md START | ebusgo, VRC Explorer, proxy |
+| XR_ENH_UnknownCommand_ExplicitError | enh.md Errors | ebusgo, VRC Explorer, proxy |
+| XR_INFO_RESETTED_CachePolicy_Explicit | enh-info-reference.md | ebusgo, adaptermux |
+| XR_INFO_FrameLength_AndSerialAccess | enh.md INFO | ebusgo, adaptermux, proxy |
+| XR_ENH_ParserReset_AfterReadTimeout | enh.md Parser | ebusgo, VRC Explorer |
+| XR_ENH_0xAA_DataNotSYN | ebus-overview.md SYN | ebusgo, VRC Explorer, proxy |
+| XR_START_RequestStart_WriteAll_NoDoubleSend | enh.md START | ebusgo, VRC Explorer |
+| XR_START_Cancel_ReleasesOwnership | enh.md START | ebusgo, adaptermux |
+| XR_Arbitration_Fairness_NoStarvation | enh.md START | ebusgo, adaptermux |
+| XR_UDP_LeaseTTL_CapRefresh_Bounded | udp-plain.md Ownership | proxy |

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -8,6 +8,24 @@ This document defines canonical cross-repo (XR) conformance test names for ENH a
 
 These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502, ebusgo PRs #131-134, and VRC Explorer PRs #245-250/follow-up.
 
+## Scope: ENH/ENS in This Document
+
+In this document and its referenced invariants, `ENH` and `ENS` refer to the **ebusd transport prefixes** (`enh:` on TCP, `ens:` as a serial-baud alias equivalent to `enh:` on network transports). This is NOT the firmware data-only ENS codec (`codec_ens.c`) described in [ens.md §Disambiguation](ens.md#disambiguation). Conformance tests in this catalog apply to the transport protocol, not to the firmware codec layer.
+
+## Timeout Glossary
+
+The invariants below reference several distinct timeouts. All implementations MUST map their internal clocks to these canonical names:
+
+| Symbol | Definition | Start | Stop | Default |
+|--------|-----------|-------|------|---------|
+| `T_init` | **INIT timeout** | `INIT` request sent | `RESETTED` received OR timeout | 500 ms |
+| `T_read` | **Read timeout** (per-frame) | First byte of a frame received | Frame complete OR timeout | 200 ms |
+| `T_request` | **Request timeout** (end-to-end) | Host issues request | Final response OR error OR timeout | 2000 ms |
+| `T_reconnect` | **Reconnect deadline** | Reconnect initiated | Connection re-established OR timeout | 5000 ms |
+| `T_inactivity` | **Inactivity timeout** (idle lease) | Last SYN observed | Next SYN OR lease expiry | 5000 ms |
+
+XR rows below reference these symbols explicitly. Implementations MAY expose these as configurable, but MUST NOT silently extend them on incidental traffic.
+
 ## INIT and Connection Lifecycle
 
 ### XR_INIT_TimeoutFailOpen_Bounded
@@ -30,11 +48,17 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ## ENH Command Handling
 
-### XR_ENH_UnknownCommand_ExplicitError
+### XR_ENH_UnknownCommand_ExplicitError_AdapterToHost
 
-**Invariant:** An encoded ENH command sequence whose command nibble (carried in `byte1` bits 5..2) does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
+**Invariant:** An encoded ENH response with an undefined command nibble (carried in `byte1` bits 5..2; defined response nibbles are 0x0-0x3, 0xA-0xC) is reported by the host as an explicit protocol error, not as a timeout or collision.
 
-**Falsifiable:** Inject an encoded ENH command sequence with an undefined command nibble into the adapter→host stream. For response nibble 0x4 (undefined — defined response nibbles are 0x0-0x3, 0xA-0xC), the encoded bytes are `0xD0 0x80` (byte1=`11_0100_00`, byte2=`10_000000`, command=0x4, data=0x00). Raw bytes `< 0x80` are short-form data, not commands, and would not exercise this path. Host must emit a transport error, not a timeout. For host→adapter direction, inject encoded request nibble 0x4 (undefined — defined request nibbles are 0x0-0x3): bytes `0xD0 0x80`. Adapter should emit `ERROR_HOST`.
+**Falsifiable:** Inject `0xD0 0x80` (byte1=`11_0100_00`, byte2=`10_000000`, command nibble 0x4, data=0x00) into the adapter→host stream. Host MUST emit a transport error (e.g., `ErrUnknownENHCommand`), not a timeout.
+
+### XR_ENH_UnknownCommand_ExplicitError_HostToAdapter
+
+**Invariant:** An encoded ENH request with an undefined command nibble (defined request nibbles are 0x0-0x3) MUST be rejected by the adapter with an explicit error signal, not silently dropped.
+
+**Falsifiable:** Send encoded `0xD0 0x80` to the adapter as a request. Adapter MUST emit `ERROR_HOST` or `FAILED` (see [enh.md §Unknown Command Contract](enh.md#unknown-command-contract) for variant handling); the host MUST NOT see a generic timeout.
 
 ### XR_ENH_ParserReset_AfterReadTimeout
 
@@ -58,9 +82,13 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_INFO_FrameLength_AndSerialAccess
 
-**Invariant:** The first byte of an INFO response is the payload length `N` (the INFO ID is not echoed — it is known from the request). The host reads exactly `N` data bytes after the length byte. Concurrent INFO requests on the same session are serialized or rejected; a new request does not steal the response channel.
+**Invariant:** The first byte of an INFO response is the payload length `N` (the INFO ID is not echoed — it is known from the request). The host reads exactly `N` data bytes after the length byte. Concurrent INFO requests on the same session MUST use one of the following deterministic policies (no stealing, no undefined behavior):
 
-**Falsifiable:** (a) Send INFO request for ID 0x00. Verify response starts with length byte, followed by exactly that many data bytes. (b) Issue two INFO requests concurrently. The first requester must receive its complete response; the second must either wait or receive an explicit error.
+- **Serialize**: queue the second request until the first completes.
+- **Reject**: return an explicit error to the second requester.
+- **Evict-old**: cancel the first request with an explicit error to its caller, then start the second. The first requester MUST NOT silently time out — it MUST be notified of the eviction.
+
+**Falsifiable:** (a) Send INFO request for ID 0x00. Verify response starts with length byte, followed by exactly that many data bytes. (b) Issue two INFO requests concurrently. The implementation MUST produce one of the three policies above; the first requester MUST NOT silently receive timeout or corrupted data without an explicit cancellation signal.
 
 ## Arbitration
 
@@ -90,21 +118,36 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 **Falsifiable:** Mock UDP-PLAIN adapter echoes the arbitration byte to indicate ownership, then produces only raw bytes other than `0xAA` (no idle SYN). Ownership must be released after TTL expires.
 
+**Scope note:** This invariant ID is strictly for **ownership lease TTL** behavior. Any separate tests that validate UDP client-connection admission caps, concurrent-session limits, or socket accept throttling MUST use a different ID (e.g., `XR_UDP_ClientAdmission_Cap`). Do not overload this ID.
+
 ---
 
 ## Cross-Reference
 
-| Test Name | Primary Spec | Implementing Repos |
-|-----------|-------------|-------------------|
-| XR_INIT_TimeoutFailOpen_Bounded | [enh.md §INIT](enh.md#init-timeout-invariant) | ebusgo, proxy, adaptermux; VRC Explorer: **deviation** (TransportTimeout = fail-closed on missing RESETTED) |
-| XR_UpstreamLoss_GracefulShutdown_NoHang | [enh.md §Errors](enh.md#errors) | ebusgo, VRC Explorer, proxy |
-| XR_START_ReconnectWait_BoundedDeadline | [enh.md §START](enh.md#start--started--failed) | ebusgo, VRC Explorer, proxy |
-| XR_ENH_UnknownCommand_ExplicitError | [enh.md §Unknown Command](enh.md#unknown-command-contract) | ebusgo, VRC Explorer, proxy |
-| XR_INFO_RESETTED_CachePolicy_Explicit | [enh-info-reference.md](enh-info-reference.md) | ebusgo, adaptermux |
-| XR_INFO_FrameLength_AndSerialAccess | [enh.md §INFO](enh.md#info-frame-length-and-interleaving) | ebusgo, adaptermux, proxy |
-| XR_ENH_ParserReset_AfterReadTimeout | [enh.md §Parser](enh.md#parser-reset-after-read-timeout) | ebusgo, VRC Explorer |
-| XR_ENH_0xAA_DataNotSYN | [ebus-overview.md §SYN](../ebus-services/ebus-overview.md#acknack-symbols) | ebusgo, VRC Explorer, proxy |
-| XR_START_RequestStart_WriteAll_NoDoubleSend | [enh.md §START](enh.md#start--started--failed) | ebusgo, VRC Explorer |
-| XR_START_Cancel_ReleasesOwnership | [enh.md §START](enh.md#start--started--failed) | ebusgo, adaptermux, proxy |
-| XR_Arbitration_Fairness_NoStarvation | [enh.md §START](enh.md#start--started--failed) | ebusgo, adaptermux |
-| XR_UDP_LeaseTTL_CapRefresh_Bounded | [udp-plain.md §Ownership](udp-plain.md#ownership-lease-ttl) | proxy |
+**Status legend:**
+- `✅` — canonical same-name test exists and passes.
+- `⚠️ partial` — test exists but has a documented subcase that deviates (see notes).
+- `⚠️ alias` — implementation has an equivalent test under a different (local) name; same-name alias pending.
+- `❌ deviation` — implementation behavior deviates from the invariant; documented here.
+- `—` — not implemented (no equivalent test).
+
+| Test Name | Primary Spec | ebusgo | VRC Explorer | adaptermux | proxy |
+|-----------|-------------|--------|--------------|------------|-------|
+| XR_INIT_TimeoutFailOpen_Bounded | [enh.md §INIT](enh.md#init-timeout-invariant) | ✅ | ❌ deviation (TransportTimeout = fail-closed) | ✅ | ✅ |
+| XR_UpstreamLoss_GracefulShutdown_NoHang | [enh.md §Errors](enh.md#errors) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
+| XR_START_ReconnectWait_BoundedDeadline | [enh.md §START](enh.md#start--started--failed) | ✅ | ⚠️ alias (no same-name test) | — | ✅ |
+| XR_ENH_UnknownCommand_ExplicitError_AdapterToHost | [enh.md §Unknown Command](enh.md#unknown-command-contract) | ⚠️ partial (`transport_recovery` subcase expects silent discard) | ⚠️ alias (no same-name test) | — | — |
+| XR_ENH_UnknownCommand_ExplicitError_HostToAdapter | [enh.md §Unknown Command](enh.md#unknown-command-contract) | — | — | — | ✅ |
+| XR_INFO_RESETTED_CachePolicy_Explicit | [enh-info-reference.md](enh-info-reference.md) | ✅ | N/A (no INFO cache) | ⚠️ alias (`XR_INFO_CACHE_SNAPSHOT`) | — |
+| XR_INFO_FrameLength_AndSerialAccess | [enh.md §INFO](enh.md#info-frame-length-and-interleaving) | ✅ (serialize) | — | ⚠️ alias (serialize) | ⚠️ partial (evict-old policy — see invariant) |
+| XR_ENH_ParserReset_AfterReadTimeout | [enh.md §Parser](enh.md#parser-reset-after-read-timeout) | ✅ | ✅ | — | ✅ |
+| XR_ENH_0xAA_DataNotSYN | [ebus-overview.md §SYN](../ebus-services/ebus-overview.md#acknack-symbols) | ✅ | ✅ | — | ✅ |
+| XR_START_RequestStart_WriteAll_NoDoubleSend | [enh.md §START](enh.md#start--started--failed) | ✅ | ✅ | — | ✅ |
+| XR_START_Cancel_ReleasesOwnership | [enh.md §START](enh.md#start--started--failed) | ✅ | — | ⚠️ alias (`XR_BLOCKING_ARB_DEADLINE`) | ✅ |
+| XR_Arbitration_Fairness_NoStarvation | [enh.md §START](enh.md#start--started--failed) | ✅ | — | ⚠️ alias | — |
+| XR_UDP_LeaseTTL_CapRefresh_Bounded | [udp-plain.md §Ownership](udp-plain.md#ownership-lease-ttl) | — | — | — | ✅ |
+
+**Notes:**
+- `XR_ENH_UnknownCommand_ExplicitError_AdapterToHost` was split from a single bidirectional invariant because proxy currently covers only the host→adapter direction. ebusgo's `transport_recovery` subcase expects silent discard on the adapter→host path; this is marked `⚠️ partial` until the live read path returns explicit errors.
+- `⚠️ alias` entries indicate that the implementation has an equivalent test (same protocol behavior) under a local ID. Canonical same-name aliases are pending in those repos.
+- `N/A` entries are documented exemptions (e.g., VRC Explorer has no INFO cache, so the cache-invalidation invariant does not apply).

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -66,9 +66,9 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_START_RequestStart_WriteAll_NoDoubleSend
 
-**Invariant:** The START request (source address byte) is written exactly once per arbitration attempt. The write is atomic (all bytes in a single write call).
+**Invariant:** The START request (source address byte) is sent exactly once per arbitration attempt on the wire. The host MUST NOT send duplicate START frames for the same arbitration attempt (double-send causes the adapter to see two arbitration requests).
 
-**Falsifiable:** Mock transport that counts write calls during START. Exactly one write call must occur per START attempt.
+**Falsifiable:** Mock transport that captures all bytes written during START. The encoded START command sequence and source address byte must appear exactly once in the captured wire bytes per arbitration attempt.
 
 ### XR_START_Cancel_ReleasesOwnership
 

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -52,7 +52,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_INFO_RESETTED_CachePolicy_Explicit
 
-**Invariant:** Cached INFO data is invalidated on every RESETTED event. INFO responses received before RESETTED are not used after RESETTED.
+**Invariant:** Cached INFO data is invalidated on every RESETTED event. INFO responses received before RESETTED are not used after RESETTED. This invariant applies only to implementations that cache INFO responses across requests (ebusgo, adaptermux). Stateless implementations that issue single-request INFO without caching (e.g., VRC Explorer) are exempt.
 
 **Falsifiable:** Query INFO ID 0x00, receive response, then receive RESETTED. Query INFO ID 0x00 again. Host must re-query the adapter, not return stale cached data.
 
@@ -96,15 +96,15 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 | Test Name | Primary Spec | Implementing Repos |
 |-----------|-------------|-------------------|
-| XR_INIT_TimeoutFailOpen_Bounded | enh.md INIT | ebusgo, proxy, adaptermux; VRC Explorer: **deviation** (TransportTimeout = fail-closed on missing RESETTED) |
-| XR_UpstreamLoss_GracefulShutdown_NoHang | enh.md Errors | ebusgo, VRC Explorer, proxy |
-| XR_START_ReconnectWait_BoundedDeadline | enh.md START | ebusgo, VRC Explorer, proxy |
-| XR_ENH_UnknownCommand_ExplicitError | enh.md Errors | ebusgo, VRC Explorer, proxy |
-| XR_INFO_RESETTED_CachePolicy_Explicit | enh-info-reference.md | ebusgo, adaptermux |
-| XR_INFO_FrameLength_AndSerialAccess | enh.md INFO | ebusgo, adaptermux, proxy |
-| XR_ENH_ParserReset_AfterReadTimeout | enh.md Parser | ebusgo, VRC Explorer |
-| XR_ENH_0xAA_DataNotSYN | ebus-overview.md SYN | ebusgo, VRC Explorer, proxy |
-| XR_START_RequestStart_WriteAll_NoDoubleSend | enh.md START | ebusgo, VRC Explorer |
-| XR_START_Cancel_ReleasesOwnership | enh.md START | ebusgo, adaptermux |
-| XR_Arbitration_Fairness_NoStarvation | enh.md START | ebusgo, adaptermux |
-| XR_UDP_LeaseTTL_CapRefresh_Bounded | udp-plain.md Ownership | proxy |
+| XR_INIT_TimeoutFailOpen_Bounded | [enh.md §INIT](enh.md#init-timeout-invariant) | ebusgo, proxy, adaptermux; VRC Explorer: **deviation** (TransportTimeout = fail-closed on missing RESETTED) |
+| XR_UpstreamLoss_GracefulShutdown_NoHang | [enh.md §Errors](enh.md#errors) | ebusgo, VRC Explorer, proxy |
+| XR_START_ReconnectWait_BoundedDeadline | [enh.md §START](enh.md#start--started--failed) | ebusgo, VRC Explorer, proxy |
+| XR_ENH_UnknownCommand_ExplicitError | [enh.md §Unknown Command](enh.md#unknown-command-contract) | ebusgo, VRC Explorer, proxy |
+| XR_INFO_RESETTED_CachePolicy_Explicit | [enh-info-reference.md](enh-info-reference.md) | ebusgo, adaptermux |
+| XR_INFO_FrameLength_AndSerialAccess | [enh.md §INFO](enh.md#info-frame-length-and-interleaving) | ebusgo, adaptermux, proxy |
+| XR_ENH_ParserReset_AfterReadTimeout | [enh.md §Parser](enh.md#parser-reset-after-read-timeout) | ebusgo, VRC Explorer |
+| XR_ENH_0xAA_DataNotSYN | [ebus-overview.md §SYN](../ebus-services/ebus-overview.md#acknack-symbols) | ebusgo, VRC Explorer, proxy |
+| XR_START_RequestStart_WriteAll_NoDoubleSend | [enh.md §START](enh.md#start--started--failed) | ebusgo, VRC Explorer |
+| XR_START_Cancel_ReleasesOwnership | [enh.md §START](enh.md#start--started--failed) | ebusgo, adaptermux, proxy |
+| XR_Arbitration_Fairness_NoStarvation | [enh.md §START](enh.md#start--started--failed) | ebusgo, adaptermux |
+| XR_UDP_LeaseTTL_CapRefresh_Bounded | [udp-plain.md §Ownership](udp-plain.md#ownership-lease-ttl) | proxy |

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -34,7 +34,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 **Invariant:** An ENH byte whose high nibble does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
 
-**Falsifiable:** Inject byte `0xB0` (undefined command 0xB) into the ENH stream. Host must emit a transport error, not a timeout.
+**Falsifiable:** Inject byte `0x40` (response nibble 0x4, undefined in ENH response space — defined response nibbles are 0x0-0x3, 0xA-0xC) into the adapter→host stream. Host must emit a transport error, not a timeout. For host→adapter direction, inject request nibble `0x50` (defined request nibbles are 0x0-0x3). Adapter should emit `ERROR_HOST`.
 
 ### XR_ENH_ParserReset_AfterReadTimeout
 
@@ -58,9 +58,9 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_INFO_FrameLength_AndSerialAccess
 
-**Invariant:** INFO responses have explicit length (`1 + N` bytes). Concurrent INFO requests on the same session are serialized or rejected; a new request does not steal the response channel.
+**Invariant:** The first byte of an INFO response is the payload length `N` (the INFO ID is not echoed — it is known from the request). The host reads exactly `N` data bytes after the length byte. Concurrent INFO requests on the same session are serialized or rejected; a new request does not steal the response channel.
 
-**Falsifiable:** Issue two INFO requests concurrently. The first requester must receive its complete response; the second must either wait or receive an explicit error.
+**Falsifiable:** (a) Send INFO request for ID 0x00. Verify response starts with length byte, followed by exactly that many data bytes. (b) Issue two INFO requests concurrently. The first requester must receive its complete response; the second must either wait or receive an explicit error.
 
 ## Arbitration
 
@@ -96,7 +96,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 | Test Name | Primary Spec | Implementing Repos |
 |-----------|-------------|-------------------|
-| XR_INIT_TimeoutFailOpen_Bounded | enh.md INIT | ebusgo, VRC Explorer, proxy, adaptermux |
+| XR_INIT_TimeoutFailOpen_Bounded | enh.md INIT | ebusgo, proxy, adaptermux; VRC Explorer: **deviation** (TransportTimeout = fail-closed on missing RESETTED) |
 | XR_UpstreamLoss_GracefulShutdown_NoHang | enh.md Errors | ebusgo, VRC Explorer, proxy |
 | XR_START_ReconnectWait_BoundedDeadline | enh.md START | ebusgo, VRC Explorer, proxy |
 | XR_ENH_UnknownCommand_ExplicitError | enh.md Errors | ebusgo, VRC Explorer, proxy |

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -32,7 +32,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_ENH_UnknownCommand_ExplicitError
 
-**Invariant:** An ENH byte whose high nibble does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
+**Invariant:** An encoded ENH command sequence whose command nibble (carried in `byte1` bits 5..2) does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
 
 **Falsifiable:** Inject an encoded ENH command sequence with an undefined command nibble into the adapter→host stream. For response nibble 0x4 (undefined — defined response nibbles are 0x0-0x3, 0xA-0xC), the encoded bytes are `0xD0 0x80` (byte1=`11_0100_00`, byte2=`10_000000`, command=0x4, data=0x00). Raw bytes `< 0x80` are short-form data, not commands, and would not exercise this path. Host must emit a transport error, not a timeout. For host→adapter direction, inject encoded request nibble 0x4 (undefined — defined request nibbles are 0x0-0x3): bytes `0xD0 0x80`. Adapter should emit `ERROR_HOST`.
 
@@ -86,9 +86,9 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 ### XR_UDP_LeaseTTL_CapRefresh_Bounded
 
-**Invariant:** Bus ownership acquired via UDP-PLAIN is bounded by a maximum TTL. If idle SYN is not observed within the TTL after STARTED, ownership is released unconditionally. Non-SYN traffic does not refresh the lease.
+**Invariant:** Bus ownership acquired via UDP-PLAIN is bounded by a maximum TTL. Once the adapter echoes the arbitration byte to indicate the bus win, ownership is released unconditionally if no idle SYN (`0xAA`) is observed within the TTL. Non-SYN raw traffic does not refresh the lease. If a proxy surfaces `STARTED`/`RECEIVED` northbound, those are derived proxy events rather than UDP-PLAIN adapter messages.
 
-**Falsifiable:** Mock adapter sends STARTED then only RECEIVED frames (no SYN). Ownership must be released after TTL expires.
+**Falsifiable:** Mock UDP-PLAIN adapter echoes the arbitration byte to indicate ownership, then produces only raw bytes other than `0xAA` (no idle SYN). Ownership must be released after TTL expires.
 
 ---
 

--- a/protocols/enh-ens-conformance-tests.md
+++ b/protocols/enh-ens-conformance-tests.md
@@ -34,7 +34,7 @@ These tests are the **doc-gate** for aligning proxy PR #101, adaptermux PR #502,
 
 **Invariant:** An ENH byte whose high nibble does not match any defined command ID is reported as an explicit protocol error, not as a timeout or collision.
 
-**Falsifiable:** Inject byte `0x40` (response nibble 0x4, undefined in ENH response space — defined response nibbles are 0x0-0x3, 0xA-0xC) into the adapter→host stream. Host must emit a transport error, not a timeout. For host→adapter direction, inject request nibble `0x50` (defined request nibbles are 0x0-0x3). Adapter should emit `ERROR_HOST`.
+**Falsifiable:** Inject an encoded ENH command sequence with an undefined command nibble into the adapter→host stream. For response nibble 0x4 (undefined — defined response nibbles are 0x0-0x3, 0xA-0xC), the encoded bytes are `0xD0 0x80` (byte1=`11_0100_00`, byte2=`10_000000`, command=0x4, data=0x00). Raw bytes `< 0x80` are short-form data, not commands, and would not exercise this path. Host must emit a transport error, not a timeout. For host→adapter direction, inject encoded request nibble 0x4 (undefined — defined request nibbles are 0x0-0x3): bytes `0xD0 0x80`. Adapter should emit `ERROR_HOST`.
 
 ### XR_ENH_ParserReset_AfterReadTimeout
 

--- a/protocols/enh-info-reference.md
+++ b/protocols/enh-info-reference.md
@@ -15,7 +15,7 @@ Response:  <INFO(0x3)> <length_N>          (first frame)
 ```
 
 `length_N` excludes itself. An empty response has `length_N = 0` with no data
-frames. A new request terminates any in-progress transfer immediately.
+frames. Overlapping INFO requests on the same session MUST be serialized or rejected (see [enh.md §INFO Concurrency](enh.md#info-concurrency)). A new INFO request MUST NOT be sent while a previous response is still streaming.
 
 ## Capability gating
 

--- a/protocols/enh-info-reference.md
+++ b/protocols/enh-info-reference.md
@@ -15,7 +15,7 @@ Response:  <INFO(0x3)> <length_N>          (first frame)
 ```
 
 `length_N` excludes itself. An empty response has `length_N = 0` with no data
-frames. Overlapping INFO requests on the same session MUST be serialized or rejected (see [enh.md §INFO Concurrency](enh.md#info-concurrency)). A new INFO request MUST NOT be sent while a previous response is still streaming.
+frames. Overlapping INFO requests on the same session MUST be serialized or rejected (see [enh.md §INFO Concurrency](enh.md#info-concurrency)). For portable behavior, a new INFO request SHOULD NOT be sent while a previous response is still streaming.
 
 ## Capability gating
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -111,7 +111,9 @@ This invariant ensures that an adapter which does not implement RESETTED (e.g., 
 
 For `data < 0x80`, the short-form (unframed) byte is also allowed.
 
-> **Escape responsibility:** The adapter is responsible for eBUS wire escape encoding (`0xA9` substitution) on SEND data. The host provides logical frame bytes without escape encoding. The adapter applies escape substitution before placing bytes on the bus.
+> **Escape responsibility (SEND / TX path only):** The adapter is responsible for eBUS wire escape **encoding** (`0xA9` substitution) on `SEND` data: the host provides logical frame bytes without escape encoding, and the adapter applies escape substitution before placing bytes on the bus.
+>
+> **Receive path (RX) is different:** The adapter does NOT decode wire escapes on the receive path. Raw eBUS wire bytes are forwarded to the host as `RECEIVED` events without transformation (verified against PIC firmware `runtime.c:1835-1841`). The host-side escape decoder reassembles `RECEIVED(0xA9) RECEIVED(0x00)` into logical `0xA9` and `RECEIVED(0xA9) RECEIVED(0x01)` into logical `0xAA`. `RECEIVED(0xAA)` is always a raw-wire SYN boundary, not a data byte.
 
 ## START / STARTED / FAILED
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -185,7 +185,7 @@ INFO response framing: the first INFO response byte is the payload length `N`, f
 - A `RESETTED` frame arriving during an INFO exchange terminates the INFO exchange. The cached INFO data from before the reset is invalidated.
 - Stale INFO frames (from a previous session or before a RESETTED) MUST be discarded. The INFO cache MUST be invalidated on every RESETTED event.
 
-There is no explicit cancellation frame for INFO streaming. If a non-INFO command arrives during INFO delivery, the INFO stream is implicitly terminated.
+There is no explicit cancellation frame for INFO streaming. `RECEIVED` frames are an explicit exception to termination (per the interleaving rules above) — they represent asynchronous bus traffic and are buffered/dispatched separately without affecting the INFO exchange. Any other non-INFO control frame (e.g., `STARTED`, `FAILED`, `ERROR_EBUS`, `ERROR_HOST`) that arrives during INFO delivery implicitly terminates the INFO stream. `RESETTED` always terminates per the rules above.
 
 Common `info_id` values include:
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -90,6 +90,17 @@ Feature bits:
 
 Practical note: some adapters may start streaming bus bytes before emitting `RESETTED`. A robust client treats `INIT` as best-effort and proceeds once it sees either a valid `RESETTED` or valid bus traffic within a short timeout window.
 
+### INIT Timeout Invariant
+
+The INIT exchange follows a **fail-open bounded** model:
+
+- If `RESETTED` is received within the timeout: `init_confirmed = true`, `features = <RESETTED.features>`.
+- If `RESETTED` is **not** received before timeout: `init_confirmed = false`, `features = unknown` (no optional features may be assumed).
+- Implementations MUST NOT claim INFO support solely because they requested INFO. Feature availability is determined exclusively by a confirmed RESETTED response.
+- **Fail-closed** (abort connection) is permitted ONLY for explicit adapter errors (`ERROR_HOST`) or transport hard failures (TCP RST, socket EOF).
+
+This invariant ensures that an adapter which does not implement RESETTED (e.g., older firmware) does not cause the host to hang or assume capabilities that do not exist.
+
 ## SEND
 
 `SEND` requests transmission of a single byte onto the eBUS:
@@ -133,6 +144,17 @@ In ebusd “direct” mode, the initiator address byte is emitted as part of arb
 
 Implementations that use a stateful parser for ENH framing (e.g., two-byte command decoding) **must reset parser state** after arbitration completes (STARTED or FAILED). TCP fragmentation can deliver extra bytes alongside the arbitration response, leaving the parser with a partially-decoded frame. Without a reset, the stale parser state corrupts subsequent echo matching. See ebusgo#113, adapter-proxy#78.
 
+### Parser Reset After Read Timeout
+
+Any read timeout that interrupts a partially received ENH frame MUST trigger a parser reset before the next frame is processed. Without this reset, the parser may interpret the first byte of the next frame as a continuation of the interrupted frame, causing cascading decode errors.
+
+The reset clears:
+- Pending byte1 (the first byte of a two-byte encoded sequence)
+- Any accumulated multi-byte response buffer
+- The current command context
+
+**Invariant name:** `XR_ENH_ParserReset_AfterReadTimeout`
+
 ## INFO
 
 `INFO` requests additional adapter metadata:
@@ -143,7 +165,25 @@ Implementations that use a stateful parser for ENH framing (e.g., two-byte comma
 
 The response is a stream of `<INFO> <data>` bytes where the **first** byte is a length `N` (excluding the length byte itself), followed by `N` data bytes.
 
-Sending a new `INFO` request while a previous response is still streaming has implementation-defined behavior. Known variants: (1) immediately terminate the previous transfer and start the new one (ebusd reference), (2) queue the new request until the previous transfer completes, (3) ignore the new request until the previous transfer finishes. Consumers should avoid overlapping INFO requests for portable behavior.
+### INFO Concurrency
+
+A new INFO request on the same transport/session while a previous INFO response is still streaming MUST be handled deterministically:
+
+1. **Serialize**: Queue the new request until the current INFO response completes, OR
+2. **Reject**: Return an explicit error to the caller of the new request.
+
+An implementation MUST NOT allow a new INFO request to "steal" the response channel from an in-progress request. The previous requester would then receive a timeout or corrupted data.
+
+Portable behavior: no overlapping INFO requests on the same transport/session.
+
+### INFO Frame Length and Interleaving
+
+INFO response frames have explicit length: `1 + N` bytes where byte 0 is the INFO ID and bytes 1..N are the payload. The payload length is determined by the INFO ID (see `enh-info-reference.md`).
+
+**Interleaving rules:**
+- Bus traffic (`RECEIVED` frames) MAY arrive between INFO request and response. These MUST be buffered or dispatched separately; they do not terminate the INFO exchange.
+- A `RESETTED` frame arriving during an INFO exchange terminates the INFO exchange. The cached INFO data from before the reset is invalidated.
+- Stale INFO frames (from a previous session or before a RESETTED) MUST be discarded. The INFO cache MUST be invalidated on every RESETTED event.
 
 There is no explicit cancellation frame for INFO streaming. If a non-INFO command arrives during INFO delivery, the INFO stream is implicitly terminated.
 
@@ -164,6 +204,16 @@ When the destination address is an initiator-capable address (both high and low 
 
 In ENH transport terms, after the target sends ACK (0x00) for an i2i frame, the host should proceed directly to end-of-message (SYN). The wire_phase FSM enters TransactionDone after ACK, not WaitResponseLen. Waiting for a response length byte on an i2i transaction would hang indefinitely.
 
+### Unknown Command Contract
+
+An ENH command byte whose high nibble does not match any defined command ID (host: INIT=0x0, SEND=0x1, START=0x2, INFO=0x3; adapter: RESETTED=0x0, RECEIVED=0x1, STARTED=0x2, INFO=0x3, FAILED=0xA, ERROR_EBUS=0xB, ERROR_HOST=0xC) MUST be mapped to an explicit protocol error.
+
+Implementations MUST NOT:
+- Report an unknown command as a timeout or collision.
+- Silently discard the byte and continue parsing (this corrupts the subsequent frame boundary).
+
+The host SHOULD emit a transport-level error (e.g., `ErrUnknownENHCommand`) and reset the parser state. The adapter SHOULD emit `ERROR_HOST(4)` for unrecognized host commands.
+
 ## Errors
 
 The adapter can report:
@@ -179,3 +229,7 @@ SEND data byte `0x5A` (encoded form):
 byte1 = 0xC0 | (0x1 << 2) | (0x5A >> 6) = 0xC5
 byte2 = 0x80 | (0x5A & 0x3F)           = 0x9A
 ```
+
+## See Also
+
+- [`enh-ens-conformance-tests.md`](enh-ens-conformance-tests.md) -- ENH/ENS shared conformance test catalog (canonical XR test names and falsifiable invariants).

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -206,13 +206,13 @@ In ENH transport terms, after the target sends ACK (0x00) for an i2i frame, the 
 
 ### Unknown Command Contract
 
-An ENH command byte whose high nibble does not match any defined command ID (host: INIT=0x0, SEND=0x1, START=0x2, INFO=0x3; adapter: RESETTED=0x0, RECEIVED=0x1, STARTED=0x2, INFO=0x3, FAILED=0xA, ERROR_EBUS=0xB, ERROR_HOST=0xC) MUST be mapped to an explicit protocol error.
+An ENH encoded command nibble (carried in the first encoded byte, `byte1` bits 5..2) that does not match any defined command ID (host: INIT=0x0, SEND=0x1, START=0x2, INFO=0x3; adapter: RESETTED=0x0, RECEIVED=0x1, STARTED=0x2, INFO=0x3, FAILED=0xA, ERROR_EBUS=0xB, ERROR_HOST=0xC) MUST be mapped to an explicit protocol error.
 
 Implementations MUST NOT:
 - Report an unknown command as a timeout or collision.
 - Silently discard the byte and continue parsing (this corrupts the subsequent frame boundary).
 
-The host SHOULD emit a transport-level error (e.g., `ErrUnknownENHCommand`) and reset the parser state. The adapter SHOULD emit `ERROR_HOST(4)` for unrecognized host commands.
+The host SHOULD emit a transport-level error (e.g., `ErrUnknownENHCommand`) and reset the parser state. The adapter SHOULD emit `ERROR_HOST` for unrecognized host commands.
 
 ## Errors
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -4,7 +4,7 @@ ENH is the “enhanced” host↔adapter protocol used by ebusd-style interfaces
 
 See also:
 
-- `protocols/ens.md` for ebusd’s `ens:` prefix semantics (serial speed selector; equivalent to `enh:` on network transports).
+- `protocols/ens.md` for ebusd’s `ens:` prefix semantics (serial speed selector; equivalent to `enh:` on network transports). Note: in this document and its conformance tests, `ENH`/`ENS` refer to the ebusd transport prefixes, NOT the firmware data-only ENS codec (`codec_ens.c`) described in [ens.md §Disambiguation](ens.md#disambiguation).
 - `protocols/udp-plain.md` for raw eBUS bytes over UDP without ENH framing.
 
 Observe-first caveat: direct adapter-class ENH/ENS listeners on the adapter port
@@ -212,7 +212,7 @@ Implementations MUST NOT:
 - Report an unknown command as a timeout or collision.
 - Silently discard the byte and continue parsing (this corrupts the subsequent frame boundary).
 
-The host SHOULD emit a transport-level error (e.g., `ErrUnknownENHCommand`) and reset the parser state. The adapter SHOULD emit `ERROR_HOST` for unrecognized host commands.
+The host SHOULD emit a transport-level error (e.g., `ErrUnknownENHCommand`) and reset the parser state. The adapter SHOULD emit `ERROR_HOST` for unrecognized host commands. Some compatibility paths emit `FAILED` instead of `ERROR_HOST`; this is a documented deviation and implementations MAY accept either as a valid adapter-side rejection signal. Conformance tests MUST accept both and mark the exact variant observed.
 
 ## Errors
 

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -178,7 +178,7 @@ Portable behavior: no overlapping INFO requests on the same transport/session.
 
 ### INFO Frame Length and Interleaving
 
-INFO response frames have explicit length: `1 + N` bytes where byte 0 is the INFO ID and bytes 1..N are the payload. The payload length is determined by the INFO ID (see `enh-info-reference.md`).
+INFO response framing: the first INFO response byte is the payload length `N`, followed by exactly `N` data bytes. The INFO ID is not echoed in the response — it is known from the request. Total response size is `1 + N` bytes (length byte + payload). Expected payload lengths per INFO ID are documented in `enh-info-reference.md`.
 
 **Interleaving rules:**
 - Bus traffic (`RECEIVED` frames) MAY arrive between INFO request and response. These MUST be buffered or dispatched separately; they do not terminate the INFO exchange.

--- a/protocols/enh.md
+++ b/protocols/enh.md
@@ -232,4 +232,4 @@ byte2 = 0x80 | (0x5A & 0x3F)           = 0x9A
 
 ## See Also
 
-- [`enh-ens-conformance-tests.md`](enh-ens-conformance-tests.md) -- ENH/ENS shared conformance test catalog (canonical XR test names and falsifiable invariants).
+- [`architecture/enh-ens-conformance-tests.md`](../architecture/enh-ens-conformance-tests.md) -- ENH/ENS shared conformance test catalog (canonical XR test names and falsifiable invariants) — Helianthus architecture document, not public-domain protocol spec.

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -95,7 +95,12 @@ If no safe initiator is available, proxy returns a host-side error for the `STAR
 
 ### Ownership Lease TTL
 
-Bus ownership acquired via UDP-PLAIN MUST be bounded by a maximum TTL (time-to-live). Ownership begins when the adapter echoes the requested initiator address byte on the bus (arbitration win, southbound signal — UDP-PLAIN has no `STARTED` response). If the proxy does not observe idle SYN (`0xAA`) within the TTL period after the arbitration-byte echo, ownership MUST be released unconditionally to prevent bus lockout.
+Bus ownership acquired via UDP-PLAIN MUST be bounded by a maximum TTL (time-to-live). Ownership begins at one of two well-defined timestamps:
+
+- **Normal path**: the moment the adapter echoes the requested initiator address byte on the bus (arbitration win, southbound signal — UDP-PLAIN has no `STARTED` response).
+- **Fallback path** (when `udp-plain-disable-start-fallback=false`, the default): if no echo arrives within `udp-plain-start-wait` (default 5s), the proxy synthesizes a northbound `STARTED` and ownership begins at the synthesis timestamp. Implementations MUST record this synthesis timestamp explicitly and MUST NOT skip TTL enforcement because the echo was absent.
+
+If the proxy does not observe idle SYN (`0xAA`) within the TTL period after the recorded lease-start timestamp, ownership MUST be released unconditionally to prevent bus lockout.
 
 The TTL cap applies to both:
 - **Active ownership**: the proxy is sending data and waiting for ACK/response.

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -93,6 +93,18 @@ When a northbound client sends `START` with `initiator=0x00`, proxy selects an i
 
 If no safe initiator is available, proxy returns a host-side error for the `START`.
 
+### Ownership Lease TTL
+
+Bus ownership acquired via UDP-PLAIN MUST be bounded by a maximum TTL (time-to-live). If the proxy does not observe idle SYN within the TTL period after STARTED, ownership MUST be released unconditionally to prevent bus lockout.
+
+The TTL cap applies to both:
+- **Active ownership**: the proxy is sending data and waiting for ACK/response.
+- **Passive ownership**: the proxy received STARTED but has not yet sent data.
+
+Implementations SHOULD use a configurable TTL with a reasonable default (e.g., 5 seconds). The TTL MUST NOT be refreshed by non-SYN bus traffic (RECEIVED frames do not extend the lease).
+
+**Invariant name:** `XR_UDP_LeaseTTL_CapRefresh_Bounded`
+
 ### Fail-fast send behavior after collision
 
 If arbitration reaches terminal failure for a session, the next send attempt for that session is short-circuited with `FAILED` (`ENHResFailed`) and the winning initiator byte in payload (when available), instead of generic host error.

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -101,7 +101,7 @@ The TTL cap applies to both:
 - **Active ownership**: the proxy is sending data and waiting for ACK/response.
 - **Passive ownership**: the proxy received STARTED but has not yet sent data.
 
-Implementations SHOULD use a configurable TTL with a reasonable default (e.g., 5 seconds). The TTL MUST NOT be refreshed by non-SYN bus traffic (RECEIVED frames do not extend the lease).
+Implementations SHOULD use a configurable TTL with a reasonable default (e.g., 5 seconds). The TTL MUST NOT be refreshed by non-SYN raw bus traffic (that is, observing other bus bytes or proxy-emitted notifications does not extend the lease).
 
 **Invariant name:** `XR_UDP_LeaseTTL_CapRefresh_Bounded`
 

--- a/protocols/udp-plain.md
+++ b/protocols/udp-plain.md
@@ -95,11 +95,13 @@ If no safe initiator is available, proxy returns a host-side error for the `STAR
 
 ### Ownership Lease TTL
 
-Bus ownership acquired via UDP-PLAIN MUST be bounded by a maximum TTL (time-to-live). If the proxy does not observe idle SYN within the TTL period after STARTED, ownership MUST be released unconditionally to prevent bus lockout.
+Bus ownership acquired via UDP-PLAIN MUST be bounded by a maximum TTL (time-to-live). Ownership begins when the adapter echoes the requested initiator address byte on the bus (arbitration win, southbound signal — UDP-PLAIN has no `STARTED` response). If the proxy does not observe idle SYN (`0xAA`) within the TTL period after the arbitration-byte echo, ownership MUST be released unconditionally to prevent bus lockout.
 
 The TTL cap applies to both:
 - **Active ownership**: the proxy is sending data and waiting for ACK/response.
-- **Passive ownership**: the proxy received STARTED but has not yet sent data.
+- **Passive ownership**: the arbitration byte has been echoed but the proxy has not yet sent data.
+
+Note: `STARTED` is an optional northbound (proxy-emitted) event, not a UDP-PLAIN adapter message. The lease TTL is anchored to the southbound arbitration-byte echo.
 
 Implementations SHOULD use a configurable TTL with a reasonable default (e.g., 5 seconds). The TTL MUST NOT be refreshed by non-SYN raw bus traffic (that is, observing other bus bytes or proxy-emitted notifications does not extend the lease).
 


### PR DESCRIPTION
## What

Aligns ENS/ENH protocol documentation to serve as the canonical specification for transport behavior across all Helianthus implementations.

## Why

Post-audit cross-repo verification (R6) revealed that proxy, adaptermux, ebusgo, and VRC Explorer each implement subtly different ENH behavioral contracts. Without a canonical spec, divergences accumulate silently. This PR makes docs-ebus the single source of truth for ENH/ENS transport invariants.

## Changes

| # | File | Change |
|---|------|--------|
| 1 | `enh.md` | INIT timeout: fail-open bounded invariant |
| 2 | `enh.md` | INFO overlap: normative serialize-or-reject |
| 3 | `enh.md` | INFO framing: 1+N payload, interleaving rules, RESETTED invalidation |
| 4 | `enh.md` | Unknown command: explicit error contract |
| 5 | `enh.md` | Parser reset after read timeout invariant |
| 6 | `ebus-overview.md` | 0xAA scoping: SYN only at raw wire layer |
| 7 | `udp-plain.md` | UDP ownership TTL cap |
| 8 | (all target files) | Broken links: verified — zero found |
| 9 | `enh-ens-conformance-tests.md` | **New:** 12 canonical XR conformance tests |

## Conformance Test Catalog (12 tests)

- `XR_INIT_TimeoutFailOpen_Bounded`
- `XR_UpstreamLoss_GracefulShutdown_NoHang`
- `XR_START_ReconnectWait_BoundedDeadline`
- `XR_ENH_UnknownCommand_ExplicitError`
- `XR_INFO_RESETTED_CachePolicy_Explicit`
- `XR_INFO_FrameLength_AndSerialAccess`
- `XR_ENH_ParserReset_AfterReadTimeout`
- `XR_ENH_0xAA_DataNotSYN`
- `XR_START_RequestStart_WriteAll_NoDoubleSend`
- `XR_START_Cancel_ReleasesOwnership`
- `XR_Arbitration_Fairness_NoStarvation`
- `XR_UDP_LeaseTTL_CapRefresh_Bounded`

## Acceptance Criteria

- [ ] All 9 spec changes present and normative
- [ ] Conformance test catalog complete with falsifiable claims
- [ ] CI passes (terminology gate, IPv4 gate)
- [ ] Cross-repo review (proxy, adaptermux, ebusgo, VRC Explorer owners)

## Dependencies

This PR is the **doc-gate** for:
- proxy PR #101
- adaptermux PR #502
- ebusgo PRs #131-134
- VRC Explorer PRs #245-250 / follow-up

Prior docs PRs: #262 (audit corrective), #263 (cross-product gaps), #264 (CRC R6 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)