### PR TITLE
[codex] add Vaillant 0704 device prefix glossary

### DIFF
--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -226,6 +226,8 @@ Observed target response payload layout:
 Notes:
 - The response length varies by device because the device id field is variable-length.
 - Many tools treat `sw`/`hw` as opaque hex.
+- Vaillant device IDs and prefixes observed through this scan are expanded in
+  [`../vaillant/ebus-vaillant.md#device-id-prefix-glossary`](../vaillant/ebus-vaillant.md#device-id-prefix-glossary).
 
 ### Identify-Only Profile Fields (Generic)
 

--- a/protocols/vaillant/ebus-vaillant.md
+++ b/protocols/vaillant/ebus-vaillant.md
@@ -31,6 +31,31 @@ For detailed coverage of selector-heavy identifiers, see:
 - Layouts are observation-based and may vary by target class.
 - `PB/SB` identifiers can multiplex multiple payload shapes.
 
+## Device ID Prefix Glossary
+
+Vaillant `0x07 0x04` identification scans commonly return short ASCII device
+IDs or prefixes. The following expansions are useful when interpreting scan
+results and mapping a physical target to its product family:
+
+| Prefix | Meaning |
+|--------|---------|
+| `BAI` | Burner Adjustment Interface |
+| `BMU` | Burner Management Unit |
+| `HMU` | Heat Management Unit |
+| `UI` | User Interface |
+| `VMS` | Vaillant Multi-circuit Solarmodul |
+| `VRC` | Vaillant Regulator Control |
+| `VWL` | Vaillant Waermepumpe Luft |
+| `VWS` | Vaillant Waermepumpe Sole |
+| `VWZ` | Vaillant Waermepumpe Zusatz |
+
+Notes:
+- These are identity hints from scan payloads, not semantic proof by
+  themselves. Runtime code still needs device-specific register evidence before
+  publishing protocol semantics.
+- `VWL`, `VWS`, and `VWZ` are German product-family abbreviations. The ASCII
+  spellings above normalize `Waermepumpe` for repository-wide portability.
+
 ## Identifier Index
 
 ```text


### PR DESCRIPTION
## What

Add a Vaillant device ID prefix glossary for standard `0x07 0x04` identification scans.

## Why

The short ASCII IDs returned by 0704 scans are useful when interpreting scan output and mapping observed devices to product families. The glossary keeps those expansions close to the Vaillant protocol index while linking from the generic eBUS identification scan documentation.

## Changes

- Adds expansions for `BAI`, `BMU`, `HMU`, `UI`, `VMS`, `VRC`, `VWL`, `VWS`, and `VWZ`.
- Notes that these are identity hints, not semantic proof by themselves.
- Links the generic `Identification Scan (0x07 0x04)` section to the Vaillant-specific glossary.

## Validation

- `./scripts/ci_local.sh`