### PR TITLE
M0_DOC_GATE: ebus_standard normative catalog (meta #14)

### DIFF
--- a/architecture/ebus_standard/00-namespace.md
+++ b/architecture/ebus_standard/00-namespace.md
@@ -1,0 +1,124 @@
+# ebus_standard Namespace
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Namespace Boundary
+
+The locked plan states:
+
+> `ebus_standard` sits strictly above `protocol.Frame`. Framing, CRC, escaping,
+> and bus-transaction behaviour are unchanged. Device identification
+> (`0x07 0x04`) is a catalog entry in this namespace, not a hand-coded path in
+> scan/identity code.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+`ebus_standard` is therefore an L7 semantic provider only. It does not
+alter frame construction, CRC validation, ACK/NACK handling, escaping,
+transport arbitration, or bus retry behavior.
+
+## Cross-Vendor Rationale
+
+The standard eBUS application-layer services are not owned by a device
+vendor. They describe bus-wide behavior such as identification,
+capability discovery, burner service data, memory server access, general
+broadcasts, and network management. Helianthus therefore models them as
+a cross-vendor namespace whose methods can apply to any conformant eBUS
+participant.
+
+Provider selection MUST NOT use manufacturer identity as a precondition
+for decoding `ebus_standard`. A frame with PB/SB in this namespace is
+eligible for catalog lookup based on its catalog identity axes, even when
+the sender is unknown, non-Vaillant, or has no confirmed `DeviceInfo`.
+
+## Provider Separation
+
+The locked plan states:
+
+> `ebus_standard` is cross-vendor and must not contain any
+> Vaillant-specific logic.
+> Vaillant `0xB5` remains a parallel, unchanged namespace.
+> Shared L7 primitives, registry lookup, MCP envelope helpers, and method
+> identifiers are namespace-isolated with explicit tests.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+Normative implications:
+
+1. A Vaillant-specific selector, quirk, alias, fallback, or manufacturer
+   heuristic MUST NOT be encoded in the `ebus_standard` catalog.
+2. Shared codecs MAY be reused only behind namespace-isolated catalog
+   metadata and tests.
+3. A standard service decode result MUST NOT depend on Vaillant provider
+   state.
+4. A Vaillant `0xB5` decode result MUST NOT depend on `ebus_standard`
+   provider state.
+
+## Catalog Source of Truth
+
+The locked plan states:
+
+> Every method in `ebus_standard` is generated from a catalog data file.
+> No provider hard-codes per-device behaviour.
+> Catalog is SHA-pinned and version-tagged.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+The catalog is the normative method source. Runtime providers consume
+catalog entries; they do not invent hidden service variants.
+
+## Catalog Identity Key
+
+The locked plan states:
+
+> The catalog identity key for each method is the full tuple:
+>
+> - `namespace` (`ebus_standard`)
+> - `PB`
+> - `SB`
+> - `selector_path` (nullable)
+> - `telegram_class` (for example initiator-target,
+>   initiator-initiator, broadcast)
+> - `direction` (request / response)
+> - `request_or_response_role`
+> - `broadcast_or_addressed`
+> - `answer_policy` (answer-required / no-answer)
+> - `length_prefix_mode`
+> - `selector_decoder` identifier
+> - `service_variant`
+> - `transport_capability_requirements`
+> - `version`
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+Generation MUST fail when two methods share the same full identity key.
+Generation MUST also fail when a length-dependent selector can resolve
+to more than one branch for the same payload.
+
+## First-Lock Service Set
+
+The first-lock `ebus_standard` namespace covers these primary services:
+
+| PB | Service |
+|---:|---|
+| `0x03` | Service Data |
+| `0x05` | Burner Control |
+| `0x07` | System Data |
+| `0x08` | Controller-to-Controller |
+| `0x09` | Memory Server |
+| `0x0F` | Test Commands |
+| `0xFE` | General Broadcast |
+| `0xFF` | Network Management |
+
+The per-command catalog is frozen in
+[`01-services-catalog.md`](./01-services-catalog.md).

--- a/architecture/ebus_standard/01-services-catalog.md
+++ b/architecture/ebus_standard/01-services-catalog.md
@@ -1,0 +1,174 @@
+# ebus_standard Services Catalog
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Scope
+
+The locked plan states:
+
+> Services in `ebus_standard` first lock baseline:
+>
+> - `0x03` Service Data
+> - `0x05` Burner Control
+> - `0x07` System Data (includes `0x04` Identification and optional `0x03` /
+>   `0x05` capability discovery)
+> - `0x08` Controller-to-Controller
+> - `0x09` Memory Server
+> - `0x0F` Test Commands
+> - `0xFE` General Broadcast
+> - `0xFF` Network Management (including `FF 00`, `FF 01`, `FF 02`, `FF 03`,
+>   `FF 04`, `FF 05`, `FF 06`)
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+`safety_class` values are defined in
+[`05-execution-safety.md`](./05-execution-safety.md). These classifications
+govern live invocation. Passive decode of an observed frame is always
+non-invoking and does not by itself originate bus traffic.
+
+Protocol command names and payload summaries are sourced from the local
+standard-service protocol documents:
+
+- [`../../protocols/ebus-services/ebus-service-03h.md`](../../protocols/ebus-services/ebus-service-03h.md)
+- [`../../protocols/ebus-services/ebus-service-05h.md`](../../protocols/ebus-services/ebus-service-05h.md)
+- [`../../protocols/ebus-services/ebus-service-07h.md`](../../protocols/ebus-services/ebus-service-07h.md)
+- [`../../protocols/ebus-services/ebus-service-08h.md`](../../protocols/ebus-services/ebus-service-08h.md)
+- [`../../protocols/ebus-services/ebus-service-09h.md`](../../protocols/ebus-services/ebus-service-09h.md)
+- [`../../protocols/ebus-services/ebus-service-0Fh.md`](../../protocols/ebus-services/ebus-service-0Fh.md)
+- [`../../protocols/ebus-services/ebus-service-FEh.md`](../../protocols/ebus-services/ebus-service-FEh.md)
+- [`../../protocols/ebus-services/ebus-service-FFh.md`](../../protocols/ebus-services/ebus-service-FFh.md)
+
+## Service `0x03` - Service Data
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x03` | `0x04` | Start Counts | Initiator -> target; target response | addressed request/response | `read_only_bus_load` |
+| `0x03` | `0x05` | Operating Time Level 1 | Initiator -> target; target response | addressed request/response | `read_only_bus_load` |
+| `0x03` | `0x06` | Operating Time Level 2 | Initiator -> target; target response | addressed request/response | `read_only_bus_load` |
+| `0x03` | `0x07` | Operating Time Level 3 | Initiator -> target; target response | addressed request/response | `read_only_bus_load` |
+| `0x03` | `0x08` | Fuel Quantity Counter | Initiator -> target; target response | addressed request/response | `read_only_bus_load` |
+| `0x03` | `0x10` | Meter Reading | Initiator -> target; target response or initiator telegram response | addressed request/response or initiator/initiator | `read_only_bus_load` |
+
+Service `0x03` methods are diagnostic reads. They are not mutating, but
+live invocation still consumes bus capacity and is therefore
+`read_only_bus_load`, not `read_only_safe`.
+
+## Service `0x05` - Burner Control
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x05` | `0x00` | Operational Data Request, burner to controller | Burner -> controller | addressed operational control | `mutating` |
+| `0x05` | `0x01` | Operational Data, controller to burner | Controller -> burner | addressed operational control | `mutating` |
+| `0x05` | `0x02` | Operational Data Request, controller to burner | Controller -> burner | addressed operational control | `mutating` |
+| `0x05` | `0x03` | Operational Data, burner to controller, block 1 | Burner -> controller | addressed operational data | `mutating` |
+| `0x05` | `0x03` | Operational Data, burner to controller, block 2 | Burner -> controller | addressed operational data, selector `block_number=0x02` | `mutating` |
+| `0x05` | `0x04` | Control Stop Response | Burner -> controller | addressed operational control | `mutating` |
+| `0x05` | `0x05` | Barred | None | invalid/reserved | `destructive` |
+| `0x05` | `0x06` | Operational Data Request, channel B, burner to controller | Burner -> controller | addressed operational control | `mutating` |
+| `0x05` | `0x07` | Operational Data, channel B, controller to burner | Controller -> burner | addressed operational control | `mutating` |
+| `0x05` | `0x08` | Operational Data Request, channel B, controller to burner | Controller -> burner | addressed operational control | `mutating` |
+| `0x05` | `0x09` | Operational Data, channel B, block 1 | Burner -> controller | addressed operational data, selector `block_number=0x01` | `mutating` |
+| `0x05` | `0x09` | Operational Data, channel B, block 2 | Burner -> controller | addressed operational data, selector `block_number=0x02` | `mutating` |
+| `0x05` | `0x09` | Operational Data, channel B, block 3 | Burner -> controller | addressed operational data, selector `block_number=0x03` | `mutating` |
+| `0x05` | `0x0A` | Configuration Data Request | Controller -> burner; burner response via `0x05 0x0B` | addressed request/response | `read_only_bus_load` |
+| `0x05` | `0x0B` | Configuration Data Response | Burner -> controller | addressed response | `read_only_safe` |
+| `0x05` | `0x0C` | Operational Requirements | Burner -> controller | addressed operational control | `mutating` |
+| `0x05` | `0x0D` | Operational Data, extended controller to burner | Controller -> burner | addressed operational control | `mutating` |
+
+Operational burner-control methods can start, stop, or alter cyclic
+control behavior. They are default-denied for user-facing invocation.
+
+## Service `0x07` - System Data
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x07` | `0x00` | Date/Time Broadcast | Controller 0 -> all | broadcast | `broadcast` |
+| `0x07` | `0x01` | Set Date/Time | PC/clock -> controller | addressed write/control | `mutating` |
+| `0x07` | `0x02` | Set Outside Temperature | Service tool -> controller | addressed write/control | `mutating` |
+| `0x07` | `0x03` | Query Supported Commands | Any initiator -> target; target response | addressed capability query | `read_only_bus_load` |
+| `0x07` | `0x04` | Identification | Any initiator -> target; target response | addressed identity query | `read_only_bus_load` |
+| `0x07` | `0x04` | Identification self-broadcast | Device -> all | broadcast identity announcement | `broadcast` |
+| `0x07` | `0x05` | Query Supported Commands, extended | Any initiator -> target; target response | addressed capability query | `read_only_bus_load` |
+| `0x07` | `0xFE` | Inquiry of Existence | Any initiator -> all, usually broadcast | broadcast inquiry | `broadcast` |
+| `0x07` | `0xFF` | Sign of Life | Any initiator -> all, usually broadcast | broadcast sign-of-life | `broadcast` |
+
+`0x07 0x03` and `0x07 0x05` are opt-in capability-discovery surfaces;
+see [`04-capability-discovery.md`](./04-capability-discovery.md).
+`0x07 0x04` produces the canonical Identification descriptor defined in
+[`03-identification.md`](./03-identification.md).
+
+## Service `0x08` - Controller-to-Controller
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x08` | `0x00` | Target Values | Secondary controller -> controller 0 | broadcast | `broadcast` |
+| `0x08` | `0x01` | Operational Data | Controller 0 -> all | broadcast | `broadcast` |
+| `0x08` | `0x02` | Control Commands | Controller 0 -> all | broadcast | `broadcast` |
+| `0x08` | `0x03` | Boiler Parameters | Controller 0 -> all | broadcast | `broadcast` |
+| `0x08` | `0x04` | System Remote Control | PC/modem/clock -> controller | addressed remote control | `mutating` |
+
+All broadcast variants are default-denied for user-facing invocation.
+The addressed system remote control method is mutating and is also
+default-denied.
+
+## Service `0x09` - Memory Server
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x09` | `0x00` | Read RAM | Initiator -> target; target response | addressed service-mode memory read | `read_only_bus_load` |
+| `0x09` | `0x01` | Write RAM | Initiator -> target | addressed service-mode memory write | `memory_write` |
+| `0x09` | `0x02` | Read EEPROM | Initiator -> target; target response | addressed service-mode memory read | `read_only_bus_load` |
+| `0x09` | `0x03` | Write EEPROM | Initiator -> target | addressed service-mode memory write | `memory_write` |
+
+Memory Server methods remain service-mode methods. Writes are
+`memory_write`. Reads are not synthetic capabilities; they stay
+`read_only_bus_load` unless a later locked plan introduces stricter
+read policy.
+
+## Service `0x0F` - Test Commands
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0x0F` | `0x01` (`NN=0x02`) | Start of Test | Test system -> test device | addressed or initiator/initiator test control | `destructive` |
+| `0x0F` | `0x01` (`NN=0x01`) | Ready | Test device -> test system | addressed or broadcast test response | `destructive` |
+| `0x0F` | `0x02` | Test Message | Varies by test function | variable test carrier | `destructive` |
+| `0x0F` | `0x03` | End of Test | Test device -> test system | addressed or initiator/initiator test control | `destructive` |
+
+Test commands can put devices into factory/service test behavior, copy
+or echo telegrams, and originate follow-on traffic. They are
+default-denied.
+
+## Service `0xFE` - General Broadcast
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0xFE` | `0x01` | Error Message | Any initiator -> all | broadcast | `broadcast` |
+
+`0xFE 0x01` is explicitly outside the first NM baseline in the adopted
+NM participant policy. It is cataloged as a standard service but not
+made available through first-delivery user invocation.
+
+## Service `0xFF` - Network Management
+
+| PB | SB | Method | Direction | Telegram class | safety_class |
+|---:|---:|---|---|---|---|
+| `0xFF` | `0x00` | Reset Status NM | Joining node -> all | broadcast | `broadcast` |
+| `0xFF` | `0x01` | Reset Target Configuration NM | Any initiator -> all | broadcast | `broadcast` |
+| `0xFF` | `0x02` | Failure Message | Detecting node -> all | broadcast | `broadcast` |
+| `0xFF` | `0x03` | Net Status Query request | Any initiator -> target | addressed NM query | `read_only_bus_load` |
+| `0xFF` | `0x03` | Net Status Query response | NM target -> initiator | addressed responder reply | `read_only_safe` |
+| `0xFF` | `0x04` | Monitored Participants Query request | Any initiator -> target | addressed NM query | `read_only_bus_load` |
+| `0xFF` | `0x04` | Monitored Participants Query response | NM target -> initiator | addressed responder reply, block-paginated | `read_only_safe` |
+| `0xFF` | `0x05` | Failed Nodes Query request | Any initiator -> target | addressed NM query | `read_only_bus_load` |
+| `0xFF` | `0x05` | Failed Nodes Query response | NM target -> initiator | addressed responder reply, block-paginated | `read_only_safe` |
+| `0xFF` | `0x06` | Required Services Query request | Any initiator -> target | addressed NM query | `read_only_bus_load` |
+| `0xFF` | `0x06` | Required Services Query response | NM target -> initiator | addressed responder reply, block-paginated | `read_only_safe` |
+
+The NM runtime state machine remains owned by the gateway runtime. The
+wire services above are catalog entries consumed by that runtime. The
+exact `system_nm_runtime` whitelist for first delivery is defined in
+[`05-execution-safety.md`](./05-execution-safety.md).

--- a/architecture/ebus_standard/02-l7-types.md
+++ b/architecture/ebus_standard/02-l7-types.md
@@ -1,0 +1,196 @@
+# ebus_standard L7 Type Rules
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Scope
+
+The locked plan states:
+
+> `BYTE`, `CHAR`, `DATA1c`, variable-length raw, composite BCD, and
+> length-dependent selector each have exact byte handling, signedness,
+> replacement-value sentinels, nibble ordering, invalid-nibble policy,
+> selector length validation, truncated/overlong payload error paths, and
+> validity propagation to decode output.
+> Golden vectors are required for each primitive and cover positive AND
+> negative cases.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+These rules are the required behavior for `ebus_standard` decode and
+encode implementations.
+
+## Decode Output Validity
+
+Every decoded field MUST carry:
+
+- `raw`: exact source bytes, in wire order.
+- `valid`: boolean.
+- `replacement`: boolean.
+- `value`: omitted or unset when `valid=false`.
+- `error`: structured decoder error when invalidity is caused by syntax,
+  length, range, or selector failure rather than by a replacement value.
+
+Replacement values and invalid syntax both produce `valid=false`, but
+they are not the same state. Replacement values set `replacement=true`;
+syntax/range/length failures set `replacement=false` and include an
+error code.
+
+## BYTE
+
+`BYTE` is exactly one octet.
+
+Rules:
+
+1. Decode requires exactly one byte. Zero bytes are `truncated_payload`.
+   More than one byte in a fixed-width BYTE field is `overlong_payload`.
+2. The decoded value is unsigned integer `0..255`.
+3. `BYTE` has no generic replacement sentinel. A field MAY declare a
+   field-specific replacement value, but that sentinel belongs to the
+   catalog field, not to the primitive type.
+4. Encoding rejects integers outside `0..255`.
+
+## CHAR
+
+`CHAR` is exactly one octet. In the eBUS standard service tables it is
+used for numeric bytes, address bytes, and fixed-width text bytes.
+
+Rules:
+
+1. Decode requires exactly one byte per `CHAR` element.
+2. Numeric `CHAR` fields decode as unsigned integer `0..255` unless a
+   catalog field declares a narrower range.
+3. Signedness is catalog-field metadata, not implicit in the byte type.
+   A field declared as signed `CHAR` decodes the byte as two's-complement
+   int8 after replacement-byte handling. A field not declared signed
+   MUST be decoded as unsigned.
+4. A range violation sets `valid=false` with `error=out_of_range`.
+5. `CHAR` has no generic replacement sentinel. A catalog field MAY
+   declare a replacement byte such as `0x3F` or `0xFF`.
+6. Fixed-width `CHAR[n]` text fields MUST preserve the exact raw byte
+   array. Display text MAY strip trailing `0x00` and `0x20` for display
+   only; raw bytes remain authoritative. `0xFF` is not padding unless the
+   catalog field explicitly declares it as padding or replacement.
+7. Text decoding accepts printable ASCII bytes `0x20..0x7E` as display
+   characters. Other bytes remain in `raw`; display text MUST escape or
+   substitute them without losing the original bytes.
+8. Encoding fixed-width text pads on the right with `0x20` unless the
+   catalog field declares a different pad byte. Encoding fails if the
+   encoded byte length exceeds the fixed width.
+
+## DATA1c
+
+`DATA1c` is one unsigned byte with resolution `0.5` and replacement
+sentinel `0xFF`.
+
+Rules:
+
+1. Decode requires exactly one byte.
+2. `0xFF` is the replacement value. It decodes to `valid=false`,
+   `replacement=true`, with no numeric value.
+3. All non-`0xFF` bytes decode as unsigned raw integer `r`.
+4. The physical value is `r / 2`.
+5. DATA1c is not two's-complement signed. Values `0x80..0xFE` are
+   positive half-unit values unless rejected by the catalog field range.
+6. Catalog field ranges are applied after scaling. For a field range
+   `0..100`, raw values above `0xC8` are `out_of_range`.
+7. Encoding rejects values outside the field range, rejects values that
+   do not round-trip exactly to a half-unit byte, and rejects values that
+   would encode to `0xFF`.
+
+## Variable-Length Raw Payload
+
+A variable-length raw payload is a byte slice whose length is determined
+by the telegram length prefix, a preceding field, or a selected catalog
+branch.
+
+Rules:
+
+1. Raw payload decoding MUST preserve byte order and content exactly.
+2. Zero length is valid only when the selected catalog branch permits
+   zero length.
+3. If the frame ends before the selected length is satisfied, decode
+   fails with `truncated_payload`.
+4. If bytes remain after all selected fields are decoded and the branch
+   does not declare a raw tail, decode fails with `overlong_payload`.
+5. Raw payloads have no replacement sentinel unless the catalog field
+   declares one.
+6. Encoders MUST write the length mode required by the selected branch
+   and MUST reject payloads exceeding that branch's maximum.
+
+## Composite BCD
+
+`BCD` is one packed decimal byte. Composite BCD fields are ordered
+sequences of packed BCD bytes.
+
+Single-byte rules:
+
+1. The high nibble is the tens digit.
+2. The low nibble is the ones digit.
+3. `0x42` decodes to decimal `42`.
+4. Any nibble greater than `9` is invalid unless the full byte exactly
+   matches a declared replacement sentinel.
+5. The primitive replacement sentinel is `0xFF`.
+
+Composite rules:
+
+1. Each byte is validated independently before any aggregate value is
+   emitted.
+2. Date/time fields treat each BCD byte as an independent component.
+   Example: seconds, minutes, hours, day, month, weekday, year.
+3. Counter fields that use base-100 chunks MUST declare their multiplier
+   in the catalog. Example: `0x03 0x10` meter reading uses multipliers
+   `1`, `100`, `10000`, and `1000000`.
+4. If any component is invalid, the composite field is `valid=false`.
+   Valid components MAY still appear in diagnostic decode output, but no
+   aggregate value is emitted.
+5. If any component is a replacement value, the composite field is
+   `valid=false` and `replacement=true` unless the catalog declares
+   per-component replacement handling.
+
+## Length-Dependent Selector
+
+A length-dependent selector chooses a catalog branch using the telegram
+length, request/response role, and any selector fields already decoded.
+
+Required selector inputs:
+
+- `PB`
+- `SB`
+- `direction`
+- `request_or_response_role`
+- telegram length prefix (`NN`)
+- selected payload bytes used by the selector
+- `selector_decoder` identifier from the catalog identity key
+
+Rules:
+
+1. Selector evaluation MUST happen before field decoding for branches
+   whose layout depends on length.
+2. The selected branch MUST be unique. If two branches match the same
+   input, decode fails with `ambiguous_selector_branch`.
+3. If no branch matches, decode fails with `unknown_selector_branch`.
+4. If the selector requires a byte that is missing, decode fails with
+   `truncated_payload`.
+5. If the selected branch consumes fewer bytes than present and no raw
+   tail is declared, decode fails with `overlong_payload`.
+6. Selectors MUST validate both lower and upper length bounds. Accepting
+   a prefix length because it is "at least enough" is forbidden.
+7. Golden vectors MUST include positive selection, no-match,
+   ambiguous-match, truncated-selector, truncated-payload, and
+   overlong-payload cases.
+
+## Validity Propagation
+
+Decode output validity propagates upward:
+
+1. A field with `valid=false` makes its enclosing composite invalid.
+2. A composite with `valid=false` makes the command decode
+   `valid=false`.
+3. A command decode with invalid fields still returns raw bytes and
+   field diagnostics when the catalog identity itself is known.
+4. Unknown catalog identity is not a partial decode; it returns
+   `unknown_method` with the frame metadata and raw payload.

--- a/architecture/ebus_standard/03-identification.md
+++ b/architecture/ebus_standard/03-identification.md
@@ -1,0 +1,125 @@
+# Identification `0x07 0x04`
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Catalog Method
+
+The locked plan states:
+
+> `0x07 0x04` produces a canonical `Identification` descriptor with fields
+> `manufacturer`, `device_id`, `software_version`, `hardware_version`.
+> The descriptor is exposed as a method result with provenance metadata.
+> It does NOT overwrite `DeviceInfo`. Disagreements between
+> `ebus_standard` Identification and existing `DeviceInfo` values are
+> retained with source labels. Consumers apply deterministic precedence
+> with both sources visible.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+`0x07 0x04` is a normal `ebus_standard` catalog method. It MUST NOT be
+implemented as a special scan-only or identity-plumbing path.
+
+## Wire Forms
+
+| Variant | Identity axes |
+|---|---|
+| Addressed request | `PB=0x07`, `SB=0x04`, request role, addressed, answer-required, request `NN=0x00` |
+| Addressed response | `PB=0x07`, `SB=0x04`, response role, addressed, answer-required, response `NN=0x0A` |
+| Self-identification broadcast | `PB=0x07`, `SB=0x04`, initiator broadcast, no-answer, payload `NN=0x0A` |
+
+## Response Payload
+
+The addressed response and self-identification broadcast share the same
+10-byte payload layout.
+
+| Byte | Field | Type | Descriptor target |
+|---:|---|---|---|
+| 0 | manufacturer | `BYTE` | `manufacturer` |
+| 1-5 | unit_id | `CHAR[5]` text/raw | `device_id` |
+| 6 | software_version_major | `BCD` | `software_version.version` |
+| 7 | software_version_minor | `BCD` | `software_version.revision` |
+| 8 | hardware_version_major | `BCD` | `hardware_version.version` |
+| 9 | hardware_version_minor | `BCD` | `hardware_version.revision` |
+
+## Descriptor Schema
+
+The canonical method result schema is:
+
+```json
+{
+  "manufacturer": {
+    "raw": "b5",
+    "code": 181,
+    "valid": true
+  },
+  "device_id": {
+    "raw": "4241493030",
+    "text": "BAI00",
+    "valid": true
+  },
+  "software_version": {
+    "version": 1,
+    "revision": 23,
+    "text": "01.23",
+    "valid": true
+  },
+  "hardware_version": {
+    "version": 4,
+    "revision": 5,
+    "text": "04.05",
+    "valid": true
+  },
+  "provenance": {
+    "namespace": "ebus_standard",
+    "method": "0x07 0x04",
+    "source": "live_bus",
+    "catalog_version": "v1.0-locked"
+  }
+}
+```
+
+The four top-level descriptor fields are mandatory. Additional
+provenance metadata is mandatory for storage or registry projection.
+
+## Field Rules
+
+`manufacturer`:
+
+1. Decode as `BYTE`.
+2. Accept the full byte range `0x00..0xFF`.
+3. Do not reject values above decimal `99`; live devices use extended
+   manufacturer codes.
+
+`device_id`:
+
+1. Decode bytes 1-5 as fixed-width `CHAR[5]`.
+2. Preserve exact raw bytes.
+3. Produce display text using the `CHAR` fixed-width text rules in
+   [`02-l7-types.md`](./02-l7-types.md).
+4. Do not infer vendor or model families from the text inside this
+   method. Provider-specific interpretation belongs outside
+   `ebus_standard`.
+
+`software_version` and `hardware_version`:
+
+1. Decode each component as independent `BCD`.
+2. The high nibble is tens; the low nibble is ones.
+3. Invalid BCD nibbles make that version object `valid=false`.
+4. `0xFF` is a replacement value for a BCD component. A replacement in
+   either component makes the corresponding version object
+   `valid=false`, `replacement=true`.
+
+## Length and Error Handling
+
+1. Request payload length MUST be exactly zero bytes.
+2. Response and self-broadcast payload length MUST be exactly 10 bytes.
+3. Fewer than 10 response bytes is `truncated_payload`.
+4. More than 10 response bytes is `overlong_payload`.
+5. A malformed descriptor MUST NOT be promoted to `DeviceInfo`.
+6. Raw bytes and field diagnostics MUST remain available to decode
+   clients when the method identity is known.
+

--- a/architecture/ebus_standard/04-capability-discovery.md
+++ b/architecture/ebus_standard/04-capability-discovery.md
@@ -1,0 +1,82 @@
+# Capability Discovery
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Policy
+
+The locked plan states:
+
+> `0x07 0x03` and `0x07 0x05` are opt-in discovery surfaces.
+> Devices that do not answer remain `capability=unknown`, which is a
+> valid terminal state. No synthetic capability is invented.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+Capability discovery is never mandatory for `ebus_standard` identity,
+decode, or NM operation.
+
+## Methods
+
+| PB | SB | Name | Invocation policy | safety_class |
+|---:|---:|---|---|---|
+| `0x07` | `0x03` | Query Supported Commands | Opt-in addressed query only | `read_only_bus_load` |
+| `0x07` | `0x05` | Query Supported Commands, extended | Opt-in addressed query only | `read_only_bus_load` |
+
+`0x07 0x03` response mapping is fixed to PB `0x05..0x0C`.
+`0x07 0x05` response mapping depends on the requested PB block.
+
+## Capability State Model
+
+| State | Meaning | Terminal |
+|---|---|---|
+| `unknown` | No capability query has been run, or the device did not provide a usable answer | Yes |
+| `known` | A valid response was decoded and mapped to supported PB/SB bits | Yes |
+| `invalid_response` | A response was received but failed strict decoding | Yes for that observation |
+| `not_attempted` | Operator or policy has not opted in | No; transitions to `unknown` if stored as device state |
+
+`unknown` is not an error. It is the required terminal state for
+non-answering devices.
+
+## No Synthetic Capability
+
+The provider MUST NOT infer capability support from:
+
+1. Observing a device transmit a command.
+2. Seeing a successful `0x07 0x04` Identification response.
+3. Manufacturer or model identity.
+4. Vaillant `0xB5` provider metadata.
+5. NM target configuration.
+6. Home Assistant or registry consumer needs.
+
+Observed behavior MAY be stored as evidence, but it MUST be labeled as
+observation evidence rather than as a capability-discovery result.
+
+## Opt-In Requirements
+
+An active `0x07 0x03` or `0x07 0x05` query requires an explicit caller
+or runtime policy decision. The decision record MUST include:
+
+- target address
+- selected method (`0x07 0x03` or `0x07 0x05`)
+- caller context
+- reason
+- timestamp
+- bus-load accounting window
+
+The default discovery pipeline MAY decode passively observed capability
+responses. Passive decode does not authorize active probing.
+
+## Error Handling
+
+1. Timeout or no answer records `capability=unknown`.
+2. NACK, arbitration failure, or transport failure records
+   `capability=unknown` plus transport diagnostics.
+3. Malformed response records `invalid_response` for that observation
+   and MUST NOT create synthetic support bits.
+4. Unsupported PB/SB bits outside the catalog are preserved as raw bits
+   with source labels, not converted into catalog methods.
+

--- a/architecture/ebus_standard/05-execution-safety.md
+++ b/architecture/ebus_standard/05-execution-safety.md
@@ -1,0 +1,137 @@
+# Execution Safety Policy
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Safety Classes
+
+Every catalog method declares exactly one `safety_class`:
+
+- `read_only_safe`
+- `read_only_bus_load`
+- `mutating`
+- `destructive`
+- `broadcast`
+- `memory_write`
+
+`read_only_safe` is reserved for non-originating or responder-local
+methods that do not cause a user-facing live bus transaction.
+`read_only_bus_load` is read-only but originates live bus traffic when
+invoked.
+
+## Default-Deny Policy
+
+The locked plan states:
+
+> `rpc.invoke` accepts `read_only_safe` and `read_only_bus_load`.
+> `rpc.invoke` default-denies `mutating`, `destructive`, `broadcast`,
+> `memory_write`.
+> Default-deny applies to any user-facing caller and to every internal
+> caller EXCEPT a single named caller context
+> `caller_context=system_nm_runtime` that carries a compile-time
+> whitelist.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+For user-facing `rpc.invoke`, safety-class acceptance is necessary but
+not sufficient. The catalog identity must also be a user-requestable
+request variant. Response-role and responder-emit variants are not
+user-requestable merely because they are read-only.
+
+## Single Policy Function
+
+The locked plan states:
+
+> One shared execution-policy module is consulted by `rpc.invoke`,
+> generated provider methods, and the NM runtime.
+> All three call the same policy function with the caller context.
+> Tests prove denial parity: direct provider invocation and MCP
+> `rpc.invoke` deny identical sets by default; the `system_nm_runtime`
+> whitelist is honoured only from the NM runtime call site.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+## system_nm_runtime Whitelist
+
+The locked plan states:
+
+> The `system_nm_runtime` whitelist is keyed by the full catalog identity
+> tuple (see §3). The whitelist in first delivery is exactly:
+>
+> - `0xFF 00` broadcast (NM reset status on join/reset)
+> - `0xFF 02` broadcast (NM failure signal)
+> - `0xFF 03` responder (net status)
+> - `0xFF 04` responder (monitored participants)
+> - `0xFF 05` responder (failed nodes)
+> - `0xFF 06` responder (required services)
+> - `0x07 FF` broadcast (sign of life, cadence-floor gated)
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+The whitelist entries below are exact variants. Matching by PB/SB alone
+is forbidden.
+
+| namespace | PB | SB | selector_path | telegram_class | direction | request_or_response_role | broadcast_or_addressed | answer_policy | length_prefix_mode | selector_decoder | service_variant | transport_capability_requirements | version |
+|---|---:|---:|---|---|---|---|---|---|---|---|---|---|---|
+| `ebus_standard` | `0xFF` | `0x00` | `null` | `broadcast` | `request` | `initiator_broadcast_emit` | `broadcast` | `no-answer` | `NN=0x00` | `none` | `nm_reset_status_broadcast` | `initiator+broadcast` | `v1.0-locked` |
+| `ebus_standard` | `0xFF` | `0x02` | `null` | `broadcast` | `request` | `initiator_broadcast_emit` | `broadcast` | `no-answer` | `NN=0x00` | `none` | `nm_failure_broadcast` | `initiator+broadcast` | `v1.0-locked` |
+| `ebus_standard` | `0xFF` | `0x03` | `null` | `initiator-target` | `response` | `responder_reply` | `addressed` | `answer-required` | `response_NN=0x01` | `none` | `nm_net_status_response` | `responder_companion_required` | `v1.0-locked` |
+| `ebus_standard` | `0xFF` | `0x04` | `request.block_number` | `initiator-target` | `response` | `responder_reply` | `addressed` | `answer-required` | `response_NN=0x01..0x0A` | `nm_block_number` | `nm_monitored_participants_response` | `responder_companion_required` | `v1.0-locked` |
+| `ebus_standard` | `0xFF` | `0x05` | `request.block_number` | `initiator-target` | `response` | `responder_reply` | `addressed` | `answer-required` | `response_NN=0x01..0x0A` | `nm_block_number` | `nm_failed_nodes_response` | `responder_companion_required` | `v1.0-locked` |
+| `ebus_standard` | `0xFF` | `0x06` | `request.block_number` | `initiator-target` | `response` | `responder_reply` | `addressed` | `answer-required` | `response_NN=0x01..0x0A` | `nm_block_number` | `nm_required_services_response` | `responder_companion_required` | `v1.0-locked` |
+| `ebus_standard` | `0x07` | `0xFF` | `null` | `broadcast` | `request` | `initiator_broadcast_emit` | `broadcast` | `no-answer` | `NN=0x00` | `none` | `sign_of_life_broadcast` | `initiator+broadcast+cadence_floor_10s` | `v1.0-locked` |
+
+Adjacent variants with the same PB/SB remain denied unless their full
+14-axis identity appears in this table. Examples:
+
+1. `0xFF 03` request is not the whitelisted `0xFF 03` responder reply.
+2. `0xFF 04` request is not the whitelisted `0xFF 04` responder reply.
+3. `0x07 FE` broadcast inquiry is not the whitelisted `0x07 FF`
+   sign-of-life broadcast.
+4. `0xFF 01` reset target configuration is not whitelisted.
+
+## Audit Requirement
+
+The locked plan states:
+
+> Audit: every allowed invocation in `system_nm_runtime` is logged with
+> catalog identity, caller, timestamp, and outcome.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+The structured audit log record MUST include at least:
+
+- full catalog identity tuple
+- caller context
+- concrete runtime caller name
+- local address-pair provenance when applicable
+- timestamp
+- decision (`allowed` or `denied`)
+- outcome (`sent`, `responded`, `suppressed`, `transport_error`,
+  `policy_denied`, or equivalent structured code)
+- error details when outcome is not successful
+
+## No Runtime Widening
+
+The locked plan states:
+
+> Widening the whitelist, adding caller contexts, or exposing
+> mutating/destructive/broadcast/memory-write surfaces via GraphQL is a
+> new locked-plan decision, not a code change.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+The first-delivery whitelist is a compile-time constant. Configuration,
+operator commands, feature flags, environment variables, registry
+records, and portal state MUST NOT widen it at runtime.

--- a/architecture/ebus_standard/06-nm-adoption.md
+++ b/architecture/ebus_standard/06-nm-adoption.md
@@ -1,0 +1,116 @@
+# NM Adopt-and-Extend
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Ownership Preface
+
+The locked plan states:
+
+> `ebus_standard` subsumes the locked NM plan via adopt-and-extend
+>
+> - `ebus-good-citizen-network-management` is superseded by `ebus_standard`.
+> - Merged normative docs `#251`, `#253`, `#256` in `helianthus-docs-ebus`
+>   remain authoritative. `ebus_standard` M0 inventories them, marks the
+>   kept-verbatim sections with attribution, adopts them as subchapters
+>   under `ebus_standard` ownership, and adds an ownership preface plus
+>   migration appendix.
+> - `ebus_standard` M0 does NOT duplicate or rewrite the normative text.
+> - The superseded plan transitions to `.maintenance` only after M6b
+>   reconciles cross-links, issue map, and canonical IDs.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+This document adopts the merged NM documents in place. It does not
+modify, restate, or supersede their normative content. Where this
+directory adds catalog identity, execution-safety, or provenance policy,
+those additions extend the NM documents under the `ebus_standard`
+ownership umbrella.
+
+## Adopted Subchapters
+
+| Adopted document | Adopted role under `ebus_standard` | Ownership note |
+|---|---|---|
+| [`../nm-model.md`](../nm-model.md) | NM runtime model, state machine, wire behavior lanes, L7 classification | Adopted verbatim as the gateway-owned NM runtime model |
+| [`../nm-discovery.md`](../nm-discovery.md) | NM-aligned discovery and discovery-to-target-configuration pipeline | Adopted verbatim as the topology evidence and enrollment model |
+| [`../nm-participant-policy.md`](../nm-participant-policy.md) | Local participant behavior, address-pair authority, bus-load policy, cycle-time policy | Adopted verbatim as the local participant and load policy |
+
+The NM documents remain authoritative for NM runtime semantics:
+
+- `NMInit -> NMReset -> NMNormal`
+- target configuration
+- cycle-time monitoring
+- self-monitoring
+- status chart
+- net status
+- start flag
+- passive/indirect monitoring model
+- bus-load bounds and transport blindness behavior
+
+## Extension Points Added by ebus_standard
+
+The locked plan states:
+
+> `NMInit/NMReset/NMNormal`, target configuration, cycle-time monitoring,
+> self-monitoring, status chart, net status, and start flag remain owned
+> by the gateway runtime as designed in the locked NM plan.
+> `0xFF 00/01/02/03/04/05/06` and `07 FF` are catalog entries in
+> `ebus_standard`. The gateway NM runtime consumes catalog metadata to
+> emit broadcasts and drive responder replies.
+> After M4c2 merges, no hand-coded `FF` command handler survives in the
+> gateway.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+This M0 doc set adds these extension points:
+
+1. `0xFF 00..06` and `0x07 FF` are catalog methods with full identity
+   keys.
+2. The NM runtime emits or responds through catalog-driven method
+   metadata.
+3. `system_nm_runtime` is the only caller context allowed to execute the
+   first-delivery NM whitelist beyond user-facing read-only invocation.
+4. Every allowed `system_nm_runtime` invocation requires structured
+   audit logging.
+5. Runtime widening of NM wire surfaces requires a future locked plan.
+
+## Migration Appendix
+
+### Current State
+
+The existing NM docs were produced by the
+`ebus-good-citizen-network-management` plan and merged before this
+`ebus_standard` plan. They remain normative and are not rewritten in
+M0_DOC_GATE.
+
+### Migration Target
+
+The migration target is catalog-driven NM wire behavior:
+
+1. Keep the gateway NM runtime state machine and state ownership from
+   [`../nm-model.md`](../nm-model.md).
+2. Keep the discovery evidence pipeline from
+   [`../nm-discovery.md`](../nm-discovery.md).
+3. Keep address-pair, bus-load, transport blindness, and cycle-time
+   policy from [`../nm-participant-policy.md`](../nm-participant-policy.md).
+4. Move `0xFF` and `0x07 FF` wire emission/response selection to
+   `ebus_standard` catalog identities.
+5. Remove hand-coded `FF` command handlers after catalog-driven runtime
+   integration lands in the gateway milestone.
+
+### Traceability Rules
+
+1. Do not edit the adopted NM text to fit catalog terminology.
+2. Add cross-links only when a future docs milestone explicitly scopes
+   reconciliation.
+3. Keep old plan issue references visible until M6b performs the
+   `.maintenance` transition.
+4. When terminology differs between the adopted NM documents and the
+   catalog, preserve both terms and label the mapping rather than
+   rewriting history.
+

--- a/architecture/ebus_standard/07-identity-provenance.md
+++ b/architecture/ebus_standard/07-identity-provenance.md
@@ -1,0 +1,120 @@
+# Identity Provenance
+
+Status: Normative
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Policy
+
+The locked plan states:
+
+> `0x07 0x04` produces a canonical `Identification` descriptor with fields
+> `manufacturer`, `device_id`, `software_version`, `hardware_version`.
+> The descriptor is exposed as a method result with provenance metadata.
+> It does NOT overwrite `DeviceInfo`. Disagreements between
+> `ebus_standard` Identification and existing `DeviceInfo` values are
+> retained with source labels. Consumers apply deterministic precedence
+> with both sources visible.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+`ebus_standard` Identification is an evidence source. It is not a
+replacement write into `DeviceInfo`.
+
+## Provenance Sources
+
+Identity records MUST preserve source labels. Required source labels:
+
+| Source label | Meaning |
+|---|---|
+| `device_info` | Existing registry `DeviceInfo` identity |
+| `ebus_standard.identification` | Decoded `0x07 0x04` descriptor |
+| `operator_seed` | Operator-provided static identity seed |
+| `passive_observation` | Identity evidence observed without Helianthus-originated query |
+
+Implementations MAY add more source labels, but they MUST NOT collapse
+multiple sources into an unlabeled merged value.
+
+## Non-Overwrite Rule
+
+When a valid `0x07 0x04` descriptor is decoded:
+
+1. Store it as `ebus_standard.identification` evidence.
+2. Attach method provenance: catalog identity, catalog version, source
+   frame metadata, timestamp, and decode validity.
+3. Do not overwrite `DeviceInfo.manufacturer`, `DeviceInfo.device_id`,
+   `DeviceInfo.software_version`, or `DeviceInfo.hardware_version`.
+4. If a projection needs a single display value, compute it from the
+   deterministic precedence rule below while keeping both source records
+   visible.
+
+## Disagreement Handling
+
+A disagreement exists when two valid source records provide different
+values for the same identity field.
+
+Required behavior:
+
+1. Preserve both values.
+2. Preserve both source labels.
+3. Mark the field with `agreement=false`.
+4. Do not silently normalize away punctuation, casing, padding, or raw
+   byte differences.
+5. Expose enough raw data for a client to distinguish display-string
+   disagreement from byte-level disagreement.
+
+Malformed `0x07 0x04` data is not a disagreement. It is invalid
+evidence and must remain labeled as such.
+
+## Deterministic Precedence
+
+When a consumer requires one preferred identity value, apply this order:
+
+1. Valid `device_info` value.
+2. Valid `ebus_standard.identification` value.
+3. Valid `operator_seed` value.
+4. Valid `passive_observation` value.
+5. `unknown`.
+
+This precedence is deterministic display selection only. It does not
+delete lower-precedence evidence.
+
+## Projection Shape
+
+A registry or MCP projection SHOULD expose both the preferred value and
+the source set:
+
+```json
+{
+  "manufacturer": {
+    "preferred": {
+      "value": "Vaillant",
+      "source": "device_info"
+    },
+    "sources": [
+      {
+        "source": "device_info",
+        "value": "Vaillant",
+        "valid": true
+      },
+      {
+        "source": "ebus_standard.identification",
+        "raw": "b5",
+        "value": 181,
+        "valid": true
+      }
+    ],
+    "agreement": false
+  }
+}
+```
+
+## HA Compatibility
+
+First delivery is a Home Assistant compatibility checkpoint only. No new
+HA entities, no new GraphQL fields, and no consumer rollout are allowed
+as a side effect of identity provenance. Existing HA-visible contracts
+must remain stable while both identity sources are retained internally.
+

--- a/architecture/ebus_standard/README.md
+++ b/architecture/ebus_standard/README.md
@@ -1,0 +1,44 @@
+# ebus_standard Normative Documentation
+
+Status: Normative
+Milestone: M0_DOC_GATE
+Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
+Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## Purpose
+
+This directory freezes the first normative documentation set for the
+Helianthus `ebus_standard` Layer 7 provider namespace.
+
+The locked plan states:
+
+> `ebus_standard` is a new L7 provider namespace for Helianthus that carries the
+> official eBUS Application Layer standard services. It is a cross-vendor,
+> catalog-driven surface applicable to any eBUS-conformant device. It runs in
+> parallel with the existing Vaillant `0xB5` provider namespace and does not
+> reuse Vaillant-specific logic.
+
+Attribution: canonical plan
+`ebus-standard-l7-services-w16-26.locked/00-canonical.md`, SHA-256
+`9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`.
+
+## Index
+
+| File | Normative subject |
+|---|---|
+| [`00-namespace.md`](./00-namespace.md) | Namespace boundary, catalog source of truth, identity key |
+| [`01-services-catalog.md`](./01-services-catalog.md) | First-lock service and command catalog with `safety_class` |
+| [`02-l7-types.md`](./02-l7-types.md) | Required primitive and selector decoding rules |
+| [`03-identification.md`](./03-identification.md) | Canonical `0x07 0x04` Identification descriptor |
+| [`04-capability-discovery.md`](./04-capability-discovery.md) | Optional `0x07 0x03` / `0x07 0x05` capability discovery |
+| [`05-execution-safety.md`](./05-execution-safety.md) | Safety classes, default-deny policy, NM runtime whitelist |
+| [`06-nm-adoption.md`](./06-nm-adoption.md) | Adopt-and-extend of merged NM docs |
+| [`07-identity-provenance.md`](./07-identity-provenance.md) | Identity provenance and `DeviceInfo` non-overwrite policy |
+
+## Related Source Documents
+
+- [`../nm-model.md`](../nm-model.md)
+- [`../nm-discovery.md`](../nm-discovery.md)
+- [`../nm-participant-policy.md`](../nm-participant-policy.md)
+- [`../../protocols/ebus-services/ebus-application-layer.md`](../../protocols/ebus-services/ebus-application-layer.md)
+


### PR DESCRIPTION
## Summary
M0 doc-gate milestone for `ebus-standard-l7-services-w16-26` locked plan. Freezes normative documentation for the `ebus_standard` L7 provider namespace (cross-vendor standard services).

## Companion code
None — this PR IS the doc-gate artifact (self-satisfying per cruise-doc-gate SELF_REFERENCE_CHECK).

## Canonical
- Meta-issue: [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14)
- Issue: [Project-Helianthus/helianthus-docs-ebus#266](https://github.com/Project-Helianthus/helianthus-docs-ebus/issues/266)
- Locked plan: [`ebus-standard-l7-services-w16-26.locked/`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/ebus-standard-l7-services-w16-26.locked)
- Canonical SHA-256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`

## Acceptance criteria satisfied
- [x] AC1 normative catalog (8 services: 0x03/0x05/0x07/0x08/0x09/0x0F/0xFE/0xFF)
- [x] AC2 L7 type rules (BYTE/CHAR/DATA1c/raw/BCD/length-selector)
- [x] AC3 0x07 0x04 Identification descriptor (4 fields)
- [x] AC4 opt-in capability discovery + capability=unknown terminal
- [x] AC5 execution-safety with 14-tuple whitelist + default-deny on `mutating/destructive/broadcast/memory_write`
- [x] AC6 adopt-and-extend (NM docs `nm-model.md`/`nm-discovery.md`/`nm-participant-policy.md` UNMODIFIED)
- [x] AC7 identity-provenance (non-overwrite of `DeviceInfo`)

## Files (9, under `architecture/ebus_standard/`)
`00-namespace.md`, `01-services-catalog.md`, `02-l7-types.md`, `03-identification.md`, `04-capability-discovery.md`, `05-execution-safety.md`, `06-nm-adoption.md`, `07-identity-provenance.md`, `README.md`.

## Gates
- **TDD:** `docs-exempt` (per `cruise-tdd-gate` DOCS_SCOPE_SHORT_CIRCUIT patch applied 2026-04-18)
- **Transport-gate:** N/A (L7 above `protocol.Frame`)
- **Doc-gate:** self-satisfying (this PR IS the doc artifact)
- **Local CI:** pass — see commit status `ci/local` on `4aa407d`

Tracks cruise-run [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14).