### PR TITLE
SAS-07: clean up source selection public docs

### DIFF
--- a/api/graphql.md
+++ b/api/graphql.md
@@ -122,6 +122,10 @@ Current value/encoding rules:
 
 - GraphQL names are camelCase (`activationCounts`, `freshnessClasses`,
   `directApplyEligibilityClasses`, `shadowingEnabled`).
+- Source-selection admission status is the explicit SAS M4 exception frozen by
+  the gateway schema: consumers query `busSummary.status.bus_admission` and
+  `bus_admission.source_selection`. The old `busAdmission` compatibility alias
+  is intentionally absent.
 - `freshnessClasses`, `directApplyEligibilityClasses`, `inventory.stateClasses`,
   `inventory.pinClasses`, `activationCounts.sourceClasses`, and
   `degraded.reasons` are non-null lists.
@@ -181,9 +185,40 @@ type BusSummary {
 type BusObservabilityStatus {
   transportClass: String!
   capability: BusObservabilityCapability!
+  bus_admission: BusAdmission
   warmup: BusObservabilityWarmup!
   timingQuality: BusObservabilityTimingQuality!
   degraded: BusObservabilityDegraded!
+}
+
+type BusAdmission {
+  source_selection: BusAdmissionSourceSelection
+}
+
+type BusAdmissionSourceSelection {
+  state: String!
+  outcome: String!
+  selected_source: Int
+  companion_target: Int
+  reason: String
+  active_probe: BusAdmissionActiveProbe
+  retryable: Boolean!
+  automatic_retry_scheduled: Boolean!
+  next_action: String
+  last_successful_source: Int
+  rejected_candidates: [BusAdmissionRejectedCandidate!]!
+}
+
+type BusAdmissionActiveProbe {
+  target: Int
+  status: String!
+}
+
+type BusAdmissionRejectedCandidate {
+  source: Int!
+  companion_target: Int
+  reason: String!
+  retryable: Boolean!
 }
 
 type BusObservabilityCapability {

--- a/api/source-selection-migration.md
+++ b/api/source-selection-migration.md
@@ -1,0 +1,47 @@
+# Source-Selection Public API Migration
+
+Status: Normative for the SAS M4 cleanup cycle.
+
+This page records the public naming cleanup from startup-admission terminology
+to source-selection terminology. The behavioral authority is unchanged:
+normal Helianthus-owned paths use only the active-probe-passed source selected
+by the gateway. Transport-specific diagnostics may use a caller supplied source
+only for one explicit request and must not mutate gateway source authority.
+
+## Migration Matrix
+
+| Old public name | New public name | Required consumer action |
+| --- | --- | --- |
+| `admission_path_selected` | `source_selection.mode` | Read the nested source-selection mode instead of the legacy flat field. |
+| `join` mode | `source_selection` mode | Treat this as gateway automatic source selection plus validation, not an eBUS protocol membership operation. |
+| `override` mode | `explicit_validate_only` mode | Treat exact configured source as validation-only; candidate search is bypassed but active validation remains mandatory. |
+| `startup_admission_degraded_total` | `startup_source_selection_degraded_total` | Rename metrics dashboards and alert queries. |
+| `startup_admission_state` | `startup_source_selection_state` | Rename metrics dashboards and alert queries. |
+| `startup_admission_override_active` | `startup_source_selection_explicit_validate_only_active` | Track exact-source validation mode instead of legacy override wording. |
+| `startup_admission_warmup_events_seen` | `startup_source_selection_observed_events_seen` | Track passive observation evidence collected before active validation. |
+| `startup_admission_warmup_cycles_total` | `startup_source_selection_cycles_total` | Track source-selection cycles. |
+| `startup_admission_override_bypass_total` | `startup_source_selection_explicit_validate_only_total` | Track exact-source validation cycles. |
+| `startup_admission_override_conflict_detected` | `startup_source_selection_explicit_conflict_detected` | Track advisory disagreement for exact-source validation. |
+| `startup_admission_degraded_escalated` | `startup_source_selection_degraded_escalated` | Rename degraded escalation flag. |
+| `startup_admission_degraded_since_ms` | `startup_source_selection_degraded_since_ms` | Rename degraded entry timestamp. |
+| `startup_admission_consecutive_rejoin_failures` | `startup_source_selection_consecutive_failures` | Track failed reselection or validation cycles without protocol rejoin wording. |
+| `startup_admission_degraded_cumulative_ms` | `startup_source_selection_degraded_cumulative_ms` | Rename degraded cumulative duration. |
+
+## Consumer Rules
+
+- MCP, GraphQL, Portal, semantic pollers, schedulers, and gateway-owned NM
+  runtime must use the admitted active source selected by the gateway.
+- Portal explorer is a gateway-owned path and must not provide its own source
+  address.
+- Transport-specific MCP diagnostics may accept an explicit source address for
+  that request only. They must label the request as a diagnostic override and
+  must not change the gateway's active source.
+- External proxy clients are separate transport sessions. They may choose their
+  own source address according to their own protocol handling and adapter-mux
+  lease.
+
+## Removed Compatibility Surface
+
+The M4 cleanup intentionally removes legacy camelCase and startup-admission
+aliases from public API surfaces. Consumers must use snake_case field names and
+source-selection terminology.

--- a/api/source-selection-migration.md
+++ b/api/source-selection-migration.md
@@ -8,7 +8,7 @@ normal Helianthus-owned paths use only the active-probe-passed source selected
 by the gateway. Transport-specific diagnostics may use a caller supplied source
 only for one explicit request and must not mutate gateway source authority.
 
-## Migration Matrix
+## Artifact And MCP JSON Migration Matrix
 
 | Old public name | New public name | Required consumer action |
 | --- | --- | --- |
@@ -28,6 +28,14 @@ only for one explicit request and must not mutate gateway source authority.
 | `startup_admission_degraded_since_ms` | `startup_source_selection_degraded_since_ms` | Rename degraded entry timestamp. |
 | `startup_admission_consecutive_rejoin_failures` | `startup_source_selection_consecutive_failures` | Track failed reselection or validation cycles without protocol rejoin wording. |
 | `startup_admission_degraded_cumulative_ms` | `startup_source_selection_degraded_cumulative_ms` | Rename degraded cumulative duration. |
+
+## GraphQL Migration
+
+GraphQL does not expose `source_selection.mode`. Gateway GraphQL consumers that
+previously queried the removed `busAdmission` compatibility alias must query
+`busSummary.status.bus_admission.source_selection` instead and use the fields
+defined in [`graphql.md`](./graphql.md), especially `state`, `outcome`,
+`selected_source`, `companion_target`, and `reason`.
 
 ## Consumer Rules
 

--- a/api/source-selection-migration.md
+++ b/api/source-selection-migration.md
@@ -15,13 +15,15 @@ only for one explicit request and must not mutate gateway source authority.
 | `admission_path_selected` | `source_selection.mode` | Read the nested source-selection mode instead of the legacy flat field. |
 | `join` mode | `source_selection` mode | Treat this as gateway automatic source selection plus validation, not an eBUS protocol membership operation. |
 | `override` mode | `explicit_validate_only` mode | Treat exact configured source as validation-only; candidate search is bypassed but active validation remains mandatory. |
+| `degraded_transport_blind` mode | `degraded_transport_blind` mode under `source_selection.mode` | Preserve the degraded classification; only the field path changes. |
+| `degraded_no_events` mode | `degraded_no_events` mode under `source_selection.mode` | Preserve the degraded classification; only the field path changes. |
 | `startup_admission_degraded_total` | `startup_source_selection_degraded_total` | Rename metrics dashboards and alert queries. |
 | `startup_admission_state` | `startup_source_selection_state` | Rename metrics dashboards and alert queries. |
-| `startup_admission_override_active` | `startup_source_selection_explicit_validate_only_active` | Track exact-source validation mode instead of legacy override wording. |
-| `startup_admission_warmup_events_seen` | `startup_source_selection_observed_events_seen` | Track passive observation evidence collected before active validation. |
-| `startup_admission_warmup_cycles_total` | `startup_source_selection_cycles_total` | Track source-selection cycles. |
+| `startup_admission_override_active` | `startup_source_selection_explicit_source_active` | Track exact-source validation mode instead of legacy override wording. |
+| `startup_admission_warmup_events_seen` | `startup_source_selection_warmup_events_seen` | Track passive observation evidence collected before active validation. |
+| `startup_admission_warmup_cycles_total` | `startup_source_selection_warmup_cycles_total` | Track source-selection cycles. |
 | `startup_admission_override_bypass_total` | `startup_source_selection_explicit_validate_only_total` | Track exact-source validation cycles. |
-| `startup_admission_override_conflict_detected` | `startup_source_selection_explicit_conflict_detected` | Track advisory disagreement for exact-source validation. |
+| `startup_admission_override_conflict_detected` | `startup_source_selection_explicit_source_conflict_detected` | Track advisory disagreement for exact-source validation. |
 | `startup_admission_degraded_escalated` | `startup_source_selection_degraded_escalated` | Rename degraded escalation flag. |
 | `startup_admission_degraded_since_ms` | `startup_source_selection_degraded_since_ms` | Rename degraded entry timestamp. |
 | `startup_admission_consecutive_rejoin_failures` | `startup_source_selection_consecutive_failures` | Track failed reselection or validation cycles without protocol rejoin wording. |
@@ -31,6 +33,10 @@ only for one explicit request and must not mutate gateway source authority.
 
 - MCP, GraphQL, Portal, semantic pollers, schedulers, and gateway-owned NM
   runtime must use the admitted active source selected by the gateway.
+- GraphQL keeps its existing camelCase convention outside this narrow source-
+  selection status surface. For this migration, the gateway schema exposes
+  `busSummary.status.bus_admission.source_selection`; the removed compatibility
+  alias is `busAdmission`.
 - Portal explorer is a gateway-owned path and must not provide its own source
   address.
 - Transport-specific MCP diagnostics may accept an explicit source address for
@@ -43,5 +49,7 @@ only for one explicit request and must not mutate gateway source authority.
 ## Removed Compatibility Surface
 
 The M4 cleanup intentionally removes legacy camelCase and startup-admission
-aliases from public API surfaces. Consumers must use snake_case field names and
-source-selection terminology.
+aliases from source-selection admission/status public API surfaces. Consumers
+must use source-selection terminology and the field casing defined by each
+surface's current schema. This page does not rename unrelated GraphQL fields
+that remain camelCase under `api/graphql.md`.

--- a/api/source-selection-migration.md
+++ b/api/source-selection-migration.md
@@ -23,7 +23,7 @@ only for one explicit request and must not mutate gateway source authority.
 | `startup_admission_warmup_events_seen` | `startup_source_selection_warmup_events_seen` | Track passive observation evidence collected before active validation. |
 | `startup_admission_warmup_cycles_total` | `startup_source_selection_warmup_cycles_total` | Track source-selection cycles. |
 | `startup_admission_override_bypass_total` | `startup_source_selection_explicit_validate_only_total` | Track exact-source validation cycles. |
-| `startup_admission_override_conflict_detected` | `startup_source_selection_explicit_source_conflict_detected` | Track advisory disagreement for exact-source validation. |
+| `startup_admission_override_conflict_detected` | `startup_source_selection_explicit_source_conflict_detected` | Track exact-source validation conflict. |
 | `startup_admission_degraded_escalated` | `startup_source_selection_degraded_escalated` | Rename degraded escalation flag. |
 | `startup_admission_degraded_since_ms` | `startup_source_selection_degraded_since_ms` | Rename degraded entry timestamp. |
 | `startup_admission_consecutive_rejoin_failures` | `startup_source_selection_consecutive_failures` | Track failed reselection or validation cycles without protocol rejoin wording. |

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -268,7 +268,7 @@ and avoid known source/companion collisions.
 - Exact source configuration uses `explicit_validate_only`: no candidate
   search, but active validation remains mandatory.
 - The only first-implementation active validation probe is bounded addressed
-  `0x07/0x04`; `0x07/0xFE` is not a startup admission probe.
+  `0x07/0x04`; `0x07/0xFE` is not a startup source-selection validation probe.
 - If no source passes validation, Helianthus enters
   `DEGRADED_SOURCE_SELECTION` and emits no Helianthus-originated eBUS traffic.
 
@@ -289,10 +289,10 @@ without pretending there is a protocol join handshake.
   - matching frame: treat as local echo, no collision event,
   - non-matching frame: mark collision as foreign same-source.
 - If runtime is in muted/listen-only mode, any `SRC == active initiator` frame is treated as collision.
-- After rejoin (initiator change), ignore frames from the previous initiator during a grace window (default `750ms`) to avoid delayed-echo false positives.
+- After an initiator source change, ignore frames from the previous initiator during a grace window (default `750ms`) to avoid delayed-echo false positives.
 - While collision state is active, new writes fail fast with an explicit arbitration-failed error classification.
 
-**Consequences:** Collision state becomes deterministic and observable, upper layers can immediately stop unsafe writes, and rejoin transitions remain stable under delayed bus echoes.
+**Consequences:** Collision state becomes deterministic and observable, upper layers can immediately stop unsafe writes, and initiator source transitions remain stable under delayed bus echoes.
 
 ## ADR-020: Read scheduler coalescing with state/config refresh windows
 

--- a/architecture/ebus_standard/12-source-address-table.md
+++ b/architecture/ebus_standard/12-source-address-table.md
@@ -85,24 +85,25 @@ bypassed, but the selected source and companion must still pass availability
 and active-probe validation before any normal gateway-owned bus-reaching path
 can use them.
 
-## Startup Admission Boundary
+## Startup Source-Selection Boundary
 
 `helianthus-ebusgo` owns the reusable `SourceAddressSelector` mechanics and
-the static table constants. `helianthus-ebusgateway` owns startup admission:
-active probe, retry/quarantine, persistence metadata, operator recovery
-surfaces, and admission status. `helianthus-ebusreg` remains admission-agnostic
-and consumes only the source byte it is given.
+the static table constants. `helianthus-ebusgateway` owns startup
+source-selection validation: active probe, retry/quarantine, persistence
+metadata, operator recovery surfaces, and source-selection status.
+`helianthus-ebusreg` remains source-selection-agnostic and consumes only the
+source byte it is given.
 
-Normal gateway-owned operations use only the admitted
+Normal gateway-owned operations use only
 `SourceAddressSelection.Source` after `active_probe_passed`. This includes MCP,
 GraphQL, Portal explorer, semantic pollers/writers, schedulers, NM runtime, and
 gateway-internal protocol dispatch. A redundant caller-provided source matching
-the admitted source may be accepted as diagnostic input; a nonmatching source
-is rejected on normal gateway-owned paths.
+the active-probe-passed source may be accepted as diagnostic input; a
+nonmatching source is rejected on normal gateway-owned paths.
 
-Only transport-specific diagnostic MCP requests may use a non-admitted source,
+Only transport-specific diagnostic MCP requests may use a non-selected source,
 and only for one audited, non-persistent request that does not mutate the
-admitted source.
+active-probe-passed source.
 
 `DEGRADED_SOURCE_SELECTION` is fail-closed. While it is active, Helianthus
 originates no eBUS traffic: no scan, semantic polling, MCP/GraphQL bus invoke,
@@ -110,10 +111,14 @@ NM `FF 00`/`FF 02`, `0x07/0xFF`, or companion responder activity.
 
 The only first-implementation pre-discovery validation probe is addressed
 `0x07/0x04`, classified as `read_only_bus_load`, against a configured or
-current bounded positive target. Startup admission must not use broadcast
-`0x07/0xFE`, `0x0F` test commands, NM services, mutating services, memory
-writes, full-range probes, SYN/ESC/broadcast destinations, the selected source,
-or the selected companion as a validation target.
+current bounded positive target. Startup source-selection validation must not
+use broadcast `0x07/0xFE`, `0x0F` test commands, NM services, mutating
+services, memory writes, full-range probes, SYN/ESC/broadcast destinations, the
+selected source, or the selected companion as a validation target.
+
+The public API migration matrix for these source-selection status and source
+authority changes is maintained in
+[`api/source-selection-migration.md`](../../api/source-selection-migration.md).
 
 ## Hash Contract
 

--- a/architecture/nm-model.md
+++ b/architecture/nm-model.md
@@ -3,9 +3,9 @@
 Status: Normative
 Plan reference: ebus-good-citizen-network-management.locked (M0/ISSUE-DOC-00)
 
-SAS-01 update: startup NM authority is the admitted
-`SourceAddressSelection` after `active_probe_passed`. Earlier references to
-join/rejoin or fixed local source are historical. During
+SAS-01 update: startup NM authority is
+`SourceAddressSelection.Source` after `active_probe_passed`. Earlier references to
+protocol membership or fixed local source are historical. During
 `DEGRADED_SOURCE_SELECTION`, Helianthus emits no NM traffic.
 
 ## Purpose
@@ -72,7 +72,7 @@ This passive, indirect approach has two key properties:
 ### States
 
 - **NMInit**: Initial state. Entered on process start, first
-  address-pair acquisition, completed rejoin, operator reset, or
+  address-pair acquisition, completed source reselection, operator reset, or
   configuration invalidation.
 - **NMReset**: Transitional. All monitored nodes reset to unknown
   status. Status chart is cleared.
@@ -98,9 +98,9 @@ re-entering `NMInit`):
 1. **Process start.** Gateway process launches for the first time.
 2. **First successful local address-pair acquisition.** The gateway
    obtains a valid active local initiator address and its companion.
-3. **Completed source-selection admission or re-admission after transport
-   recovery.** Transport reconnects after a disconnection event and source
-   admission succeeds.
+3. **Completed source-selection validation after transport recovery.**
+   Transport reconnects after a disconnection event and source-selection
+   validation succeeds.
 4. **Explicit operator NM reset.** An operator or MCP tool issues a
    manual NM reset command.
 5. **Configuration changes invalidating target configuration.** The
@@ -161,7 +161,7 @@ exists. Without an address, the gateway cannot construct a valid eBUS
 frame.
 
 For startup ordering on source-selection-capable direct transports, Helianthus MUST
-also satisfy the admission gate frozen in
+also satisfy the source-selection gate frozen in
 [startup-admission-and-discovery.md §2, "Startup Ordering Contract"](./startup-admission-and-discovery.md#startup-ordering-contract):
 passive reconstructor and source-selection observation complete before any
 non-override active startup traffic, and semantic polling is released

--- a/architecture/nm-participant-policy.md
+++ b/architecture/nm-participant-policy.md
@@ -3,12 +3,13 @@
 Status: Normative
 Plan reference: ebus-good-citizen-network-management.locked (M0/ISSUE-DOC-02)
 
-SAS-01 update: local NM source authority is the admitted
-`SourceAddressSelection` after `active_probe_passed`. Earlier references to
-`JoinResult`, configured fallback, or re-admission are historical for the prior
-startup-admission plan. NM runtime must fail closed before admission and during
+SAS-01 update: local NM source authority is
+`SourceAddressSelection.Source` after `active_probe_passed`. Earlier references to
+`JoinResult`, configured fallback, or source reselection are historical for the
+prior startup plan. NM runtime must fail closed before source-selection
+validation and during
 `DEGRADED_SOURCE_SELECTION`; it must not emit `FF 00`, `FF 02`, or `0x07/0xFF`
-without an admitted source.
+without an active-probe-passed source.
 
 ## Purpose
 
@@ -31,9 +32,8 @@ the pair was selected and from which source.
 
 ### Preferred Source: SourceAddressSelection
 
-On transports that support source address selection admission, the canonical
-source is the gateway-owned selection that has passed the active admission
-probe:
+On transports that support source address selection validation, the canonical
+source is the gateway-owned selection that has passed the active probe:
 
 - **Initiator:** `SourceAddressSelection.Source`
 - **Companion target:** `SourceAddressSelection.CompanionTarget`
@@ -62,7 +62,8 @@ The active local address pair carries a provenance tag that records:
 - A monotonic sequence number incremented on each address-pair change
 
 Provenance enables runtime code to distinguish high-confidence pairs
-from configured fallbacks and to detect stale references after re-admission.
+from configured fallbacks and to detect stale references after source
+reselection.
 
 ## Init_NM and Transport Events
 
@@ -73,8 +74,8 @@ Helianthus enters the NMInit state on exactly these events:
 1. **Process start.** Gateway process begins execution.
 2. **First valid address pair.** First successful acquisition of a valid
    local address pair after process start.
-3. **Completed source-selection admission or re-admission after transport
-   recovery.** Transport reconnects and source admission succeeds.
+3. **Completed source-selection validation after transport recovery.**
+   Transport reconnects and source-selection validation succeeds.
 4. **Explicit operator-triggered NM reset.** An operator command
    requests NM reinitialization.
 5. **Configuration change invalidating the target configuration.**
@@ -84,9 +85,9 @@ Helianthus enters the NMInit state on exactly these events:
 Cross-reference: [nm-model.md](./nm-model.md) defines the NMInit,
 NMReset, and NMNormal state machine transitions.
 
-### Re-admission Semantics
+### Source Reselection Semantics
 
-A source-selection re-admission that changes the active local address pair is
+A source-selection validation cycle that changes the active local address pair is
 NM-relevant. The
 transition sequence is:
 
@@ -95,16 +96,16 @@ transition sequence is:
 The previous address pair is discarded. All NM state derived from the
 old pair (including monitored-node timers) is invalidated.
 
-A re-admission that preserves the same address pair is NOT NM-relevant and
-does not trigger a state transition.
+A source-selection validation cycle that preserves the same address pair is NOT
+NM-relevant and does not trigger a state transition.
 
 Source-selection observations seed evidence but do not promote devices directly
 into the monitored-node set.
 
 ### Transport Blindness
 
-When the transport disconnects without a completed source-selection
-re-admission:
+When the transport disconnects without a completed source-selection validation
+cycle:
 
 - **self status:** transitions to NOK immediately.
 - **Remote-node cycle-time timers:** freeze. Timers do not advance
@@ -112,9 +113,9 @@ re-admission:
 - **NM-originated broadcasts:** suppressed. Any broadcast requiring a
   valid local initiator address is not emitted.
 
-A transport disconnect without a completed source-selection re-admission is NOT a fake NM
-reset. The NM state machine remains in its current state; it does not
-transition to NMInit until source admission succeeds.
+A transport disconnect without a completed source-selection validation cycle is
+NOT a fake NM reset. The NM state machine remains in its current state; it does
+not transition to NMInit until source-selection validation succeeds.
 
 ## Self-Monitoring
 
@@ -231,7 +232,7 @@ measurement at implementation time.
 ### Sustained Load Budget
 
 Helianthus-originated NM traffic must not exceed **0.5% of bus
-capacity** outside of reset and source-selection re-admission windows.
+capacity** outside of reset and source-reselection windows.
 
 This is a sustained average measured over a rolling window. The
 measurement window length is defined at implementation time but must be
@@ -240,15 +241,15 @@ at least 60 seconds.
 ### Burst Load Budget
 
 Helianthus-originated NM traffic must not exceed **2.0% of bus
-capacity** during reset and source-selection re-admission windows.
+capacity** during reset and source-reselection windows.
 
-Reset and source-selection re-admission windows are bounded by the NMReset-to-NMNormal
-transition. Once the state machine enters NMNormal, the sustained
-budget applies.
+Reset and source-reselection windows are bounded by the NMReset-to-NMNormal
+transition. Once the state machine enters NMNormal, the sustained budget
+applies.
 
 ### Discovery-Class Burst Budget
 
-The startup-admission directed discovery phase defined in
+The startup source-selection directed discovery phase defined in
 [startup-admission-and-discovery.md](./startup-admission-and-discovery.md#startup-directed-probe-phase)
 uses a distinct **discovery-class** startup burst budget and MUST be
 kept separate from the frozen NM-class sustained and burst numbers
@@ -263,7 +264,7 @@ treated as approximately `5 B/s`. A hard ceiling of
 full `07 04` transactions (`18-22` bytes each), or about
 `4.5-5.5 B/s`, which is the ratified startup-discovery envelope for
 this plan. Post-startup steady-state reverts to the separate
-`1 probe per 15s` limit defined in the startup-admission document.
+`1 probe per 15s` limit defined in the startup source-selection document.
 
 ### 07 FF Cadence Floor
 

--- a/architecture/startup-admission-and-discovery.md
+++ b/architecture/startup-admission-and-discovery.md
@@ -317,14 +317,14 @@ closes only when BOTH of the following are true:
 
 1. `startupScanSignals.semanticBootstrapReady` has fired; and
 2. admission is either:
-   - Joiner-success with a valid `JoinResult`, or
-   - override-set.
+   - `source_selection` with active probe validation passed; or
+   - `explicit_validate_only` with active probe validation passed.
 
 The barrier MUST remain open when:
 
-- admission is degraded without override;
+- admission is degraded;
 - warmup observed no valid admission outcome;
-- Joiner has not yet succeeded;
+- active probe validation has not succeeded;
 - the transport has not recovered after rejoin failure.
 
 The semantic polling change above is a signal-source change only. The

--- a/architecture/startup-admission-and-discovery.md
+++ b/architecture/startup-admission-and-discovery.md
@@ -360,22 +360,25 @@ full-range scan or to static-source operation.
 
 ### 3.1 Enum
 
-The startup admission path selection SHALL be emitted and reasoned
-about using the enum:
+For the current SAS M4 source-selection surface, startup source selection SHALL
+be emitted and reasoned about using:
 
-`admission_path_selected ∈ {join, override, degraded_transport_blind,
-degraded_no_events}`
+`admission.source_selection.mode ∈ {source_selection, explicit_validate_only,
+degraded_transport_blind, degraded_no_events}`
 
-No other value is valid under AD23.
+No other value is valid under the current source-selection artifact contract.
 
 ### 3.2 Value Definitions
 
 | Value | Triggering Condition | Meaning | Active Traffic Allowed |
 |---|---|---|---|
-| `join` | Join-capable direct transport produced a valid `JoinResult` before first non-override active frame | direct admission succeeded | yes, using `JoinResult.Initiator` |
-| `override` | `StartupSource.Override` is set, regardless of `Validate` branch | operator supplied active source | yes, using override initiator |
+| `source_selection` | source-selection-capable direct transport produced a valid source before first non-explicit-source active frame | direct source selection succeeded | yes, using selected source |
+| `explicit_validate_only` | exact source configuration is set, regardless of `Validate` branch | operator supplied exact source, still actively validated | yes, using explicitly configured source after validation rules |
 | `degraded_transport_blind` | warmup window observed zero passive events and admission could not establish a valid source | silent-bus or transport-blind startup | no |
 | `degraded_no_events` | transport is observable enough to run warmup, but no admissible `JoinResult` exists by warmup end and no override is set | admission degraded after observable but insufficient or conflicting evidence | no |
+
+Subsections 3.3 through 3.6 retain the historical W17-26 wording. Current SAS
+M4 consumers use the mapped labels in the table above.
 
 ### 3.3 `join`
 
@@ -1017,15 +1020,15 @@ The implementation MUST NOT:
 - promote advisory Joiner output into runtime configuration.
 
 <a id="admission-artifact-schema-key-paths"></a>
-## 8. Admission-Artifact Schema Key-Paths
+## 8. Source-Selection Artifact Schema Key-Paths
 
 ### 8.1 Status and Scope
 
-This section is the normative AD23 key-path listing for the admission
+This section is the normative SAS M4 key-path listing for the source-selection
 artifact. The JSON schema file itself lives in
 `helianthus-ebusgateway` at
-`docs/schemas/admission-artifact.schema.json` and is committed there as
-part of `M2a`. This document authorizes the schema semantics and field
+`docs/schemas/source-selection-artifact.schema.json`. This document authorizes
+the schema semantics and field
 set; it does not move schema-file authorship into this repository.
 
 Artifact scope is:
@@ -1043,7 +1046,7 @@ Artifact scope is:
 | `admission.warmup_duration_s` | yes | effective warmup duration used for the admission cycle |
 | `admission.reason_if_degraded` | yes | structured degraded reason, empty or null-equivalent only when not degraded |
 | `admission.transport_kind` | yes | classified transport kind for the run |
-| `admission.admission_path_selected` | yes | enum in `{join, override, degraded_transport_blind, degraded_no_events}` |
+| `admission.source_selection.mode` | yes | enum in `{source_selection, explicit_validate_only, degraded_transport_blind, degraded_no_events}` |
 
 ### 8.3 Discovery Object
 
@@ -1061,7 +1064,7 @@ Artifact scope is:
 
 The schema SHALL enforce:
 
-`admission.admission_path_selected ∈ {join, override,
+`admission.source_selection.mode ∈ {source_selection, explicit_validate_only,
 degraded_transport_blind, degraded_no_events}`
 
 Any out-of-range value is invalid and SHALL be treated as a failure by

--- a/architecture/startup-admission-and-discovery.md
+++ b/architecture/startup-admission-and-discovery.md
@@ -259,64 +259,55 @@ Before those conditions hold:
 
 #### 2.2.5 Directed Probes Follow Admission
 
-The directed-probe phase MAY begin only after the `join` path has been
-selected. Directed probes use `JoinResult.Initiator` as their source.
+In the historical W17-26 wording, the directed-probe phase could begin only
+after the `join` path was selected, and directed probes used
+`JoinResult.Initiator` as their source.
+
+In current SAS M4 terms, directed probes MAY begin only after source selection
+and active probe validation admit a source. Directed probes use the admitted
+`SourceAddressSelection.Source` as their source.
 
 No directed probe MAY be used to bootstrap admission itself.
 
-### 2.3 Override Carve-Out
+### 2.3 Historical Override Carve-Out
 
-The override path is an explicit carve-out from the warmup-before-
-active-frame invariant.
+The old override path was an explicit W17-26 carve-out from the
+warmup-before-active-frame invariant: when `StartupSource.Override` was set,
+the operator override acted as the active source and warmup did not gate
+emission on that historical path.
 
-When `StartupSource.Override` is set:
+SAS M4 supersedes that carve-out. Exact source configuration now maps to
+`explicit_validate_only`: candidate search is bypassed, but the configured
+source still requires active validation before any normal Helianthus-owned
+traffic uses it. It does not create a general allowance for static-source
+fallthrough on source-selection-capable direct transports.
 
-- active frames MAY emit immediately using the override initiator;
-- the active source is the operator override, not a `JoinResult`;
-- warmup does not gate emission on this path.
+### 2.4 Historical Override Branches
 
-This carve-out exists only for the override path. It does not create a
-general allowance for static-source fallthrough on join-capable direct
-transports.
+#### 2.4.1 Historical `Override` Set and `Validate=false`
 
-### 2.4 Override Branches
+The old `StartupSource.Override.Validate=false` branch is historical W17-26
+wording only. Current SAS M4 implementations SHALL NOT emit immediate normal
+Helianthus-owned active traffic from this branch. Exact configured source input
+SHALL be represented as `admission.source_selection.mode =
+explicit_validate_only`, SHALL set
+`startup_source_selection_explicit_source_active=1`, and SHALL pass active
+validation before normal gateway-owned MCP, GraphQL, Portal, semantic,
+scheduler, poller, NM, or protocol-dispatch traffic uses the source.
 
-#### 2.4.1 `Override` Set and `Validate=false`
+Diagnostic transport-specific MCP calls remain outside this normal-operation
+authority and may use a caller-supplied source for that one diagnostic request.
 
-When `StartupSource.Override` is set and
-`StartupSource.Override.Validate=false`:
+#### 2.4.2 Historical `Override` Set and `Validate=true`
 
-- Joiner does NOT gate startup;
-- Joiner does NOT need to run;
-- the gateway emits
-  `startup admission override source=0xXX confidence=low`
-  before the first active frame;
-- `startup_source_selection_explicit_source_active=1` is exposed;
-- the selected path is `override`.
+The old `StartupSource.Override.Validate=true` advisory-Joiner branch is also
+historical. Current SAS M4 implementations use source-address selection plus
+active probe validation; they SHALL NOT emit the removed `override` value and
+SHALL NOT keep an advisory Joiner as current source authority.
 
-This path is a soft short-circuit, not a silent fallback.
-
-#### 2.4.2 `Override` Set and `Validate=true`
-
-When `StartupSource.Override` is set and
-`StartupSource.Override.Validate=true`:
-
-- active frames MAY still emit immediately using the override
-  initiator;
-- Joiner runs in parallel in advisory-only mode;
-- Joiner warmup does NOT gate emissions;
-- Joiner may populate `JoinMetrics` and a preferred initiator view;
-- retrospective conflict detection runs at approximately the end of
-  the `5s` advisory warmup.
-
-If advisory Joiner disagrees with the override choice:
-
-- the gateway emits a structured WARN;
-- `startup_source_selection_explicit_source_conflict_detected=1` is set;
-- already-emitted active traffic remains valid and is NOT
-  retroactively invalidated;
-- the selected path remains `override` until the operator changes
-  configuration and restarts.
+If exact source validation fails, normal gateway-owned traffic remains blocked
+and the admission state transitions to degraded source selection rather than
+falling back to unvalidated static-source operation.
 
 ### 2.5 Semantic Polling Gate
 
@@ -382,7 +373,10 @@ M4 consumers use the mapped labels in the table above.
 
 ### 3.3 `join`
 
-`join` is selected only when all of the following are true:
+`join` is a historical W17-26 artifact label. Current SAS M4 artifacts SHALL
+emit `source_selection` instead.
+
+The old `join` label was selected only when all of the following were true:
 
 - the transport is one of ENH, ENS, UDP-plain, or TCP-plain;
 - Joiner was wired through `JoinBus`;
@@ -390,19 +384,15 @@ M4 consumers use the mapped labels in the table above.
 - the first non-override active frame, if any, uses
   `JoinResult.Initiator`.
 
-`join` is the only high-confidence non-override admission path on
-join-capable direct transports.
+The current high-confidence non-explicit-source path on source-selection-
+capable direct transports is `source_selection`, not `join`.
 
 ### 3.4 `override`
 
-`override` is selected when the operator has configured an explicit
-override. The `Validate` flag changes observability and advisory
-behaviour, but it does not change the selected enum.
-
-`override` therefore covers both:
-
-- set + `Validate=false`;
-- set + `Validate=true`.
+`override` is a historical W17-26 artifact label. Current SAS M4 artifacts SHALL
+emit `explicit_validate_only` for exact configured source input, and that source
+still requires active validation before normal Helianthus-owned traffic may use
+it. Current artifacts SHALL NOT emit `override`.
 
 ### 3.5 `degraded_transport_blind`
 
@@ -442,7 +432,7 @@ and restated as a focused startup matrix in
 The path-selection implications are:
 
 - ENH, ENS, UDP-plain, TCP-plain:
-  `join` or `override`, otherwise degraded;
+  `source_selection` or `explicit_validate_only`, otherwise degraded;
 - `ebusd-tcp`:
   static configured fallback remains the default path outside the
   artifact scope of this plan.
@@ -647,8 +637,8 @@ scan pass" for adapter-direct transports.
 The startup-directed probe phase MAY begin only when all of the
 following are true:
 
-- the transport is join-capable direct transport;
-- the admission path is `join` or `override`;
+- the transport is source-selection-capable direct transport;
+- the admission mode is `source_selection` or `explicit_validate_only`;
 - the target set is explicit and non-empty;
 - each target is target-capable and valid for directed scan;
 - the startup rate limiter allows the next probe.
@@ -746,10 +736,9 @@ fails acceptance regardless of why extra probes were emitted.
 
 ### 5.9 Probe Source
 
-The source address used for directed probes SHALL be:
-
-- `JoinResult.Initiator` on the `join` path;
-- override initiator on the `override` path.
+The source address used for directed probes SHALL be the admitted
+`SourceAddressSelection.Source`, regardless of whether the mode is
+`source_selection` or `explicit_validate_only`.
 
 No other source is valid on direct transports in this plan.
 
@@ -836,7 +825,7 @@ expvars:
 | `startup_source_selection_warmup_events_seen` | per-cycle gauge | reset each warmup interval |
 | `startup_source_selection_warmup_cycles_total` | monotonic counter | increments per source-selection warmup entered |
 | `startup_source_selection_explicit_validate_only_total` | monotonic counter | increments per exact-source validation cycle |
-| `startup_source_selection_explicit_source_conflict_detected` | boolean-like gauge | advisory conflict under `Validate=true` |
+| `startup_source_selection_explicit_source_conflict_detected` | boolean-like gauge | exact-source validation conflict detected |
 | `startup_source_selection_degraded_escalated` | latched flag | `1` while escalation latch active |
 | `startup_source_selection_degraded_since_ms` | unix-ms gauge | timestamp of current envelope-visible degraded state entry |
 | `startup_source_selection_consecutive_failures` | gauge | reset on source-selection success |
@@ -950,9 +939,11 @@ On process start the gateway SHALL emit:
 
 Operator override is opt-in and default-off.
 
-It exists to let an operator intentionally force the local initiator
-selection on join-capable direct transports when admission must not
-wait for a successful Joiner result.
+Historically it let an operator force the local initiator selection on
+join-capable direct transports. SAS M4 supersedes that behavior: the operator
+may configure an exact source, but the gateway treats it as
+`explicit_validate_only` and still requires active validation before normal
+Helianthus-owned traffic uses it.
 
 ### 7.2 Configuration Surface
 
@@ -976,37 +967,28 @@ When override is unset:
 
 This is the default and preferred branch.
 
-### 7.4 Set + `Validate=false`
+### 7.4 Exact Source Set
 
-When override is set and `Validate=false`:
+When exact source configuration is set:
 
-- warmup does not gate active traffic;
-- Joiner is bypassed for gating purposes;
-- active traffic uses the override initiator immediately;
-- the selected path is `override`;
-- the gateway logs
-  `startup admission override source=0xXX confidence=low`
-  before the first active frame;
+- candidate search is bypassed;
+- active probe validation remains mandatory;
+- normal gateway-owned active traffic waits for validation success;
+- the selected mode is `explicit_validate_only`;
 - `startup_source_selection_explicit_source_active=1`;
 - `startup_source_selection_explicit_validate_only_total` increments for the
   admission cycle.
 
-### 7.5 Set + `Validate=true`
+### 7.5 Exact Source Validation Failure
 
-When override is set and `Validate=true`:
+If exact source validation fails:
 
-- active traffic still uses the override initiator immediately;
-- warmup does not gate active traffic;
-- Joiner runs in parallel for advisory observation only;
-- advisory Joiner may populate `JoinMetrics`;
-- retrospective conflict detection runs at approximately `t=5s`.
-
-If advisory Joiner prefers a different initiator than the override:
-
-- the gateway emits a WARN;
-- `startup_source_selection_explicit_source_conflict_detected=1`;
-- the selected path remains `override`;
-- already-emitted traffic is not invalidated.
+- normal gateway-owned active traffic remains blocked;
+- the gateway records a degraded source-selection state;
+- the selected mode remains `explicit_validate_only` for the attempted
+  exact-source cycle;
+- the failed source may be reported under `source_selection.failed_source`;
+- automatic fallback to unvalidated static-source operation is forbidden.
 
 ### 7.6 No Auto-Lift
 

--- a/architecture/startup-admission-and-discovery.md
+++ b/architecture/startup-admission-and-discovery.md
@@ -291,7 +291,7 @@ When `StartupSource.Override` is set and
 - the gateway emits
   `startup admission override source=0xXX confidence=low`
   before the first active frame;
-- `startup_admission_override_active=1` is exposed;
+- `startup_source_selection_explicit_source_active=1` is exposed;
 - the selected path is `override`.
 
 This path is a soft short-circuit, not a silent fallback.
@@ -312,7 +312,7 @@ When `StartupSource.Override` is set and
 If advisory Joiner disagrees with the override choice:
 
 - the gateway emits a structured WARN;
-- `startup_admission_override_conflict_detected=1` is set;
+- `startup_source_selection_explicit_source_conflict_detected=1` is set;
 - already-emitted active traffic remains valid and is NOT
   retroactively invalidated;
 - the selected path remains `override` until the operator changes
@@ -448,9 +448,9 @@ The path-selection implications are:
   artifact scope of this plan.
 
 The selected enum value SHALL drive the admission artifact field
-`admission.admission_path_selected`, degraded-mode log classification,
-and observability review of startup behaviour. It SHALL NOT by itself
-change discovery promotion rules.
+`admission.source_selection.mode`, degraded-mode log classification, and
+observability review of startup behaviour. It SHALL NOT by itself change
+discovery promotion rules.
 
 <a id="evidence-pipeline-and-promotion"></a>
 ## 4. Evidence Pipeline and Promotion
@@ -830,17 +830,17 @@ expvars:
 
 | Expvar | Type / Domain | Required Semantics |
 |---|---|---|
-| `startup_admission_degraded_total` | monotonic counter | count of degraded transitions |
-| `startup_admission_state` | enum `{0,1,2}` | current admission state |
-| `startup_admission_override_active` | boolean-like gauge | `1` when override configured |
-| `startup_admission_warmup_events_seen` | per-cycle gauge | reset each warmup interval |
-| `startup_admission_warmup_cycles_total` | monotonic counter | increments per Joiner warmup entered |
-| `startup_admission_override_bypass_total` | monotonic counter | increments per override-selected admission cycle |
-| `startup_admission_override_conflict_detected` | boolean-like gauge | advisory conflict under `Validate=true` |
-| `startup_admission_degraded_escalated` | latched flag | `1` while escalation latch active |
-| `startup_admission_degraded_since_ms` | unix-ms gauge | timestamp of current envelope-visible degraded state entry |
-| `startup_admission_consecutive_rejoin_failures` | gauge | reset on rejoin success |
-| `startup_admission_degraded_cumulative_ms` | rolling gauge | 15-minute in-process cumulative degraded time |
+| `startup_source_selection_degraded_total` | monotonic counter | count of degraded transitions |
+| `startup_source_selection_state` | enum `{0,1,2}` | current source-selection state |
+| `startup_source_selection_explicit_source_active` | boolean-like gauge | `1` when exact source configuration is active |
+| `startup_source_selection_warmup_events_seen` | per-cycle gauge | reset each warmup interval |
+| `startup_source_selection_warmup_cycles_total` | monotonic counter | increments per source-selection warmup entered |
+| `startup_source_selection_explicit_validate_only_total` | monotonic counter | increments per exact-source validation cycle |
+| `startup_source_selection_explicit_source_conflict_detected` | boolean-like gauge | advisory conflict under `Validate=true` |
+| `startup_source_selection_degraded_escalated` | latched flag | `1` while escalation latch active |
+| `startup_source_selection_degraded_since_ms` | unix-ms gauge | timestamp of current envelope-visible degraded state entry |
+| `startup_source_selection_consecutive_failures` | gauge | reset on source-selection success |
+| `startup_source_selection_degraded_cumulative_ms` | rolling gauge | 15-minute in-process cumulative degraded time |
 
 ### 6.5 `bus_admission` Envelope Field
 
@@ -897,7 +897,7 @@ On the first unlatched-to-latched escalation transition, the gateway
 SHALL:
 
 - emit one structured WARN line;
-- set `startup_admission_degraded_escalated=1`.
+- set `startup_source_selection_degraded_escalated=1`.
 
 The WARN line is:
 
@@ -928,7 +928,7 @@ The implementation is defined as:
 - rolling window length `900s` (`15 min`);
 - each slot stores degraded milliseconds in that second;
 - sum over all slots produces
-  `startup_admission_degraded_cumulative_ms`.
+  `startup_source_selection_degraded_cumulative_ms`.
 
 With `900` buckets at `4 bytes` each, the memory bound is
 approximately `3.6 KB` per admission instance.
@@ -987,8 +987,8 @@ When override is set and `Validate=false`:
 - the gateway logs
   `startup admission override source=0xXX confidence=low`
   before the first active frame;
-- `startup_admission_override_active=1`;
-- `startup_admission_override_bypass_total` increments for the
+- `startup_source_selection_explicit_source_active=1`;
+- `startup_source_selection_explicit_validate_only_total` increments for the
   admission cycle.
 
 ### 7.5 Set + `Validate=true`
@@ -1004,7 +1004,7 @@ When override is set and `Validate=true`:
 If advisory Joiner prefers a different initiator than the override:
 
 - the gateway emits a WARN;
-- `startup_admission_override_conflict_detected=1`;
+- `startup_source_selection_explicit_source_conflict_detected=1`;
 - the selected path remains `override`;
 - already-emitted traffic is not invalidated.
 
@@ -1085,7 +1085,7 @@ At minimum, the emitted values must support validation that:
 
 This admission artifact is outside `ebusd-tcp` scope in this plan.
 `ebusd-tcp` is referenced in the transport matrix and in the guarded
-full-range retry rule, but does not emit `admission_path_selected`
+full-range retry rule, but does not emit `admission.source_selection.mode`
 within this plan's adapter-direct acceptance surface.
 
 <a id="full-range-retry-guard"></a>

--- a/deployment/full-stack.md
+++ b/deployment/full-stack.md
@@ -78,12 +78,13 @@ go run ./cmd/gateway \
 
 For ebusd command syntax and response framing details, see `protocols/ebusd-tcp.md`.
 
-### Source-address behavior
+### Source-Selection Behavior
 
-- `-source-addr auto` delegates to the gateway default source-selection policy. The gateway selects and validates an admitted source before any normal Helianthus-originated bus traffic.
+- `-source-addr auto` delegates to the gateway default source-selection policy. The gateway selects and validates an admitted source with the active probe before any normal Helianthus-originated bus traffic.
 - Legacy `source_addr.last` files are rollback/migration input only. They must not be promoted into active source authority before gateway validation.
 - `-source-addr 0x31` should be avoided when `ebusd` is also active, because `0x31` is `ebusd`'s common default initiator.
 - With `-transport ebusd-tcp`, source selection only affects ebusd command parameters; the on-wire initiator is still ebusd's own bus identity.
+- The source-selection public API migration matrix is documented in [`api/source-selection-migration.md`](../api/source-selection-migration.md).
 
 Terminology note:
 

--- a/protocols/ebus-services/ebus-overview.md
+++ b/protocols/ebus-services/ebus-overview.md
@@ -51,8 +51,8 @@ Addresses equal to `0xA9` (escape) or `0xAA` (SYN) are invalid in address positi
 ### Helianthus Source Address Selection
 
 When Helianthus must choose an initiator address on a live bus, it performs
-source address selection plus gateway admission validation. It does not perform
-a protocol membership join.
+source address selection plus gateway active-probe validation. It does not
+perform a protocol membership operation.
 
 The standard source-address table is frozen in
 [`architecture/ebus_standard/12-source-address-table.md`](../../architecture/ebus_standard/12-source-address-table.md).
@@ -72,10 +72,10 @@ wire, p0 / `0x0` outranks p1 / `0x1`, then p2 / `0x3`, p3 / `0x7`, and p4 /
 `0xFF` is a valid source address and maps to companion `0x04`. The `0xFF`
 NACK meaning applies only in ACK/NACK byte context.
 
-Before startup scan or any normal gateway-owned bus-reaching operation,
-gateway admission must actively validate the selected source and companion. A
-failed active probe quarantines/excludes that source and either tries the next
-candidate or enters `DEGRADED_SOURCE_SELECTION`, which emits no
+Before startup scan or any normal gateway-owned bus-reaching operation, gateway
+source-selection validation must actively validate the selected source and
+companion. A failed active probe quarantines/excludes that source and either
+tries the next candidate or enters `DEGRADED_SOURCE_SELECTION`, which emits no
 Helianthus-originated eBUS traffic.
 
 ## ACK/NACK Symbols
@@ -157,7 +157,7 @@ For multi-client/proxy setups, Helianthus collision handling uses a receive-vs-t
   - if frame matches a recent local transmit inside the echo window (`200ms` default), treat as local echo,
   - otherwise classify as foreign same-source collision.
 - In muted/listen-only mode, any `SRC == active initiator` receive frame is classified as collision.
-- After initiator rejoin, frames with the previous initiator source are ignored during a grace window (`750ms` default).
+- After initiator source changes, frames with the previous initiator source are ignored during a grace window (`750ms` default).
 - While collision is active, write attempts fail fast with an arbitration-failed classification.
 
 ## CRC8 and Escaping
@@ -222,8 +222,8 @@ Notes:
   refresh internal address state that can later be queried (e.g. via the ebusd
   TCP `info` command).
 
-Helianthus source-selection admission does not use `0x07/0xFE` as its first
-startup validation probe. The admission probe is bounded addressed
+Helianthus source-selection validation does not use `0x07/0xFE` as its first
+startup validation probe. The active probe is bounded addressed
 Identification (`0x07/0x04`) only.
 
 ### Identification Scan (0x07 0x04)


### PR DESCRIPTION
## What
Clean up source-selection public terminology in docs and add the M4 public API migration matrix.

## Why
SAS M4 removes the old startup-admission/gentle-join public surface and documents the source-selection naming that gateway/API consumers must use.

## Validation
- ./scripts/ci_local.sh

Closes #293