### PR TITLE
docs(ebus_standard): M6b publication — transport matrix cross-reference + completion marker

### DIFF
--- a/architecture/ebus_standard/14-transport-matrix-cross-reference.md
+++ b/architecture/ebus_standard/14-transport-matrix-cross-reference.md
@@ -1,0 +1,75 @@
+# M6a Transport Matrix — Cross-Reference
+
+Status: Normative (pointer chapter)
+Milestone: M6b_docs_publication_and_closeout
+Plan reference: `ebus-standard-l7-services-w16-26.implementing/00-canonical.md`
+Canonical SHA-256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`
+Gateway anchor commit: `686dfaf0` (helianthus-ebusgateway#514, merged 2026-04-19)
+
+## Purpose
+
+The M6a transport matrix artifact is maintained in
+`helianthus-ebusgateway` as the authoritative live-bus conformance record
+for the `ebus_standard` L7 namespace. This chapter exists so operators
+discovering `ebus_standard` via docs-ebus can locate the matrix without
+having to infer its repository of origin.
+
+This chapter is a **pointer**: it does not restate the matrix content and
+MUST NOT diverge from it. Any conflict between the prose here and the
+linked artifact is resolved in favour of the artifact.
+
+## §1 — Location
+
+The canonical transport matrix artifact lives at:
+
+```
+helianthus-ebusgateway/matrix/M6a-transport-matrix.md
+```
+
+Anchor commit at time of this chapter's lock: `686dfaf0`
+(helianthus-ebusgateway#514).
+
+The matrix is co-located with the gateway because it records live-bus
+conformance behaviour emitted by the gateway's transport stack; drift
+between the matrix and the running producer is detectable only against
+that source tree.
+
+## §2 — Section pointers
+
+Within the matrix artifact, the following sections are the load-bearing
+references for `ebus_standard` consumers and reviewers:
+
+| Matrix section | Subject |
+|---|---|
+| §3 | Vaillant regression surface — confirms the `0xB5` provider namespace is unaffected by `ebus_standard` parallel operation. |
+| §4 | NM wire behaviour — records observed initiator/responder dynamics against the adopt-and-extend NM plan. |
+| §5 | Cadence floor — per-transport minimum inter-frame spacing observed on the live bus. |
+| §6 | Rollback criteria — the conditions under which `ebus_standard` emission MUST be disabled at runtime via the M3 provider-contract disable switch. |
+| §7 | BENCH-REPLACE obligation — operator follow-up on the BASV2 bench for synthetic-to-live fixture replacement. |
+
+Consumers that need to reason about transport-conditional responder
+capability SHOULD cross-read §5 (cadence) and §6 (rollback) together
+with [`13-responder-capability-signal.md`](./13-responder-capability-signal.md)
+§4 (fail-closed consumer rule) and §5.2 (`transport_mux_bypass` reason
+semantics).
+
+## §3 — BENCH-REPLACE status
+
+At the time of this chapter's lock, matrix §7 carries the status marker
+`PLACEHOLDER`. The bench-replacement obligation is deferred to an
+operator BASV2 bench follow-up outside the cruise-run's merge scope. Once
+the bench pass lands, the matrix §7 status flips from `PLACEHOLDER` to a
+fixture-anchored entry; this chapter does NOT need to be amended for
+that flip — the matrix is the source of truth and the link above already
+resolves to the updated content.
+
+## §4 — Amendment policy
+
+This chapter amends only when:
+
+- The matrix artifact's repository path changes.
+- A new matrix section is introduced that `ebus_standard` consumers must
+  cross-read (additive pointer row).
+
+The matrix's own content evolves independently under the gateway repo's
+review process and does NOT trigger amendments here.

--- a/architecture/ebus_standard/README.md
+++ b/architecture/ebus_standard/README.md
@@ -5,6 +5,15 @@ Milestone: M0_DOC_GATE
 Plan reference: ebus-standard-l7-services-w16-26.locked/00-canonical.md
 Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
 
+## Completion status
+
+The first-delivery `ebus_standard` L7 namespace plan (cruise-run meta
+`Project-Helianthus/helianthus-execution-plans#14`) completed 2026-04-20
+with 17 milestones merged. Transport matrix:
+`helianthus-ebusgateway/matrix/M6a-transport-matrix.md` (anchor commit
+`686dfaf0`, helianthus-ebusgateway#514). BENCH-REPLACE operator
+follow-up: pending (matrix §7 status `PLACEHOLDER`).
+
 ## Purpose
 
 This directory freezes the first normative documentation set for the
@@ -39,6 +48,7 @@ Attribution: canonical plan
 | [`10-rpc-source-113.md`](./10-rpc-source-113.md) | M4 `rpc.invoke` gateway source byte invariant |
 | [`11-m4b-semantic-lock.md`](./11-m4b-semantic-lock.md) | M4B semantic lock of read & decode surfaces (envelope, error, safety_class, decode scaffold, catalog version) |
 | [`13-responder-capability-signal.md`](./13-responder-capability-signal.md) | M4D normative lock of `meta.capabilities.responder` (shape, invariants I1-I8, fail-closed consumer rule, enum catalogue at v1.1, subtree version policy) |
+| [`14-transport-matrix-cross-reference.md`](./14-transport-matrix-cross-reference.md) | M6b pointer to the canonical transport matrix artifact in helianthus-ebusgateway (section pointers §3-§7, BENCH-REPLACE status) |
 
 ## Related Source Documents
 


### PR DESCRIPTION
## M6b_docs_publication_and_closeout — final milestone

Seals the first-delivery `ebus_standard` L7 namespace plan. Closes #280.

LANE B additive, docs-only, auto-merge candidate per operator directive.

### Scope (this PR — single-repo docs-ebus)

1. **Matrix cross-reference** — new chapter `architecture/ebus_standard/14-transport-matrix-cross-reference.md` pointing to the canonical transport-matrix artifact at `helianthus-ebusgateway/matrix/M6a-transport-matrix.md` (anchor `686dfaf0`, helianthus-ebusgateway#514). Section pointers to matrix §3 (Vaillant regression), §4 (NM wire), §5 (cadence floor), §6 (rollback criteria), §7 (BENCH-REPLACE obligation, `PLACEHOLDER` status).
2. **Completion marker** — terse completion-status paragraph near the top of `architecture/ebus_standard/README.md` (17 milestones merged 2026-04-20, BENCH-REPLACE follow-up pending).
3. **Index row** — README index table extended with row 14.

### Out of scope — post-merge orchestrator handoff (helianthus-execution-plans maintenance)

- `90-issue-map.md` + `91-milestone-map.md` reconciliation with all 17 merged milestones + PR/squash SHAs.
- `ebus-good-citizen-network-management.locked/` → `.maintenance/` rename (deprecation-obligation transition per canonical plan; adopt-and-extend superseded by M0).
- `ebus-standard-l7-services-w16-26.implementing/` → `.locked/` rename with `plan.yaml` `state: locked` (plan-dir terminal convention, after this PR merges).

These three items land as direct commits on `helianthus-execution-plans/main` per the plan-maintenance convention used throughout the cruise-run.

### Predecessor references

- Canonical plan: `ebus-standard-l7-services-w16-26.implementing/00-canonical.md` (SHA-256 `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`)
- Cruise-run meta: `Project-Helianthus/helianthus-execution-plans#14`
- M6a transport matrix merge: `helianthus-ebusgateway#514` @ `686dfaf0`
- M4D responder capability lock predecessor: `helianthus-docs-ebus#279` @ `2fe399af`

### Local-CI

Markdown-only, docs-exempt. Pass@HEAD.

### Review

`@codex review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)