### PR TITLE
SAS-01: Docs source address selection

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -28,8 +28,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Install test dependencies
-        run: python3 -m pip install pytest pytest-json-report
+        run: python -m pip install pytest pytest-json-report
 
       - name: Run local docs CI
         run: ./scripts/ci_local.sh

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,125 +4,32 @@ on:
   pull_request:
     paths:
       - "**/*.md"
+      - "**/*.py"
+      - "**/*.json"
+      - "scripts/**"
+      - "tests/**"
       - ".github/workflows/docs-ci.yml"
   push:
     branches:
       - main
     paths:
       - "**/*.md"
+      - "**/*.py"
+      - "**/*.json"
+      - "scripts/**"
+      - "tests/**"
       - ".github/workflows/docs-ci.yml"
 
 jobs:
   markdown-checks:
-    name: Markdown Checks
+    name: Docs Checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify markdown files are present
-        run: |
-          set -euo pipefail
-          count="$(git ls-files "*.md" | wc -l | tr -d " ")"
-          if [ "${count}" -eq 0 ]; then
-            echo "No markdown files found."
-            exit 1
-          fi
-          echo "Found ${count} markdown files."
+      - name: Install test dependencies
+        run: python3 -m pip install pytest pytest-json-report
 
-      - name: Check markdown for tabs and trailing spaces
-        run: |
-          set -euo pipefail
-          failed=0
-
-          if git grep -nI $'\t' -- "*.md"; then
-            echo "Tab characters are not allowed in markdown files."
-            failed=1
-          fi
-
-          if git grep -nI -E ' +$' -- "*.md"; then
-            echo "Trailing spaces are not allowed in markdown files."
-            failed=1
-          fi
-
-          if [ "${failed}" -ne 0 ]; then
-            exit 1
-          fi
-
-          echo "Markdown checks passed."
-
-      - name: Enforce initiator/target terminology
-        run: |
-          set -euo pipefail
-
-          python3 - <<'PY'
-          from __future__ import annotations
-
-          import pathlib
-          import re
-          import subprocess
-          import sys
-
-          allowed_file = pathlib.Path("protocols/ebus-services/ebus-overview.md")
-          begin_marker = "<!-- legacy-role-mapping:begin -->"
-          end_marker = "<!-- legacy-role-mapping:end -->"
-
-          # Construct legacy terms without spelling them out literally in-repo.
-          terms = ["m" + "aster", "sl" + "ave"]
-          pattern = re.compile(r"\\b(" + "|".join(map(re.escape, terms)) + r")\\b", re.IGNORECASE)
-
-          md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
-
-          def line_number(text: str, index: int) -> int:
-              return text.count("\\n", 0, index) + 1
-
-          def print_match(file_path: str, text: str, index: int, match_text: str) -> None:
-              print(f"{file_path}:{line_number(text, index)}:{match_text}", file=sys.stderr)
-
-          if not allowed_file.exists():
-              print(f"Expected {allowed_file} to exist.", file=sys.stderr)
-              sys.exit(1)
-
-          allowed_text = allowed_file.read_text(encoding="utf-8")
-          begin_index = allowed_text.find(begin_marker)
-          end_index = allowed_text.find(end_marker)
-          if begin_index == -1 or end_index == -1 or end_index <= begin_index:
-              print(
-                  "Missing or malformed legacy-role-mapping markers in protocols/ebus-services/ebus-overview.md.",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-
-          allowed_region_start = begin_index
-          allowed_region_end = end_index
-
-          failed = False
-
-          for file_path in md_files:
-              path = pathlib.Path(file_path)
-              text = path.read_text(encoding="utf-8")
-              for match in pattern.finditer(text):
-                  if path != allowed_file:
-                      if not failed:
-                          print(
-                              "Legacy role terms must not appear outside protocols/ebus-services/ebus-overview.md.",
-                              file=sys.stderr,
-                          )
-                      failed = True
-                      print_match(file_path, text, match.start(), match.group(0))
-
-          for match in pattern.finditer(allowed_text):
-              if not (allowed_region_start <= match.start() < allowed_region_end):
-                  if not failed:
-                      print(
-                          "Legacy role terms must only appear inside the legacy-role-mapping note.",
-                          file=sys.stderr,
-                      )
-                  failed = True
-                  print_match(str(allowed_file), allowed_text, match.start(), match.group(0))
-
-          if failed:
-              sys.exit(1)
-
-          print("Terminology gate passed.")
-          PY
+      - name: Run local docs CI
+        run: ./scripts/ci_local.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Claude Code orchestrator-session artifacts (per-session tool/skills config, not repo-tracked)
 .claude/
+
+# Python local test/cache artifacts
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -87,13 +87,16 @@ Wire-level escape encoding for **transmission** is a separate step applied after
 
 **Consequences:** Callers use a single `Send` call and receive typed errors after retries are exhausted.
 
-## ADR-008: Priority queue by source address
+## ADR-008: Priority queue by eBUS arbitration rank
 
 **Status:** Accepted
 
 **Context:** eBUS arbitration favors lower initiator addresses.
 
-**Decision:** Outgoing frames are queued in a priority queue keyed by the source address, with FIFO ordering for equal priority.
+**Decision:** Outgoing frames are queued by eBUS arbitration rank, not by
+Helianthus preference. p0 / `0x0` outranks p1 / `0x1`, then p2 / `0x3`, p3 /
+`0x7`, and p4 / `0xF`. Lower source byte wins only within otherwise equal
+contention. FIFO ordering applies after that protocol ordering.
 
 **Consequences:** Concurrent callers are serialized according to bus arbitration rules without each caller knowing about priorities.
 
@@ -247,23 +250,31 @@ For write confirmation (when a write API exists), perform targeted confirm reads
 
 **Consequences:** Device identity remains stable and explainable, UIs can render correct parent/child topology, and derived semantic devices do not pretend to be independently addressable hardware.
 
-## ADR-018: Initiator join uses passive warmup with bounded active inquiry
+## ADR-018: Source address selection uses passive observation with bounded active validation
 
 **Status:** Accepted
 
-**Context:** On live buses, Helianthus may join while other initiators are already active. Joining should minimize additional traffic and avoid known address collisions.
+**Context:** On live buses, Helianthus must choose a source address while other
+initiators may already be active. Selection should minimize additional traffic
+and avoid known source/companion collisions.
 
 **Decision:**
 
-- Join starts with a passive listen warmup (default 5s) and builds source/target activity statistics.
-- Candidate initiator addresses are selected from the valid 25-address set.
-- Selection prefers highest addresses by default (lower arbitration priority) unless explicitly configured otherwise.
-- Companion target (`initiator + 0x05`) activity heuristics reject risky candidates when the companion target looks active.
-- Active `0x07 0xFE` inquiry is optional, rate-limited, and bounded per process session.
-- Last-good initiator persistence is best-effort and only reused when still safe.
-- If all initiator addresses are occupied, join fails explicitly by default; force mode is opt-in.
+- Source address selection starts with passive observation and known-address
+  evidence.
+- The default gateway policy is `0xFF,0x7F,0x3F,0x1F,0xF7,0x77,0x37,0x17,0x07,0x11,0x31,0x00`.
+- Companion target is computed as source plus `0x05` modulo one byte, so
+  `0xFF -> 0x04` and `0xF7 -> 0xFC`.
+- Exact source configuration uses `explicit_validate_only`: no candidate
+  search, but active validation remains mandatory.
+- The only first-implementation active validation probe is bounded addressed
+  `0x07/0x04`; `0x07/0xFE` is not a startup admission probe.
+- If no source passes validation, Helianthus enters
+  `DEGRADED_SOURCE_SELECTION` and emits no Helianthus-originated eBUS traffic.
 
-**Consequences:** Default join behavior keeps bus chatter low, produces deterministic telemetry for selection rationale, and avoids unsafe address reuse while preserving an explicit operator override path.
+**Consequences:** Default selection behavior keeps bus chatter low, produces
+deterministic telemetry for selection rationale, and avoids unsafe address reuse
+without pretending there is a protocol join handshake.
 
 ## ADR-019: Collision monitor enforces fail-fast writes on foreign same-source traffic
 

--- a/architecture/ebus_standard/10-rpc-source-113.md
+++ b/architecture/ebus_standard/10-rpc-source-113.md
@@ -1,9 +1,30 @@
 # `rpc.invoke` Source Byte Invariant
 
-Status: Normative
+Status: Superseded by SAS-01 for normal gateway-owned traffic
 Milestone: M4_GATEWAY_MCP
 Plan reference: ebus-standard-l7-services-w16-26.implementing/00-canonical.md
 Canonical SHA-256: 9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+
+## SAS-01 Supersession
+
+The fixed `0x71` invariant below is historical. It applied to the
+`ebus-standard-l7-services-w16-26` M4 implementation before source address
+selection admission was locked. Current gateway-owned traffic uses the admitted
+`SourceAddressSelection.Source` after `active_probe_passed`.
+
+Normal MCP/GraphQL/Portal/semantic/NM/protocol-dispatch paths must not hardcode
+`0x71`, fallback to `0x31`, or accept caller-selected source authority. Missing
+source uses the admitted source. A value matching the admitted source is
+redundant diagnostic input. A nonmatching source is rejected for normal
+operations. `DEGRADED_SOURCE_SELECTION` fails closed with no
+Helianthus-originated eBUS traffic.
+
+Only transport-specific diagnostic MCP requests may use a non-admitted explicit
+source, and only for one audited, non-persistent request that does not mutate
+the admitted source.
+
+The remaining sections are retained as historical rationale for the superseded
+fixed-source contract.
 
 ## Purpose
 

--- a/architecture/ebus_standard/12-source-address-table.md
+++ b/architecture/ebus_standard/12-source-address-table.md
@@ -13,21 +13,24 @@ standard rows or infer device intent from priority alone.
 
 ## Official Spec Evidence
 
-This table is derived only from local official specifications in the workspace
-corpus:
+This table is derived only from local official specifications. In developer
+workspaces and local CI, `HELIANTHUS_OFFICIAL_SPEC_DIR` points to the directory
+that contains these files. If the variable is unset, the checker tries
+`../docs` relative to this repository; repo-only CI falls back to the committed
+excerpt fixture below.
 
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:28-60`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:28-60`
   for the 25 source-capable address rows and free-use note.
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:69-77`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:69-77`
   for companion-address reservation examples.
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:178-184`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_12_V1_3_1_E.en.md:178-184`
   for the companion-address arithmetic.
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:254-256`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_12_V1_3_1_E.en.md:254-256`
   for the source-address and arbitration role.
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:320-349`
-  and `/Users/razvan/Desktop/Helianthus Project/docs/SRC/Spec_Prot_12_V1_3_1_E.md:320-349`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_12_V1_3_1_E.en.md:320-349`
+  and `$HELIANTHUS_OFFICIAL_SPEC_DIR/SRC/Spec_Prot_12_V1_3_1_E.md:320-349`
   for the priority-class and sub-address split.
-- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:471-478`
+- `$HELIANTHUS_OFFICIAL_SPEC_DIR/Spec_Prot_12_V1_3_1_E.en.md:471-478`
   for the ACK/NACK byte context.
 
 The checker in

--- a/architecture/ebus_standard/12-source-address-table.md
+++ b/architecture/ebus_standard/12-source-address-table.md
@@ -1,0 +1,157 @@
+# eBUS Source Address Selection Table
+
+Status: Normative
+Milestone: SAS-01 M1
+Table owner: `helianthus-docs-ebus`
+
+## Purpose
+
+This chapter freezes the standard eBUS source-address table used by
+Helianthus source-address selection code. The table is protocol data, not a
+gateway policy: consumers may filter or order it, but they must not rewrite the
+standard rows or infer device intent from priority alone.
+
+## Official Spec Evidence
+
+This table is derived only from local official specifications in the workspace
+corpus:
+
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:28-60`
+  for the 25 source-capable address rows and free-use note.
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md:69-77`
+  for companion-address reservation examples.
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:178-184`
+  for the companion-address arithmetic.
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:254-256`
+  for the source-address and arbitration role.
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:320-349`
+  and `/Users/razvan/Desktop/Helianthus Project/docs/SRC/Spec_Prot_12_V1_3_1_E.md:320-349`
+  for the priority-class and sub-address split.
+- `/Users/razvan/Desktop/Helianthus Project/docs/Spec_Prot_12_V1_3_1_E.en.md:471-478`
+  for the ACK/NACK byte context.
+
+The checker in
+[`scripts/check_source_address_table_against_official_specs.py`](../../scripts/check_source_address_table_against_official_specs.py)
+validates these rows against the local official specs when
+`HELIANTHUS_OFFICIAL_SPEC_DIR` is set. Repo-only CI uses a committed
+official-derived fixture with source file hashes and line provenance instead
+of comparing the table to itself.
+
+## Semantics
+
+- `Source` is the byte emitted as the source address of an active eBUS frame.
+- `Priority index` is the p0..p4 source-address priority class.
+- `Arbitration nibble` is the low nibble used for byte-oriented arbitration.
+  Lower bus priority class wins on the wire: p0 / `0x0`, then p1 / `0x1`,
+  p2 / `0x3`, p3 / `0x7`, and p4 / `0xF`. This does not define Helianthus
+  preference order.
+- `Official description summary` is a compact summary of the local official
+  spec row. It is not an enum.
+- `Canonical description` is the stable Helianthus enum-facing description.
+- `Free-use` and `Recommended for` are separate fields. A recommendation never
+  authorizes gateway startup selection by itself.
+- `Companion` is the responder-side address derived by adding `0x05` to the
+  source address modulo one byte; `0xFF` therefore maps to `0x04`.
+- `0xFF` is valid in the `Source` column. In an ACK/NACK field, `0xFF` is a
+  negative acknowledgement. Consumers must keep those contexts separate.
+
+## Gateway Selection Policy
+
+The standard table does not prescribe the Helianthus gateway startup order.
+When no source description, priority index, or exact address is configured, the
+gateway uses `HelianthusGatewayDefaultPolicy`:
+
+1. p4 candidates: `0xFF`, `0x7F`, `0x3F`, `0x1F`
+2. p3 candidates: `0xF7`, `0x77`, `0x37`, `0x17`, `0x07`
+3. p1 candidates: `0x11`, `0x31`
+4. p0 candidates: `0x00`
+
+This is a Helianthus policy, not an eBUS priority claim. The p4 rows lose to
+p0..p3 during bus arbitration; they are tried first because Helianthus wants
+free-use or tool-like addresses before preallocated controller identities.
+
+If gateway startup configuration supplies only a priority index, selection
+filters `HelianthusGatewayDefaultPolicy`; it does not search every standard
+row at that priority. If it supplies a standard source description, selection
+uses only rows with that exact canonical description and optionally intersects
+them with the configured priority index. Free-use recommendations remain
+informational.
+
+An exact source address uses `explicit_validate_only`: candidate search is
+bypassed, but the selected source and companion must still pass availability
+and active-probe validation before any normal gateway-owned bus-reaching path
+can use them.
+
+## Startup Admission Boundary
+
+`helianthus-ebusgo` owns the reusable `SourceAddressSelector` mechanics and
+the static table constants. `helianthus-ebusgateway` owns startup admission:
+active probe, retry/quarantine, persistence metadata, operator recovery
+surfaces, and admission status. `helianthus-ebusreg` remains admission-agnostic
+and consumes only the source byte it is given.
+
+Normal gateway-owned operations use only the admitted
+`SourceAddressSelection.Source` after `active_probe_passed`. This includes MCP,
+GraphQL, Portal explorer, semantic pollers/writers, schedulers, NM runtime, and
+gateway-internal protocol dispatch. A redundant caller-provided source matching
+the admitted source may be accepted as diagnostic input; a nonmatching source
+is rejected on normal gateway-owned paths.
+
+Only transport-specific diagnostic MCP requests may use a non-admitted source,
+and only for one audited, non-persistent request that does not mutate the
+admitted source.
+
+`DEGRADED_SOURCE_SELECTION` is fail-closed. While it is active, Helianthus
+originates no eBUS traffic: no scan, semantic polling, MCP/GraphQL bus invoke,
+NM `FF 00`/`FF 02`, `0x07/0xFF`, or companion responder activity.
+
+The only first-implementation pre-discovery validation probe is addressed
+`0x07/0x04`, classified as `read_only_bus_load`, against a configured or
+current bounded positive target. Startup admission must not use broadcast
+`0x07/0xFE`, `0x0F` test commands, NM services, mutating services, memory
+writes, full-range probes, SYN/ESC/broadcast destinations, the selected source,
+or the selected companion as a validation target.
+
+## Hash Contract
+
+Table anchor: `#ebus-source-address-table-v1`
+
+Table version: `ebus-source-address-table/v1`
+
+Hash algorithm: SHA-256 over the exact Markdown table block from the header
+row through the last data row, UTF-8 encoded, LF line endings, trailing spaces
+stripped per line, and exactly one terminal LF. The heading and surrounding
+prose are excluded.
+
+Normalized table hash:
+`e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103`
+
+## eBUS Source Address Table v1
+
+| Source | Priority index | Arbitration nibble | Official description summary | Canonical description | Free-use | Recommended for | Companion |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `0x00` | p0 | `0x0` | PC/Modem | PC/Modem | no | none | `0x05` |
+| `0x10` | p0 | `0x0` | Heating controller | Heating regulator | no | none | `0x15` |
+| `0x30` | p0 | `0x0` | Heating circuit controller 1 | Heating circuit regulator 1 | no | none | `0x35` |
+| `0x70` | p0 | `0x0` | Heating circuit controller 2 | Heating circuit regulator 2 | no | none | `0x75` |
+| `0xF0` | p0 | `0x0` | Heating circuit controller 3 | Heating circuit regulator 3 | no | none | `0xF5` |
+| `0x01` | p1 | `0x1` | Hand programmer / Remote control | Handheld programmer / remote | no | none | `0x06` |
+| `0x11` | p1 | `0x1` | Bus interface / Climate controller | Bus interface / climate regulator | no | none | `0x16` |
+| `0x31` | p1 | `0x1` | Bus interface | Bus interface | no | none | `0x36` |
+| `0x71` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0x76` |
+| `0xF1` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0xF6` |
+| `0x03` | p2 | `0x3` | Burner controller 1 | Combustion controller 1 | no | none | `0x08` |
+| `0x13` | p2 | `0x3` | Burner controller 2 | Combustion controller 2 | no | none | `0x18` |
+| `0x33` | p2 | `0x3` | Burner controller 3 | Combustion controller 3 | no | none | `0x38` |
+| `0x73` | p2 | `0x3` | Burner controller 4 | Combustion controller 4 | no | none | `0x78` |
+| `0xF3` | p2 | `0x3` | Burner controller 5 | Combustion controller 5 | no | none | `0xF8` |
+| `0x07` | p3 | `0x7` | empty | Not preallocated | yes | none | `0x0C` |
+| `0x17` | p3 | `0x7` | Heating controller recommendation | Not preallocated | yes | Heating regulator | `0x1C` |
+| `0x37` | p3 | `0x7` | Heating controller recommendation | Not preallocated | yes | Heating regulator | `0x3C` |
+| `0x77` | p3 | `0x7` | Heating controller recommendation | Not preallocated | yes | Heating regulator | `0x7C` |
+| `0xF7` | p3 | `0x7` | Heating controller recommendation | Not preallocated | yes | Heating regulator | `0xFC` |
+| `0x0F` | p4 | `0xF` | Clock module / Radio clock module | Clock/radio-clock module | no | none | `0x14` |
+| `0x1F` | p4 | `0xF` | Burner controller 6 recommendation | Not preallocated | yes | Combustion controller 6 | `0x24` |
+| `0x3F` | p4 | `0xF` | Burner controller 7 recommendation | Not preallocated | yes | Combustion controller 7 | `0x44` |
+| `0x7F` | p4 | `0xF` | Burner controller 8 recommendation | Not preallocated | yes | Combustion controller 8 | `0x84` |
+| `0xFF` | p4 | `0xF` | PC | PC | no | none | `0x04` |

--- a/architecture/ebus_standard/README.md
+++ b/architecture/ebus_standard/README.md
@@ -47,6 +47,7 @@ Attribution: canonical plan
 | [`09-mcp-envelope.md`](./09-mcp-envelope.md) | M4 MCP envelope contract, deterministic `data_hash`, golden fixture discipline |
 | [`10-rpc-source-113.md`](./10-rpc-source-113.md) | M4 `rpc.invoke` gateway source byte invariant |
 | [`11-m4b-semantic-lock.md`](./11-m4b-semantic-lock.md) | M4B semantic lock of read & decode surfaces (envelope, error, safety_class, decode scaffold, catalog version) |
+| [`12-source-address-table.md`](./12-source-address-table.md) | SAS-01 source-address table v1, priority mapping, companion mapping, and hash contract |
 | [`13-responder-capability-signal.md`](./13-responder-capability-signal.md) | M4D normative lock of `meta.capabilities.responder` (shape, invariants I1-I8, fail-closed consumer rule, enum catalogue at v1.1, subtree version policy) |
 | [`14-transport-matrix-cross-reference.md`](./14-transport-matrix-cross-reference.md) | M6b pointer to the canonical transport matrix artifact in helianthus-ebusgateway (section pointers §3-§7, BENCH-REPLACE status) |
 

--- a/architecture/nm-discovery.md
+++ b/architecture/nm-discovery.md
@@ -3,6 +3,12 @@
 Status: Normative
 Plan reference: ebus-good-citizen-network-management.locked (M0/ISSUE-DOC-01)
 
+SAS-01 update: source-selection observation replaces Joiner warmup as the
+admission evidence stage. The only first-implementation pre-discovery
+source-validation active probe is bounded addressed `0x07/0x04`; `0x07/0xFE`
+Inquiry of Existence and `0x07/0xFF` Sign of Life are not startup admission
+validation probes.
+
 ## Purpose
 
 This document freezes the normative interpretation of the eBUS
@@ -125,7 +131,7 @@ When Helianthus does use `07 FE`, responses are fed into the same
 evidence pipeline as passive observations -- they do not bypass the
 normal promotion path.
 
-### 07 FF (QueryExistence Broadcast) -- Not Discovery
+### 07 FF (Sign of Life Broadcast) -- Not Discovery
 
 `07 FF` is a good-citizen existence signal that Helianthus may emit
 as an optional-later feature, with a cadence floor of >= 10 seconds
@@ -148,7 +154,7 @@ devices cannot skip stages.
 ### Pipeline Stages
 
 ```text
-1. Joiner warmup observation
+1. Source-selection observation
        |
        v
 2. Evidence buffer / suspect seeding
@@ -160,11 +166,10 @@ devices cannot skip stages.
 4. Target-configuration enrollment
 ```
 
-**Stage 1 -- Joiner warmup observation.** During transport join
-warmup, Helianthus observes bus traffic and collects evidence without
-promoting any device. This is a listen-only period where the gateway
-builds an initial picture of bus population without injecting any
-traffic of its own.
+**Stage 1 -- Source-selection observation.** During source-selection warmup,
+Helianthus observes bus traffic and collects evidence without promoting any
+device. This is a listen-only period where the gateway builds an initial
+picture of bus population without injecting any traffic of its own.
 
 **Stage 2 -- Evidence buffer / suspect seeding.** Passive
 observations create suspect entries. Each suspect accumulates

--- a/architecture/nm-model.md
+++ b/architecture/nm-model.md
@@ -3,6 +3,11 @@
 Status: Normative
 Plan reference: ebus-good-citizen-network-management.locked (M0/ISSUE-DOC-00)
 
+SAS-01 update: startup NM authority is the admitted
+`SourceAddressSelection` after `active_probe_passed`. Earlier references to
+join/rejoin or fixed local source are historical. During
+`DEGRADED_SOURCE_SELECTION`, Helianthus emits no NM traffic.
+
 ## Purpose
 
 This document freezes the normative interpretation of the eBUS Network
@@ -93,8 +98,9 @@ re-entering `NMInit`):
 1. **Process start.** Gateway process launches for the first time.
 2. **First successful local address-pair acquisition.** The gateway
    obtains a valid active local initiator address and its companion.
