### PR TITLE
SAS-02A: Remove legacy gentle join deployment wording

### DIFF
--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -80,8 +80,8 @@ For ebusd command syntax and response framing details, see `protocols/ebusd-tcp.
 
 ### Source-address behavior
 
-- `-source-addr auto` (or `-source-addr 0x00`) enables **gentle-join** behavior with proxy-mediated ENS/ENH/UDP-plain/TCP-plain flows.
-- In gentle-join mode, Helianthus asks the proxy to select a free initiator dynamically instead of pinning a fixed address.
+- `-source-addr auto` delegates to the gateway default source-selection policy. The gateway selects and validates an admitted source before any normal Helianthus-originated bus traffic.
+- Legacy `source_addr.last` files are rollback/migration input only. They must not be promoted into active source authority before gateway validation.
 - `-source-addr 0x31` should be avoided when `ebusd` is also active, because `0x31` is `ebusd`'s common default initiator.
 - With `-transport ebusd-tcp`, source selection only affects ebusd command parameters; the on-wire initiator is still ebusd's own bus identity.
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -137,6 +137,48 @@ echo "==> check eBUS source-address table"
 python3 scripts/check_source_address_table_against_official_specs.py --run-canary
 python3 -m pytest -q tests/test_source_address_table_checker.py
 
+echo "==> check deployment source-address wording"
+python3 - <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+path = pathlib.Path("deployment/full-stack.md")
+text = path.read_text(encoding="utf-8")
+lower = text.lower()
+
+forbidden = [
+    "gentle-join",
+    "gentle join",
+    "enables **gentle-join**",
+    "asks the proxy to select a free initiator",
+    "reuses the persisted source address",
+    "promote source_addr.last",
+]
+required = [
+    "gateway default source-selection policy",
+    "selects and validates an admitted source",
+    "rollback/migration input only",
+    "must not be promoted into active source authority",
+]
+
+failed = False
+for phrase in forbidden:
+    if phrase in lower:
+        print(f"{path}: legacy source-address wording remains: {phrase}", file=sys.stderr)
+        failed = True
+
+for phrase in required:
+    if phrase not in lower:
+        print(f"{path}: required source-address wording missing: {phrase}", file=sys.stderr)
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("Deployment source-address wording gate passed.")
+PY
+
 echo "==> check NM 07FE/07FF service names"
 python3 - <<'PY'
 from __future__ import annotations


### PR DESCRIPTION
## What
Remove stale deployment guidance that said `-source-addr auto` enables gentle-join behavior.

## Why
This is a companion docs correction for Project-Helianthus/helianthus-ha-addon#121 and the source-address selection/admission cruise run Project-Helianthus/helianthus-execution-plans#22. The HA add-on wrapper no longer promotes `source_addr.last` into active authority; deployment docs must describe gateway default source-selection and rollback-only legacy state instead of join-era behavior.

## Acceptance Criteria
- [x] Deployment docs no longer claim `-source-addr auto` enables gentle-join
- [x] Deployment docs describe gateway default source-selection policy
- [x] Deployment docs state legacy source state is rollback/migration input only
- [x] Unit tests cover the implemented code
- [x] CI green
- [x] Smoke test required: NO

## Dependencies
- Companion to Project-Helianthus/helianthus-ha-addon#121
- Tracks Project-Helianthus/helianthus-execution-plans#22

## Validation
- `PYTHONDONTWRITEBYTECODE=1 ./scripts/ci_local.sh`