### PR TITLE
docs: document serial-based registry aliases

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -541,6 +541,7 @@ Address semantics:
 - `address` is the canonical primary eBUS address for the physical device node.
 - `addresses` contains canonical + alias faces observed for that same device.
 - `device(address:)`, `planes(address:)`, and `methods(address:, plane:)` accept either the canonical address or any alias address from `addresses`.
+- Alias grouping uses stable physical identifiers when available. A shared manufacturer + serial number or manufacturer + MAC address can merge faces even when their eBUS `deviceId` values differ; `deviceId` remains exported as model/provider metadata for the canonical entry.
 
 ### Service Status Notes
 

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -156,6 +156,8 @@ The registry layer treats each physical eBUS device as a **DeviceEntry** discove
 
 During scan, Helianthus treats the response source as canonical when available, but still retains the queried target as an alias face when source and target differ. This avoids losing valid faces (for example, a SOL00-style `0xEC` target) when multiple targets answer with the same source identity.
 
+When stable enrichment later supplies a serial number or MAC address, that stable identifier becomes the physical-device identity key together with manufacturer. `DeviceID` is not part of the serial/MAC identity key: the same physical regulator can present different role-specific device IDs on different eBUS faces. During a cross-entry merge, the existing canonical entry keeps its `DeviceID` for provider matching and exported metadata; ordinary same-entry updates can still correct a stale `DeviceID`.
+
 A DeviceEntry does not directly expose behavior; instead, **PlaneProviders** match against the DeviceInfo (manufacturer, device ID, HW/SW versions, and stable identifiers when available) and **create one or more Planes** that represent distinct semantic views of that same device (e.g., heating, DHW, system).
 
 Each Plane publishes:


### PR DESCRIPTION
## What
Document the registry identity behavior introduced by Project-Helianthus/helianthus-ebusreg#117.

## Why
PR #117 changes physical-device deduplication so stable serial/MAC identifiers can merge multiple eBUS faces even when their DeviceID values differ. This is externally visible through device/address semantics and should be recorded in the architecture and GraphQL API docs.

## Acceptance Criteria
- [x] Architecture overview documents serial/MAC physical identity independent of DeviceID
- [x] GraphQL device address semantics document alias grouping with stable identifiers
- [x] Unit tests cover the implemented code
- [x] CI green
- [ ] Smoke test required: NO

## Dependencies
- Supports Project-Helianthus/helianthus-ebusreg#117 doc-gate.