-3. **Completed join/rejoin after transport recovery.** Transport
-   reconnects after a disconnection event.
+3. **Completed source-selection admission or re-admission after transport
+   recovery.** Transport reconnects after a disconnection event and source
+   admission succeeds.
 4. **Explicit operator NM reset.** An operator or MCP tool issues a
    manual NM reset command.
 5. **Configuration changes invalidating target configuration.** The
@@ -154,13 +160,13 @@ wire presence.
 exists. Without an address, the gateway cannot construct a valid eBUS
 frame.
 
-For startup ordering on join-capable direct transports, Helianthus MUST
+For startup ordering on source-selection-capable direct transports, Helianthus MUST
 also satisfy the admission gate frozen in
 [startup-admission-and-discovery.md §2, "Startup Ordering Contract"](./startup-admission-and-discovery.md#startup-ordering-contract):
-passive reconstructor and Joiner warmup complete before any
+passive reconstructor and source-selection observation complete before any
 non-override active startup traffic, and semantic polling is released
-only after `semanticBootstrapReady` plus `{Joiner-success OR
-Override-set}`.
+only after `semanticBootstrapReady` plus active-probe-passed
+`SourceAddressSelection`.
 
 `FF 02` is payload-less before responder support is available. It
 serves as a partially interrogable failure signal: peers can observe
@@ -175,9 +181,9 @@ production.
 | Service ID | Name | Purpose | Notes |
 |---|---|---|---|
 | `FF 01` | NMState | Periodic NM state broadcast | Added after broadcast lane is proven stable |
-| `07 FF` | QueryExistence | Good-citizen existence signal | Cadence floor >= 10 seconds |
+| `07 FF` | Sign of Life | Good-citizen presence signal | Cadence floor >= 10 seconds |
 
-`07 FF` QueryExistence is a good-citizen signal announcing the
+`07 FF` Sign of Life is a good-citizen signal announcing the
 gateway's presence on the bus. The cadence floor of 10 seconds ensures
 the gateway does not contribute excessive bus load.
 
@@ -217,13 +223,14 @@ by its OSI Layer 7 role within the eBUS application layer.
 | `FF 05` | QueryNMState | Network management | Targeted |
 | `FF 06` | ReportNMState | Network management | Targeted |
 | `07 04` | Identification | Identification | Targeted |
-| `07 FE` | QueryExistence | Existence/presence | Broadcast |
-| `07 FF` | QueryExistence (broadcast) | Existence/presence | Broadcast |
+| `07 FE` | Inquiry of Existence | Existence/presence | Broadcast |
+| `07 FF` | Sign of Life | Presence signal | Broadcast |
 
 These services form a subset of the eBUS OSI Layer 7 application
 services. The NM services (`FF 00` through `FF 06`) manage topology
 state. The identification service (`07 04`) provides device identity.
-The existence services (`07 FE`, `07 FF`) provide presence detection.
+`07 FE` is Inquiry of Existence. `07 FF` is Sign of Life. Both can provide
+presence evidence, but they are distinct services.
 
 Within Helianthus, `07 FE` is used only for bounded active confirmation
 during discovery. It is never treated as a direct-answer NM query. See

--- a/architecture/nm-participant-policy.md
+++ b/architecture/nm-participant-policy.md
@@ -3,6 +3,13 @@
 Status: Normative
 Plan reference: ebus-good-citizen-network-management.locked (M0/ISSUE-DOC-02)
 
+SAS-01 update: local NM source authority is the admitted
+`SourceAddressSelection` after `active_probe_passed`. Earlier references to
+`JoinResult`, configured fallback, or re-admission are historical for the prior
+startup-admission plan. NM runtime must fail closed before admission and during
+`DEGRADED_SOURCE_SELECTION`; it must not emit `FF 00`, `FF 02`, or `0x07/0xFF`
+without an admitted source.
+
 ## Purpose
 
 This document freezes the numeric bus-load bounds, transport capability
@@ -22,22 +29,22 @@ initiator address and one companion target address. The pair is runtime
 state with provenance, not a literal constant. Provenance indicates how
 the pair was selected and from which source.
 
-### Preferred Source: JoinResult
+### Preferred Source: SourceAddressSelection
 
-On transports that support a join handshake, the canonical source is the
-transport join result:
+On transports that support source address selection admission, the canonical
+source is the gateway-owned selection that has passed the active admission
+probe:
 
-- **Initiator:** `JoinResult.Initiator`
-- **Companion target:** `JoinResult.CompanionTarget`
+- **Initiator:** `SourceAddressSelection.Source`
+- **Companion target:** `SourceAddressSelection.CompanionTarget`
 
-A completed join that yields a valid pair is the highest-confidence
-source. The ENH, ENS, UDP-plain, and TCP-plain transports are expected
-to support this path once their join protocols are implemented.
+An active-probe-passed selection is the only high-confidence source for
+gateway-originated NM traffic on ENH, ENS, UDP-plain, and TCP-plain.
 
 ### Fallback Source: Configured Policy
 
-On transports that do not support a join handshake (notably ebusd-tcp),
-the canonical source is operator configuration:
+On transports that do not support source-selection active validation (notably
+ebusd-tcp), the canonical source is operator configuration:
 
 - **Initiator:** configured local initiator address
 - **Companion target:** derived from the initiator per the eBUS
@@ -50,12 +57,12 @@ validated against the live bus before use.
 
 The active local address pair carries a provenance tag that records:
 
-- The source class (join-result or configured-fallback)
+- The source class (`active_probe_passed` or configured fallback)
 - The transport identity that produced the pair
 - A monotonic sequence number incremented on each address-pair change
 
 Provenance enables runtime code to distinguish high-confidence pairs
-from configured fallbacks and to detect stale references after a rejoin.
+from configured fallbacks and to detect stale references after re-admission.
 
 ## Init_NM and Transport Events
 
@@ -66,8 +73,8 @@ Helianthus enters the NMInit state on exactly these events:
 1. **Process start.** Gateway process begins execution.
 2. **First valid address pair.** First successful acquisition of a valid
    local address pair after process start.
-3. **Completed join or rejoin after transport recovery.** Transport
-   reconnects and a join handshake completes successfully.
+3. **Completed source-selection admission or re-admission after transport
+   recovery.** Transport reconnects and source admission succeeds.
 4. **Explicit operator-triggered NM reset.** An operator command
    requests NM reinitialization.
 5. **Configuration change invalidating the target configuration.**
@@ -77,9 +84,10 @@ Helianthus enters the NMInit state on exactly these events:
 Cross-reference: [nm-model.md](./nm-model.md) defines the NMInit,
 NMReset, and NMNormal state machine transitions.
 
-### Rejoin Semantics
+### Re-admission Semantics
 
-A rejoin that changes the active local address pair is NM-relevant. The
+A source-selection re-admission that changes the active local address pair is
+NM-relevant. The
 transition sequence is:
 
     NMInit --> NMReset --> NMNormal
@@ -87,15 +95,16 @@ transition sequence is:
 The previous address pair is discarded. All NM state derived from the
 old pair (including monitored-node timers) is invalidated.
 
-A rejoin that preserves the same address pair is NOT NM-relevant and
+A re-admission that preserves the same address pair is NOT NM-relevant and
 does not trigger a state transition.
 
-Joiner warmup observations seed evidence but do not promote devices
-directly into the monitored-node set.
+Source-selection observations seed evidence but do not promote devices directly
+into the monitored-node set.
 
 ### Transport Blindness
 
-When the transport disconnects without a completed rejoin:
+When the transport disconnects without a completed source-selection
+re-admission:
 
 - **self status:** transitions to NOK immediately.
 - **Remote-node cycle-time timers:** freeze. Timers do not advance
@@ -103,9 +112,9 @@ When the transport disconnects without a completed rejoin:
 - **NM-originated broadcasts:** suppressed. Any broadcast requiring a
   valid local initiator address is not emitted.
 
-A transport disconnect without a completed rejoin is NOT a fake NM
+A transport disconnect without a completed source-selection re-admission is NOT a fake NM
 reset. The NM state machine remains in its current state; it does not
-transition to NMInit until a rejoin completes.
+transition to NMInit until source admission succeeds.
 
 ## Self-Monitoring
 
@@ -160,12 +169,12 @@ Deferred until the broadcast lane is proven stable through operational
 experience with `FF 00` and `FF 02`. Not part of the first lock
 baseline.
 
-### 07 FF (QueryExistence) -- Optional-Later
+### 07 FF (Sign of Life) -- Optional-Later
 
 Deferred. Subject to the cadence floor defined in the Bus-Load Policy
 section below (minimum 10 seconds between successive broadcasts).
 
-`07 FF` is a broadcast (DST = `0xFE`) used for existence queries, not
+`07 FF` is a broadcast (DST = `0xFE`) used as a sign-of-life signal, not
 a targeted discovery probe. Cross-reference:
 [nm-discovery.md](./nm-discovery.md) defines the discovery pipeline and
 its relationship to NM.
@@ -222,7 +231,7 @@ measurement at implementation time.
 ### Sustained Load Budget
 
 Helianthus-originated NM traffic must not exceed **0.5% of bus
-capacity** outside of reset and rejoin windows.
+capacity** outside of reset and source-selection re-admission windows.
 
 This is a sustained average measured over a rolling window. The
 measurement window length is defined at implementation time but must be
@@ -231,9 +240,9 @@ at least 60 seconds.
 ### Burst Load Budget
 
 Helianthus-originated NM traffic must not exceed **2.0% of bus
-capacity** during reset and rejoin windows.
+capacity** during reset and source-selection re-admission windows.
 
-Reset and rejoin windows are bounded by the NMReset-to-NMNormal
+Reset and source-selection re-admission windows are bounded by the NMReset-to-NMNormal
 transition. Once the state machine enters NMNormal, the sustained
 budget applies.
 
@@ -259,7 +268,7 @@ this plan. Post-startup steady-state reverts to the separate
 ### 07 FF Cadence Floor
 
 A minimum of **10 seconds** must elapse between successive
-`07 FF` (QueryExistence) broadcasts originated by Helianthus,
+`07 FF` (Sign of Life) broadcasts originated by Helianthus,
 regardless of how many monitored nodes are pending existence
 confirmation.
 

--- a/architecture/startup-admission-and-discovery.md
+++ b/architecture/startup-admission-and-discovery.md
@@ -1,10 +1,38 @@
 # Startup Admission and Discovery Pipeline
 
-Status: Normative
+Status: Normative; source-selection semantics superseded by SAS-01
 Plan reference:
 [startup-admission-discovery-w17-26.locked/00-canonical.md](../../helianthus-execution-plans/startup-admission-discovery-w17-26.locked/00-canonical.md)
 (`Canonical-SHA256:
 345445f1cedfc21e6c35d6e0f21513979fbf7ff3a520978932f0dd82e65c1b3d`)
+
+SAS-01 update:
+`source-address-selection-admission.locked` supersedes this document wherever
+it describes `JoinBus`, `Joiner`, `JoinConfig`, `JoinResult`,
+`admission_path_selected`, forced selection, or fixed-source override as current
+startup authority. Those terms remain here only as history for the W17-26
+startup plan. Current startup admission is:
+
+```text
+observe -> source_address_select -> active_probe
+  -> persist/scan only on active_probe_passed
+  -> quarantine/exclude/reselect on probe failure
+  -> DEGRADED_SOURCE_SELECTION with zero Helianthus-originated eBUS traffic
+     when no candidate can be admitted
+```
+
+The admitted `SourceAddressSelection.Source` is the sole normal source
+authority for gateway-owned MCP, GraphQL, Portal, semantic, scheduler, poller,
+NM, and protocol-dispatch traffic. Exact operator source configuration maps to
+`explicit_validate_only`; it bypasses candidate search but not active
+validation. Persisted raw `source_addr.last` is migration input only and cannot
+override explicit configuration or current validation.
+
+The only first-implementation pre-discovery source-validation probe is a
+bounded addressed `0x07/0x04` read-only request against a configured or current
+positive target. Broadcast `0x07/0xFE`, `0x07/0xFF`, `0x0F`, NM, mutating
+services, memory writes, and full-range probes are not admission-validation
+traffic.
 
 ## Purpose
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -48,17 +48,35 @@ In direct-mode eBUS implementations (including Helianthus), initiator addresses 
 
 Addresses equal to `0xA9` (escape) or `0xAA` (SYN) are invalid in address positions.
 
-### Helianthus Initiator Join Strategy
+### Helianthus Source Address Selection
 
-When Helianthus must choose an initiator address on a live bus, it follows a low-disturbance join sequence:
+When Helianthus must choose an initiator address on a live bus, it performs
+source address selection plus gateway admission validation. It does not perform
+a protocol membership join.
 
-1. Passive listen warmup (default `5s`), collecting observed source and destination activity.
-2. Candidate selection from the valid 25-address initiator set.
-3. Default preference for higher addresses first (`F7, F3, F1, ...`) to keep lower-priority arbitration behavior. (`0xFF` is excluded from the default preference list because it may conflict with NACK signaling.)
-4. Companion-target heuristic: reject a candidate if `(initiator + 0x05)` appears active as a probable target source or is frequently addressed as destination traffic.
-5. Optional active discovery (`0x07 0xFE`) is disabled by default and bounded/rate-limited when enabled.
+The standard source-address table is frozen in
+[`architecture/ebus_standard/12-source-address-table.md`](../../architecture/ebus_standard/12-source-address-table.md).
+The default gateway candidate order is:
 
-If all 25 initiator addresses are observed as occupied, join fails by default with an explicit error. Force selection is opt-in.
+```text
+0xFF, 0x7F, 0x3F, 0x1F,
+0xF7, 0x77, 0x37, 0x17, 0x07,
+0x11, 0x31,
+0x00
+```
+
+This order is Helianthus policy. It is not the eBUS arbitration rank. On the
+wire, p0 / `0x0` outranks p1 / `0x1`, then p2 / `0x3`, p3 / `0x7`, and p4 /
+`0xF`; lower source byte wins only within otherwise equal contention.
+
+`0xFF` is a valid source address and maps to companion `0x04`. The `0xFF`
+NACK meaning applies only in ACK/NACK byte context.
+
+Before startup scan or any normal gateway-owned bus-reaching operation,
+gateway admission must actively validate the selected source and companion. A
+failed active probe quarantines/excludes that source and either tries the next
+candidate or enters `DEGRADED_SOURCE_SELECTION`, which emits no
+Helianthus-originated eBUS traffic.
 
 ## ACK/NACK Symbols
 
@@ -184,9 +202,10 @@ This section documents common discovery-style requests used to enumerate devices
 
 In BASV-style discovery orchestration, these standard functions are the protocol-level building blocks for presence refresh and identity probing.
 
-### QueryExistence (0x07 0xFE)
+### Inquiry of Existence (0x07 0xFE)
 
-QueryExistence is commonly used as a best-effort “who is present?” broadcast.
+Inquiry of Existence is commonly used as a best-effort “who is present?”
+broadcast.
 
 ```text
 Initiator telegram:
@@ -199,7 +218,13 @@ Initiator telegram:
 
 Notes:
 - Broadcast messages do not have a response telegram.
-- Some stacks (including ebusd) use QueryExistence as a trigger to refresh internal address state that can later be queried (e.g. via the ebusd TCP `info` command).
+- Some stacks (including ebusd) use Inquiry of Existence as a trigger to
+  refresh internal address state that can later be queried (e.g. via the ebusd
+  TCP `info` command).
+
+Helianthus source-selection admission does not use `0x07/0xFE` as its first
+startup validation probe. The admission probe is bounded addressed
+Identification (`0x07/0x04`) only.
 
 ### Identification Scan (0x07 0x04)
 

--- a/protocols/ebus-services/ebus-service-FFh.md
+++ b/protocols/ebus-services/ebus-service-FFh.md
@@ -13,7 +13,7 @@ Service `0xFF` carries all Network Management (NM) messages. NM enables safe ope
 
 NM is based on **indirect network management** (OSEK/VDX concept): it monitors the bus by observing cyclic application messages, adding **no extra bus load** for monitoring. NM implementation is optional. Target devices have no network management — each target is monitored by the initiator nodes that need it.
 
-> **Helianthus implementation:** For the Helianthus-specific NM model, see [`../../architecture/nm-model.md`](../../architecture/nm-model.md). **Caveat:** the architecture doc remaps official service IDs to different names and directions (e.g., `FF03`/`FF04` as resolution messages, `07FF` as QueryExistence). For wire-level service IDs, semantics, and payload formats, this document is authoritative; the architecture doc describes the Helianthus behavioral interpretation layered on top.
+> **Helianthus implementation:** For the Helianthus-specific NM model, see [`../../architecture/nm-model.md`](../../architecture/nm-model.md). **Caveat:** the architecture doc layers runtime behavior on top of wire-level service IDs and treats `07FF` as Sign of Life, distinct from `07FE` Inquiry of Existence. For wire-level service IDs, semantics, and payload formats, this document is authoritative; the architecture doc describes the Helianthus behavioral interpretation layered on top.
 
 ## Terminology
 

--- a/protocols/vaillant/ebus-vaillant-B503.md
+++ b/protocols/vaillant/ebus-vaillant-B503.md
@@ -527,7 +527,7 @@ Invoke(ctx context.Context, target byte, payload []byte) ([]byte, error)
 
 Normative obligations:
 
-- **Request shape.** `target` is the bus address of the destination slave
+- **Request shape.** `target` is the bus address of the destination responder
   (e.g. `0x08` for BAI00). `payload` is the L7 request body whose first
   two bytes are the §2 `(family, selector)` prefix (e.g. `00 01` for
   `Currenterror`, `01 01` for `Errorhistory`, `00 03` for the HMU

--- a/scripts/check_source_address_table_against_official_specs.py
+++ b/scripts/check_source_address_table_against_official_specs.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOC_PATH = REPO_ROOT / "architecture/ebus_standard/12-source-address-table.md"
+FIXTURE_PATH = REPO_ROOT / "tests/fixtures/source_address_table_official_v1.json"
+
+TABLE_VERSION = "ebus-source-address-table/v1"
+ANCHOR = "#ebus-source-address-table-v1"
+EXPECTED_TABLE_HASH = "e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103"
+
+TABLE_HEADER = (
+    "| Source | Priority index | Arbitration nibble | Official description summary | "
+    "Canonical description | Free-use | Recommended for | Companion |"
+)
+
+APPENDIX_REL = "Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md"
+SPEC12_EN_REL = "Spec_Prot_12_V1_3_1_E.en.md"
+SPEC12_SRC_REL = "SRC/Spec_Prot_12_V1_3_1_E.md"
+OFFICIAL_RELS = (APPENDIX_REL, SPEC12_EN_REL, SPEC12_SRC_REL)
+
+PRIORITY_TO_NIBBLE = {
+    0: "0x0",
+    1: "0x1",
+    2: "0x3",
+    3: "0x7",
+    4: "0xF",
+}
+
+EXPECTED_PRIORITY_SKETCH = [
+    ("Participant 1", "0000", "0000"),
+    ("Participant 2", "0001", "0000"),
+    ("Participant 3", "0011", "0000"),
+    ("Participant 4", "0111", "0000"),
+    ("Participant 5", "1111", "0000"),
+    ("Participant 6", "0000", "0001"),
+    ("Participant 7", "0001", "0001"),
+    ("Participant 24", "0111", "1111"),
+    ("Participant 25", "1111", "1111"),
+]
+
+
+class CheckError(Exception):
+    pass
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def read_text(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def split_markdown_row(line: str) -> list[str]:
+    if not line.startswith("|"):
+        raise CheckError(f"not a Markdown table row: {line!r}")
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def is_separator_row(line: str) -> bool:
+    body = line.strip().strip("|").strip()
+    return bool(body) and set(body) <= {"-", ":", "|", " "}
+
+
+def clean_cell(cell: str) -> str:
+    return cell.strip().strip("`").strip()
+
+
+def normalized_table_block(doc_text: str) -> str:
+    lines = doc_text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.rstrip() == TABLE_HEADER)
+    except StopIteration as exc:
+        raise CheckError("source-address table header not found") from exc
+
+    table_lines: list[str] = []
+    for line in lines[start:]:
+        if not line.startswith("|"):
+            break
+        table_lines.append(line.rstrip())
+
+    if len(table_lines) != 27:
+        raise CheckError(f"expected 27 table lines, found {len(table_lines)}")
+    return "\n".join(table_lines) + "\n"
+
+
+def parse_doc_rows(table_block: str) -> list[dict[str, Any]]:
+    lines = table_block.splitlines()
+    if lines[0] != TABLE_HEADER:
+        raise CheckError("source-address table header changed")
+    if not is_separator_row(lines[1]):
+        raise CheckError("source-address table separator row is invalid")
+
+    rows: list[dict[str, Any]] = []
+    for line in lines[2:]:
+        cells = split_markdown_row(line)
+        if len(cells) != 8:
+            raise CheckError(f"expected 8 cells in table row, got {len(cells)}: {line}")
+        rows.append(
+            {
+                "source": clean_cell(cells[0]),
+                "priority_index": cells[1],
+                "arbitration_nibble": clean_cell(cells[2]),
+                "official_description_summary": cells[3],
+                "canonical_description": cells[4],
+                "free_use": cells[5],
+                "recommended_for": cells[6],
+                "companion": clean_cell(cells[7]),
+            }
+        )
+
+    if len(rows) != 25:
+        raise CheckError(f"expected 25 source-address rows, found {len(rows)}")
+    return rows
+
+
+def load_fixture() -> dict[str, Any]:
+    try:
+        return json.loads(read_text(FIXTURE_PATH))
+    except FileNotFoundError as exc:
+        raise CheckError(f"fixture missing: {FIXTURE_PATH}") from exc
+
+
+def plain_description(raw_description: str) -> str:
+    desc = raw_description.replace("*", "").replace("`", "").strip()
+    desc = re.sub(r"\s*\([^)]*\)", "", desc).strip()
+    return re.sub(r"\s+", " ", desc)
+
+
+def official_summary(raw_description: str) -> str:
+    plain = plain_description(raw_description)
+    if not plain:
+        return "empty"
+    if "*" in raw_description:
+        return f"{plain} recommendation"
+    return plain
+
+
+def canonical_description(summary: str, free_use: str) -> str:
+    if free_use == "yes":
+        return "Not preallocated"
+    if summary == "PC/Modem":
+        return "PC/Modem"
+    if summary == "PC":
+        return "PC"
+    if summary == "Heating controller":
+        return "Heating regulator"
+    if summary.startswith("Heating circuit controller "):
+        return summary.replace("Heating circuit controller", "Heating circuit regulator", 1)
+    if summary == "Hand programmer / Remote control":
+        return "Handheld programmer / remote"
+    if summary == "Bus interface / Climate controller":
+        return "Bus interface / climate regulator"
+    if summary == "Bus interface":
+        return "Bus interface"
+    if summary.startswith("Burner controller "):
+        return summary.replace("Burner controller", "Combustion controller", 1)
+    if summary == "Clock module / Radio clock module":
+        return "Clock/radio-clock module"
+    raise CheckError(f"cannot derive canonical description for {summary!r}")
+
+
+def recommended_for(raw_description: str, free_use: str) -> str:
+    if free_use != "yes":
+        return "none"
+    plain = plain_description(raw_description)
+    if plain == "Heating controller":
+        return "Heating regulator"
+    if plain.startswith("Burner controller "):
+        return plain.replace("Burner controller", "Combustion controller", 1)
+    return "none"
+
+
+def normalize_address_token(token: str) -> str:
+    raw = clean_cell(token).upper()
+    if raw.endswith("H"):
+        raw = raw[:-1]
+    value = int(raw, 16)
+    if not 0 <= value <= 0xFF:
+        raise CheckError(f"address out of one-byte range: {token!r}")
+    return f"0x{value:02X}"
+
+
+def parse_official_address_table(appendix_text: str) -> list[dict[str, Any]]:
+    lines = appendix_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("| Address | Priority |"):
+            start = i
+            break
+    if start is None:
+        raise CheckError("official source-address table was not found")
+
+    rows: list[dict[str, Any]] = []
+    for line in lines[start + 2 :]:
+        if not line.startswith("|"):
+            break
+        cells = split_markdown_row(line)
+        if len(cells) < 4:
+            continue
+
+        source = normalize_address_token(cells[0])
+        source_value = int(source[2:], 16)
+        priority = int(cells[1])
+        free_use = "yes" if ("*" in cells[3] or not plain_description(cells[3])) else "no"
+        summary = official_summary(cells[3])
+        expected_nibble = PRIORITY_TO_NIBBLE.get(priority)
+        actual_nibble = f"0x{source_value & 0x0F:X}"
+        if actual_nibble != expected_nibble:
+            raise CheckError(
+                f"{source} priority p{priority} implies {expected_nibble}, got {actual_nibble}"
+            )
+
+        rows.append(
+            {
+                "source": source,
+                "priority_index": f"p{priority}",
+                "arbitration_nibble": actual_nibble,
+                "official_description_summary": summary,
+                "canonical_description": canonical_description(summary, free_use),
+                "free_use": free_use,
+                "recommended_for": recommended_for(cells[3], free_use),
+                "companion": f"0x{(source_value + 5) & 0xFF:02X}",
+            }
+        )
+
+    if len(rows) != 25:
+        raise CheckError(f"official source-address table has {len(rows)} rows, expected 25")
+    return rows
+
+
+def parse_priority_sketch(spec_text: str) -> list[tuple[str, str, str]]:
+    lines = spec_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("| Participant") and "Sub-Address" in line and "Priority Class" in line:
+            start = i
+            break
+    if start is None:
+        raise CheckError("priority/sub-address sketch table was not found")
+
+    rows: list[tuple[str, str, str]] = []
+    for line in lines[start + 2 :]:
+        if not line.startswith("|"):
+            break
+        cells = split_markdown_row(line)
+        if len(cells) != 3:
+            continue
+        if cells[0] == "...":
+            continue
+        rows.append((cells[0], cells[1], cells[2]))
+    return rows
+
+
+def validate_priority_sketch(spec_text: str, rel_path: str) -> None:
+    rows = parse_priority_sketch(spec_text)
+    for expected in EXPECTED_PRIORITY_SKETCH:
+        if expected not in rows:
+            raise CheckError(f"{rel_path}: priority sketch missing {expected}")
+
+
+def validate_companion_and_ack_context(spec_text: str) -> None:
+    legacy_responder = "sl" + "ave"
+    required_fragments = [
+        "`0x01` = `0x06`",
+        "address `0xFF`",
+        f"{legacy_responder}-address `0x04`",
+        "positive acknowledgement (`0x00`)",
+        "negative acknowledgement (`0xFF`)",
+    ]
+    for fragment in required_fragments:
+        if fragment not in spec_text:
+            raise CheckError(f"official companion/ACK context missing fragment: {fragment}")
+
+
+def validate_official_hashes(spec_dir: pathlib.Path, fixture: dict[str, Any]) -> None:
+    expected_files = fixture["source_files"]
+    for rel in OFFICIAL_RELS:
+        path = spec_dir / rel
+        if not path.exists():
+            raise CheckError(f"official spec file missing: {path}")
+        actual_hash = sha256_file(path)
+        expected_hash = expected_files[rel]["sha256"]
+        print(f"official_spec_sha256 {rel} {actual_hash}")
+        if actual_hash != expected_hash:
+            raise CheckError(
+                f"official spec hash drift for {rel}: expected {expected_hash}, got {actual_hash}"
+            )
+        actual_lines = read_text(path).splitlines()
+        for line_range, expected_excerpt in expected_files[rel].get("excerpts", {}).items():
+            start, end = (int(part) for part in line_range.split("-", 1))
+            actual_excerpt = "\n".join(actual_lines[start - 1 : end]) + "\n"
+            if actual_excerpt != expected_excerpt:
+                raise CheckError(f"official spec excerpt drift for {rel}:{line_range}")
+
+
+def expected_rows_from_official(spec_dir: pathlib.Path, fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    validate_official_hashes(spec_dir, fixture)
+
+    appendix_text = read_text(spec_dir / APPENDIX_REL)
+    spec12_en_text = read_text(spec_dir / SPEC12_EN_REL)
+    spec12_src_text = read_text(spec_dir / SPEC12_SRC_REL)
+
+    rows = parse_official_address_table(appendix_text)
+    validate_priority_sketch(spec12_en_text, SPEC12_EN_REL)
+    validate_priority_sketch(spec12_src_text, SPEC12_SRC_REL)
+    validate_companion_and_ack_context(spec12_en_text)
+
+    fixture_rows = fixture["rows"]
+    if rows != fixture_rows:
+        raise CheckError("official spec rows no longer match committed fixture")
+    return rows
+
+
+def expected_rows_from_fixture(fixture: dict[str, Any]) -> list[dict[str, Any]]:
+    source_files = fixture["source_files"]
+    try:
+        appendix_text = source_files[APPENDIX_REL]["excerpts"]["28-60"]
+        spec12_en_text = "\n".join(
+            source_files[SPEC12_EN_REL]["excerpts"][line_range]
+            for line_range in ("178-184", "254-256", "320-349", "471-478")
+        )
+        spec12_src_text = source_files[SPEC12_SRC_REL]["excerpts"]["320-349"]
+    except KeyError as exc:
+        raise CheckError(f"fixture missing exact official excerpt text: {exc}") from exc
+
+    rows = parse_official_address_table(appendix_text)
+    validate_priority_sketch(spec12_en_text, SPEC12_EN_REL)
+    validate_priority_sketch(spec12_src_text, SPEC12_SRC_REL)
+    validate_companion_and_ack_context(spec12_en_text)
+    if rows != fixture["rows"]:
+        raise CheckError("fixture rows do not match fixture official excerpts")
+    return rows
+
+
+def expected_rows(args: argparse.Namespace, fixture: dict[str, Any]) -> tuple[list[dict[str, Any]], str]:
+    if args.fixture_only:
+        print("official_spec_mode fixture-only")
+        return expected_rows_from_fixture(fixture), "fixture"
+
+    spec_dir_value = args.spec_dir or os.environ.get("HELIANTHUS_OFFICIAL_SPEC_DIR")
+    explicit = bool(spec_dir_value)
+    if spec_dir_value:
+        spec_dir = pathlib.Path(spec_dir_value).expanduser()
+    else:
+        spec_dir = REPO_ROOT.parent / "docs"
+
+    if spec_dir.exists():
+        return expected_rows_from_official(spec_dir, fixture), f"official:{spec_dir}"
+    if explicit:
+        raise CheckError(f"explicit official spec dir does not exist: {spec_dir}")
+
+    print("official_spec_mode fixture-only")
+    return expected_rows_from_fixture(fixture), "fixture"
+
+
+def compare_rows(actual: list[dict[str, Any]], expected: list[dict[str, Any]]) -> None:
+    if actual == expected:
+        return
+    for index, (got, want) in enumerate(zip(actual, expected), start=1):
+        if got != want:
+            source = want.get("source", got.get("source", f"row-{index}"))
+            for field_name in sorted(set(got) | set(want)):
+                if got.get(field_name) != want.get(field_name):
+                    raise CheckError(
+                        f"source-address row mismatch at row {index} source {source} "
+                        f"field {field_name}: expected {want.get(field_name)!r}, "
+                        f"got {got.get(field_name)!r}"
+                    )
+            raise CheckError(
+                "source-address row mismatch at row "
+                f"{index}: expected {json.dumps(want, sort_keys=True)}, "
+                f"got {json.dumps(got, sort_keys=True)}"
+            )
+    raise CheckError(f"row count mismatch: expected {len(expected)}, got {len(actual)}")
+
+
+def validate_doc_text(
+    doc_text: str,
+    expected: list[dict[str, Any]],
+    *,
+    check_hash: bool = True,
+) -> str:
+    if "## eBUS Source Address Table v1" not in doc_text:
+        raise CheckError("required heading for GitHub anchor is missing")
+    if f"Table anchor: `{ANCHOR}`" not in doc_text:
+        raise CheckError("required table anchor declaration is missing")
+    if f"Table version: `{TABLE_VERSION}`" not in doc_text:
+        raise CheckError("required table version declaration is missing")
+
+    table_block = normalized_table_block(doc_text)
+    table_hash = sha256_bytes(table_block.encode("utf-8"))
+    if check_hash and table_hash != EXPECTED_TABLE_HASH:
+        raise CheckError(
+            f"normalized Markdown table hash mismatch: expected {EXPECTED_TABLE_HASH}, got {table_hash}"
+        )
+
+    rows = parse_doc_rows(table_block)
+    compare_rows(rows, expected)
+    return table_hash
+
+
+def run_mutation_canary(doc_text: str, expected: list[dict[str, Any]]) -> None:
+    needle = "| `0x71` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0x76` |"
+    replacement = "| `0x71` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0x77` |"
+    if needle not in doc_text:
+        raise CheckError("mutation canary needle not found")
+    mutated = doc_text.replace(needle, replacement, 1)
+    try:
+        validate_doc_text(mutated, expected, check_hash=False)
+    except CheckError as exc:
+        print(f"mutation_canary rejected_mutated_table {exc}")
+        return
+    raise CheckError("mutation canary failed: mutated table was accepted")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate the eBUS source-address table against official specs."
+    )
+    parser.add_argument(
+        "--spec-dir",
+        help="Official spec directory. Defaults to HELIANTHUS_OFFICIAL_SPEC_DIR, then ../docs.",
+    )
+    parser.add_argument(
+        "--run-canary",
+        action="store_true",
+        help="Mutate one table cell in memory and require validation to fail.",
+    )
+    parser.add_argument(
+        "--fixture-only",
+        action="store_true",
+        help="Use the committed official-derived fixture even if local specs are available.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    fixture = load_fixture()
+
+    if fixture["table_version"] != TABLE_VERSION:
+        raise CheckError("fixture table version mismatch")
+    if fixture["normalized_table_hash"] != EXPECTED_TABLE_HASH:
+        raise CheckError("fixture table hash mismatch")
+
+    expected, mode = expected_rows(args, fixture)
+    doc_text = read_text(DOC_PATH)
+    table_hash = validate_doc_text(doc_text, expected)
+
+    if args.run_canary:
+        run_mutation_canary(doc_text, expected)
+
+    print(f"source_address_table_ok mode={mode} version={TABLE_VERSION} hash={table_hash}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except CheckError as exc:
+        print(f"source_address_table_error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -132,3 +132,49 @@ if failed:
     sys.exit(1)
 print("Private IPv4 gate passed.")
 PY
+
+echo "==> check eBUS source-address table"
+python3 scripts/check_source_address_table_against_official_specs.py --run-canary
+python3 -m pytest -q tests/test_source_address_table_checker.py
+
+echo "==> check NM 07FE/07FF service names"
+python3 - <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+checks = {
+    "architecture/nm-model.md": [
+        "`07 FE` | Inquiry of Existence",
+        "`07 FF` | Sign of Life",
+        "`07 FE` is Inquiry of Existence. `07 FF` is Sign of Life.",
+    ],
+    "architecture/nm-discovery.md": [
+        "### 07 FF (Sign of Life Broadcast) -- Not Discovery",
+    ],
+    "architecture/nm-participant-policy.md": [
+        "### 07 FF (Sign of Life) -- Optional-Later",
+        "`07 FF` (Sign of Life) broadcasts originated by Helianthus",
+    ],
+}
+
+for file_path, required_fragments in checks.items():
+    text = pathlib.Path(file_path).read_text(encoding="utf-8")
+    for fragment in required_fragments:
+        if fragment not in text:
+            print(f"{file_path}: missing required fragment: {fragment}", file=sys.stderr)
+            sys.exit(1)
+    forbidden = [
+        "07 FF (QueryExistence",
+        "`07 FF` | QueryExistence",
+        "`07 FF` QueryExistence",
+        "`07 FF` (QueryExistence)",
+    ]
+    for fragment in forbidden:
+        if fragment in text:
+            print(f"{file_path}: stale 07FF QueryExistence text: {fragment}", file=sys.stderr)
+            sys.exit(1)
+
+print("NM 07FE/07FF service name gate passed.")
+PY

--- a/tests/fixtures/source_address_table_official_v1.json
+++ b/tests/fixtures/source_address_table_official_v1.json
@@ -1,0 +1,293 @@
+{
+  "table_version": "ebus-source-address-table/v1",
+  "normalized_table_hash": "e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103",
+  "source_files": {
+    "Spec_Prot_7_V1_6_1_Anhang_Ausgabe_1.en.md": {
+      "sha256": "befb1f93d08a29722c0cd6476e6ed64245c9fd5a13267b7057178d4899bd05a5",
+      "line_ranges": [
+        "28-60",
+        "69-77"
+      ],
+      "excerpts": {
+        "28-60": "## 1 Assignment of Master Addresses\n\nThe following address allocation is prescribed for eBUS systems. Addresses not pre-assigned may be freely allocated for special system configurations.\n\n| Address | Priority | Master    | Description                                                       |\n|---------|----------|-----------|-------------------------------------------------------------------|\n| `00H`   | 0        | Master 1  | PC/Modem                                                          |\n| `10H`   | 0        | Master 2  | Heating controller (Heizungsregler)                               |\n| `30H`   | 0        | Master 3  | Heating circuit controller 1 (Heizkreisregler 1)                  |\n| `70H`   | 0        | Master 4  | Heating circuit controller 2 (Heizkreisregler 2)                  |\n| `F0H`   | 0        | Master 5  | Heating circuit controller 3 (Heizkreisregler 3)                  |\n| `01H`   | 1        | Master 6  | Hand programmer / Remote control (Handprogrammiergerät / Fernbedienung) |\n| `11H`   | 1        | Master 7  | Bus interface / Climate controller (Businterface / Klimaregler)   |\n| `31H`   | 1        | Master 8  | Bus interface (Businterface)                                      |\n| `71H`   | 1        | Master 9  | Heating controller (Heizungsregler)                               |\n| `F1H`   | 1        | Master 10 | Heating controller (Heizungsregler)                               |\n| `03H`   | 2        | Master 11 | Burner controller 1 (Feuerungsautomat 1)                          |\n| `13H`   | 2        | Master 12 | Burner controller 2 (Feuerungsautomat 2)                          |\n| `33H`   | 2        | Master 13 | Burner controller 3 (Feuerungsautomat 3)                          |\n| `73H`   | 2        | Master 14 | Burner controller 4 (Feuerungsautomat 4)                          |\n| `F3H`   | 2        | Master 15 | Burner controller 5 (Feuerungsautomat 5)                          |\n| `07H`   | 3        | Master 16 |                                                                   |\n| `17H`   | 3        | Master 17 | *Heating controller (Heizungsregler)*                             |\n| `37H`   | 3        | Master 18 | *Heating controller (Heizungsregler)*                             |\n| `77H`   | 3        | Master 19 | *Heating controller (Heizungsregler)*                             |\n| `F7H`   | 3        | Master 20 | *Heating controller (Heizungsregler)*                             |\n| `0FH`   | 4        | Master 21 | Clock module / Radio clock module (Uhrmodul / Funkuhrmodul)       |\n| `1FH`   | 4        | Master 22 | *Burner controller 6 (Feuerungsautomat 6)*                        |\n| `3FH`   | 4        | Master 23 | *Burner controller 7 (Feuerungsautomat 7)*                        |\n| `7FH`   | 4        | Master 24 | *Burner controller 8 (Feuerungsautomat 8)*                        |\n| `FFH`   | 4        | Master 25 | PC                                                                |\n\n> **Note:** The marked (italic) addresses are reserved for free use; the device types listed there are recommendations.\n",
+        "69-77": "## 2 Assignment of Slave Addresses\n\nThe slave addresses are listed in ascending address order. All grey-highlighted addresses must not be used as slave addresses, as they are reserved.\n\n| Address | Slave     | Description                                                                                             |\n|---------|-----------|---------------------------------------------------------------------------------------------------------|\n| `02H`   | Slave 1   |                                                                                                         |\n| `04H`   |           | Reserved for slave address of master address `FFH`                                                      |\n| `05H`   |           | Reserved for slave address of master address `00H`                                                      |\n"
+      }
+    },
+    "Spec_Prot_12_V1_3_1_E.en.md": {
+      "sha256": "e0073cb088ad617fbb7a953e67f318abc1188bf6b9e9fb309712beb590c4bafc",
+      "line_ranges": [
+        "178-184",
+        "254-256",
+        "320-349",
+        "471-478"
+      ],
+      "excerpts": {
+        "178-184": "#### 4.1.1 Master\n\nA master may start communication with other bus participants. It has to meet certain criteria, i.e. must carry out a bus-arbitration in order to control bus allocation in case of simultaneous bus access action by several masters.\n\nFurthermore, a master possesses a slave address. The slave address of a master results from the addition of a 5 to the master address. (Example: Slave-address of master `0x01` = `0x06`). Provided it supports them, it may be accessed also in slave mode.\n\n**SPECIAL CASE:** The master with the address `0xFF` receives by addition of 5 to its master-address the slave-address `0x04`.\n",
+        "254-256": "### 5.2 The Source Address [QQ]\n\nThe source address is the address of the master that is issuing a telegram. At the same time, it serves for arbitration of a bus conflict. A maximum of 25 source addresses are possible.\n",
+        "320-349": "#### 6.2.2 The Byte-oriented Arbitration Procedure\n\nIn a byte-oriented arbitration procedure the assignment of addresses is of utmost importance.\n\n##### 6.2.2.1 Priority Class and Sub Address\n\nThe address (the 8-bit word) is split in two 4-bit words. The address consists of a priority class (bit.0 to bit.3) and of a sub-address (bit.4 to bit.7). By this measure, it is possible to assign 25 master addresses.\n\n| Participant    | Sub-Address | Priority Class |\n|----------------|-------------|----------------|\n| Participant 1  | 0000        | 0000           |\n| Participant 2  | 0001        | 0000           |\n| Participant 3  | 0011        | 0000           |\n| Participant 4  | 0111        | 0000           |\n| Participant 5  | 1111        | 0000           |\n| Participant 6  | 0000        | 0001           |\n| Participant 7  | 0001        | 0001           |\n| ...            | ...         | ...            |\n| Participant 24 | 0111        | 1111           |\n| Participant 25 | 1111        | 1111           |\n\nAlso with these addresses, it may occur that none of the participants recognises itself, if several participants attempt to access the bus simultaneously. This is illustrated in the following diagram.\n\n##### 6.2.2.2 Collision Remedy\n\nIf several sending-authorised participants attempt to access the bus simultaneously and fail to recognise themselves, these participants withdraw from the bus. Subsequently, each of these participants checks if its address bit.0 to address bit.3 (priority class) matches with the received word. If this is the case, another access attempt will be started following the next SYN-symbol (AUTO-SYN).\n\nWhen the SYN-symbol is sent, all participants that have made no prior attempt to access the bus will recognise that only one word has been sent to the bus between two SYN-symbols. Through word sequence SYN-symbol / Address-symbol / AUTO-SYN-symbol, these participants will be barred and may only attempt to access the bus following the next SYN-symbol. The members that have recognised their priority class before that, will access the bus following the AUTO-SYN symbol.\n\nSince all participants that access the bus in this second round of arbitration have the same priority class, one of them will recognise itself and stay on the bus. The others that do not recognise their priority class will withdraw.\n",
+        "471-478": "### 7.3 Acknowledgement\n\nIf the receiver has received the message correctly, i.e. received CRC and calculated CRC match, it will send a positive acknowledgement (`0x00`). Should, however, the received CRC not match the calculated CRC, the receiver will send a negative acknowledgement (`0xFF`). Broadcast messages are not acknowledged.\n\n### 7.4 Repetition of a Telegram in Case of failed Transmission\n\nIn case a master or slave receives a negative acknowledgement, they will repeat their telegram. The telegram repetition must be generated before the AUTO-SYN facility initiates an AUTO-SYN symbol. To prevent blocking the bus by constant telegram repetitions, the repeat rate is set to the value 1, i.e. repetition is limited to one. In case a repeated message again does not get a positive acknowledgement, the respective telegram is rated as not sent.\n\n"
+      }
+    },
+    "SRC/Spec_Prot_12_V1_3_1_E.md": {
+      "sha256": "c3ed91075c078a78cf9c2141bdb920c416356bb93536c45605ba22eede876ceb",
+      "line_ranges": [
+        "320-349"
+      ],
+      "excerpts": {
+        "320-349": "#### 6.2.2 The Byte-oriented Arbitration Procedure\n\nIn a byte-oriented arbitration procedure the assignment of addresses is of utmost importance.\n\n##### 6.2.2.1 Priority Class and Sub Address\n\nThe address (the 8-bit word) is split in two 4-bit words. The address consists of a priority class (bit.0 to bit.3) and of a sub-address (bit.4 to bit.7). By this measure, it is possible to assign 25 master addresses.\n\n| Participant    | Sub-Address | Priority Class |\n|----------------|-------------|----------------|\n| Participant 1  | 0000        | 0000           |\n| Participant 2  | 0001        | 0000           |\n| Participant 3  | 0011        | 0000           |\n| Participant 4  | 0111        | 0000           |\n| Participant 5  | 1111        | 0000           |\n| Participant 6  | 0000        | 0001           |\n| Participant 7  | 0001        | 0001           |\n| ...            | ...         | ...            |\n| Participant 24 | 0111        | 1111           |\n| Participant 25 | 1111        | 1111           |\n\nAlso with these addresses, it may occur that none of the participants recognises itself, if several participants attempt to access the bus simultaneously. This is illustrated in the following diagram.\n\n##### 6.2.2.2 Collision Remedy\n\nIf several sending-authorised participants attempt to access the bus simultaneously and fail to recognise themselves, these participants withdraw from the bus. Subsequently, each of these participants checks if its address bit.0 to address bit.3 (priority class) matches with the received word. If this is the case, another access attempt will be started following the next SYN-symbol (AUTO-SYN).\n\nWhen the SYN-symbol is sent, all participants that have made no prior attempt to access the bus will recognise that only one word has been sent to the bus between two SYN-symbols. Through word sequence SYN-symbol / Address-symbol / AUTO-SYN-symbol, these participants will be barred and may only attempt to access the bus following the next SYN-symbol. The members that have recognised their priority class before that, will access the bus following the AUTO-SYN symbol.\n\nSince all participants that access the bus in this second round of arbitration have the same priority class, one of them will recognise itself and stay on the bus. The others that do not recognise their priority class will withdraw.\n"
+      }
+    }
+  },
+  "rows": [
+    {
+      "source": "0x00",
+      "priority_index": "p0",
+      "arbitration_nibble": "0x0",
+      "official_description_summary": "PC/Modem",
+      "canonical_description": "PC/Modem",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x05"
+    },
+    {
+      "source": "0x10",
+      "priority_index": "p0",
+      "arbitration_nibble": "0x0",
+      "official_description_summary": "Heating controller",
+      "canonical_description": "Heating regulator",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x15"
+    },
+    {
+      "source": "0x30",
+      "priority_index": "p0",
+      "arbitration_nibble": "0x0",
+      "official_description_summary": "Heating circuit controller 1",
+      "canonical_description": "Heating circuit regulator 1",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x35"
+    },
+    {
+      "source": "0x70",
+      "priority_index": "p0",
+      "arbitration_nibble": "0x0",
+      "official_description_summary": "Heating circuit controller 2",
+      "canonical_description": "Heating circuit regulator 2",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x75"
+    },
+    {
+      "source": "0xF0",
+      "priority_index": "p0",
+      "arbitration_nibble": "0x0",
+      "official_description_summary": "Heating circuit controller 3",
+      "canonical_description": "Heating circuit regulator 3",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0xF5"
+    },
+    {
+      "source": "0x01",
+      "priority_index": "p1",
+      "arbitration_nibble": "0x1",
+      "official_description_summary": "Hand programmer / Remote control",
+      "canonical_description": "Handheld programmer / remote",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x06"
+    },
+    {
+      "source": "0x11",
+      "priority_index": "p1",
+      "arbitration_nibble": "0x1",
+      "official_description_summary": "Bus interface / Climate controller",
+      "canonical_description": "Bus interface / climate regulator",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x16"
+    },
+    {
+      "source": "0x31",
+      "priority_index": "p1",
+      "arbitration_nibble": "0x1",
+      "official_description_summary": "Bus interface",
+      "canonical_description": "Bus interface",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x36"
+    },
+    {
+      "source": "0x71",
+      "priority_index": "p1",
+      "arbitration_nibble": "0x1",
+      "official_description_summary": "Heating controller",
+      "canonical_description": "Heating regulator",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x76"
+    },
+    {
+      "source": "0xF1",
+      "priority_index": "p1",
+      "arbitration_nibble": "0x1",
+      "official_description_summary": "Heating controller",
+      "canonical_description": "Heating regulator",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0xF6"
+    },
+    {
+      "source": "0x03",
+      "priority_index": "p2",
+      "arbitration_nibble": "0x3",
+      "official_description_summary": "Burner controller 1",
+      "canonical_description": "Combustion controller 1",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x08"
+    },
+    {
+      "source": "0x13",
+      "priority_index": "p2",
+      "arbitration_nibble": "0x3",
+      "official_description_summary": "Burner controller 2",
+      "canonical_description": "Combustion controller 2",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x18"
+    },
+    {
+      "source": "0x33",
+      "priority_index": "p2",
+      "arbitration_nibble": "0x3",
+      "official_description_summary": "Burner controller 3",
+      "canonical_description": "Combustion controller 3",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x38"
+    },
+    {
+      "source": "0x73",
+      "priority_index": "p2",
+      "arbitration_nibble": "0x3",
+      "official_description_summary": "Burner controller 4",
+      "canonical_description": "Combustion controller 4",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x78"
+    },
+    {
+      "source": "0xF3",
+      "priority_index": "p2",
+      "arbitration_nibble": "0x3",
+      "official_description_summary": "Burner controller 5",
+      "canonical_description": "Combustion controller 5",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0xF8"
+    },
+    {
+      "source": "0x07",
+      "priority_index": "p3",
+      "arbitration_nibble": "0x7",
+      "official_description_summary": "empty",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "none",
+      "companion": "0x0C"
+    },
+    {
+      "source": "0x17",
+      "priority_index": "p3",
+      "arbitration_nibble": "0x7",
+      "official_description_summary": "Heating controller recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Heating regulator",
+      "companion": "0x1C"
+    },
+    {
+      "source": "0x37",
+      "priority_index": "p3",
+      "arbitration_nibble": "0x7",
+      "official_description_summary": "Heating controller recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Heating regulator",
+      "companion": "0x3C"
+    },
+    {
+      "source": "0x77",
+      "priority_index": "p3",
+      "arbitration_nibble": "0x7",
+      "official_description_summary": "Heating controller recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Heating regulator",
+      "companion": "0x7C"
+    },
+    {
+      "source": "0xF7",
+      "priority_index": "p3",
+      "arbitration_nibble": "0x7",
+      "official_description_summary": "Heating controller recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Heating regulator",
+      "companion": "0xFC"
+    },
+    {
+      "source": "0x0F",
+      "priority_index": "p4",
+      "arbitration_nibble": "0xF",
+      "official_description_summary": "Clock module / Radio clock module",
+      "canonical_description": "Clock/radio-clock module",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x14"
+    },
+    {
+      "source": "0x1F",
+      "priority_index": "p4",
+      "arbitration_nibble": "0xF",
+      "official_description_summary": "Burner controller 6 recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Combustion controller 6",
+      "companion": "0x24"
+    },
+    {
+      "source": "0x3F",
+      "priority_index": "p4",
+      "arbitration_nibble": "0xF",
+      "official_description_summary": "Burner controller 7 recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Combustion controller 7",
+      "companion": "0x44"
+    },
+    {
+      "source": "0x7F",
+      "priority_index": "p4",
+      "arbitration_nibble": "0xF",
+      "official_description_summary": "Burner controller 8 recommendation",
+      "canonical_description": "Not preallocated",
+      "free_use": "yes",
+      "recommended_for": "Combustion controller 8",
+      "companion": "0x84"
+    },
+    {
+      "source": "0xFF",
+      "priority_index": "p4",
+      "arbitration_nibble": "0xF",
+      "official_description_summary": "PC",
+      "canonical_description": "PC",
+      "free_use": "no",
+      "recommended_for": "none",
+      "companion": "0x04"
+    }
+  ]
+}

--- a/tests/test_source_address_table_checker.py
+++ b/tests/test_source_address_table_checker.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CHECKER_PATH = REPO_ROOT / "scripts/check_source_address_table_against_official_specs.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("source_address_checker", CHECKER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_source_address_table_mutation_canary() -> None:
+    checker = load_checker()
+    fixture = checker.load_fixture()
+    expected = checker.expected_rows_from_fixture(fixture)
+    doc_text = checker.read_text(checker.DOC_PATH)
+    mutated = doc_text.replace(
+        "| `0x71` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0x76` |",
+        "| `0x71` | p1 | `0x1` | Heating controller | Heating regulator | no | none | `0x77` |",
+        1,
+    )
+
+    with pytest.raises(checker.CheckError) as excinfo:
+        checker.validate_doc_text(mutated, expected, check_hash=False)
+
+    message = str(excinfo.value)
+    assert "row 9" in message
+    assert "source 0x71" in message
+    assert "field companion" in message
+    assert "expected '0x76'" in message
+    assert "got '0x77'" in message


### PR DESCRIPTION
## What
Implements SAS-01/M1 docs source address selection for cruise-run Project-Helianthus/helianthus-execution-plans#22 and issue #290.

## Why
Freezes the docs-owned eBUS source address table and supersedes stale join/fixed-source docs before ebusgo and gateway implementation milestones consume the contract.

## Key Changes
- Adds source address table v1 with anchor `#ebus-source-address-table-v1`, version `ebus-source-address-table/v1`, and normalized hash `e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103`.
- Adds non-self-ratifying official-spec fixture with exact excerpt text, source hashes, line provenance, fixture-only derivation, and mutation canary.
- Supersedes stale Join-era/fixed `0x71` docs with admitted-source authority, `0xFF -> 0x04`, `0x07FE` vs `0x07FF`, and degraded zero-traffic semantics.
- Updates docs CI to run the repo-local CI script and installs pytest dependencies in GitHub Actions.
- Includes one semantic-no-op B503 terminology gate unblocker from current main: `destination slave` -> `destination responder`.

## Verification
- `./scripts/ci_local.sh` passed on `eda6c9c1b827a95f4712300d63eaf3fb8d9181d0`
- `ci/local` commit status posted for `eda6c9c1b827a95f4712300d63eaf3fb8d9181d0`
- Fresh gpt-5.5-xhigh adversarial review loop reached `NO FINDINGS`

Tracks Project-Helianthus/helianthus-execution-plans#22.
Closes #290.