### PR TITLE
feat(scripts): Phase C M-C0 — taxonomy hash gate + filename fix + terminology mapping

### DIFF
--- a/architecture/ebus_standard/12-address-table.md
+++ b/architecture/ebus_standard/12-address-table.md
@@ -4,6 +4,14 @@ Status: Normative
 Milestone: SAS-01 M1 (table v1) + Phase C C0_DOC_SPEC (256-byte taxonomy and frame-type contract)
 Table owner: `helianthus-docs-ebus`
 
+<!-- legacy-role-mapping:begin -->
+> **Vocabulary note**: this chapter uses the eBUS-spec normative terms
+> "Master" and "Slave" verbatim because they are the AddressClass enum
+> names defined by the spec. In Helianthus prose outside this chapter,
+> "initiator" maps to Master and "target" maps to Slave per the global
+> terminology gate. The legacy-role-mapping markers wrap the entire
+> chapter to allow spec-faithful vocabulary in the normative content.
+
 ## Rename note
 
 This chapter was previously named `12-source-address-table.md` and is renamed
@@ -661,3 +669,5 @@ independently against this file.
 - `helianthus-docs-ebus/architecture/atr/01-address-table-model.md` for the
   `AddressSlot` data model that consumes this taxonomy at the registry
   layer.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/ebus_standard/README.md
+++ b/architecture/ebus_standard/README.md
@@ -47,7 +47,9 @@ Attribution: canonical plan
 | [`09-mcp-envelope.md`](./09-mcp-envelope.md) | M4 MCP envelope contract, deterministic `data_hash`, golden fixture discipline |
 | [`10-rpc-source-113.md`](./10-rpc-source-113.md) | M4 `rpc.invoke` gateway source byte invariant |
 | [`11-m4b-semantic-lock.md`](./11-m4b-semantic-lock.md) | M4B semantic lock of read & decode surfaces (envelope, error, safety_class, decode scaffold, catalog version) |
+<!-- legacy-role-mapping:begin -->
 | [`12-address-table.md`](./12-address-table.md) | SAS-01 source-address table v1, priority mapping, companion mapping, hash contract; Phase C 256-byte address taxonomy (`Master\|Slave\|Broadcast\|Reserved`), frame-type addressing contract, and `ValidateFrameAddressing` validator contract |
+<!-- legacy-role-mapping:end -->
 | [`13-responder-capability-signal.md`](./13-responder-capability-signal.md) | M4D normative lock of `meta.capabilities.responder` (shape, invariants I1-I8, fail-closed consumer rule, enum catalogue at v1.1, subtree version policy) |
 | [`14-transport-matrix-cross-reference.md`](./14-transport-matrix-cross-reference.md) | M6b pointer to the canonical transport matrix artifact in helianthus-ebusgateway (section pointers §3-§7, BENCH-REPLACE status) |
 

--- a/scripts/check_address_table_taxonomy_hash.sh
+++ b/scripts/check_address_table_taxonomy_hash.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# check_address_table_taxonomy_hash.sh — Phase C M-C0 hash gate.
+#
+# Recomputes the SHA-256 over the 256-byte taxonomy + frame-type contract
+# + validator contract blocks of architecture/ebus_standard/12-address-table.md
+# and compares it to the pinned canonical value.
+#
+# Hard-fails (exit 1) on mismatch — any edit to those blocks requires
+# recompute + pin update in the same PR.
+#
+# Decision references: AD25, AD26, AD27 of locked plan
+# address-table-registry-w19-26 / Phase C / M-C0_DOC_SPEC.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOC_PATH="${REPO_ROOT}/architecture/ebus_standard/12-address-table.md"
+EXPECTED_HASH="316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec"
+
+if [[ ! -f "${DOC_PATH}" ]]; then
+  echo "ERROR: address-table doc not found at ${DOC_PATH}" >&2
+  exit 1
+fi
+
+# Extract block: from `## 256-Byte Address Taxonomy` (inclusive) to
+# `## Hash Contract (taxonomy + frame-type contract)` (exclusive).
+# Trailing whitespace stripped per line, exactly one terminal LF.
+ACTUAL_HASH="$(
+  awk '
+    /^## 256-Byte Address Taxonomy[[:space:]]*$/ { inblock = 1 }
+    inblock { print }
+    /^## Hash Contract \(taxonomy \+ frame-type contract\)[[:space:]]*$/ {
+      inblock = 0
+    }
+  ' "${DOC_PATH}" \
+    | sed -E 's/[[:space:]]+$//' \
+    | shasum -a 256 \
+    | cut -d' ' -f1
+)"
+
+if [[ "${ACTUAL_HASH}" == "${EXPECTED_HASH}" ]]; then
+  echo "address-table taxonomy hash OK: ${ACTUAL_HASH}"
+  exit 0
+fi
+
+cat >&2 <<EOF
+ERROR: address-table taxonomy hash mismatch.
+  expected: ${EXPECTED_HASH}
+  actual:   ${ACTUAL_HASH}
+
+The 256-byte taxonomy / frame-type contract / validator contract blocks
+in 12-address-table.md were edited but the pinned hash was not updated.
+
+Resolution: recompute via the awk+sed+shasum snippet at the bottom of
+the doc's "Hash Contract (taxonomy + frame-type contract)" section,
+then update the "Normalized hash:" line in 12-address-table.md to the
+new value. Both must land in the same PR.
+EOF
+exit 1

--- a/scripts/check_source_address_table_against_official_specs.py
+++ b/scripts/check_source_address_table_against_official_specs.py
@@ -12,7 +12,7 @@ from typing import Any
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-DOC_PATH = REPO_ROOT / "architecture/ebus_standard/12-source-address-table.md"
+DOC_PATH = REPO_ROOT / "architecture/ebus_standard/12-address-table.md"
 FIXTURE_PATH = REPO_ROOT / "tests/fixtures/source_address_table_official_v1.json"
 
 TABLE_VERSION = "ebus-source-address-table/v1"

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -137,6 +137,9 @@ echo "==> check eBUS source-address table"
 python3 scripts/check_source_address_table_against_official_specs.py --run-canary
 python3 -m pytest -q tests/test_source_address_table_checker.py
 
+echo "==> check eBUS address-table taxonomy + frame-type contract hash (Phase C M-C0)"
+bash scripts/check_address_table_taxonomy_hash.sh
+
 echo "==> check deployment source-address wording"
 python3 - <<'PY'
 from __future__ import annotations


### PR DESCRIPTION
Phase C M-C0_DOC_SPEC. Ships check_address_table_taxonomy_hash.sh (regression gate on the 256-byte taxonomy + frame-type contract + validator contract blocks), fixes the existing source-address script's stale filename reference, wires the new gate into ci_local.sh, and adds legacy-role-mapping markers so the terminology gate accepts the eBUS-spec-normative 'Master/Slave' vocabulary inside AddressClass enum definitions.

Pinned hash: `316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec`

Local CI green on all gates.