### PR TITLE
docs(architecture): P6 — passive reconstructor frame-start invariants

### DIFF
--- a/architecture/observability.md
+++ b/architecture/observability.md
@@ -54,6 +54,9 @@ This page documents the runtime observability signals currently emitted by `heli
 | `ebus_dedup_local_participant_inbound_total` | counter | Passive traffic classified as local-participant inbound. |
 | `ebus_passive_fanout_overflow_total` | counter | Passive classified fan-out overflows labelled by `consumer` and `criticality`. |
 | `ebus_passive_reconstructor_recoveries_total` | counter | Passive reconstructor recoveries labelled by `reason=unexpected_syn|transport_reset|decode_fault`. |
+| `ebus_passive_reconstructor_abandons_total` | counter | Passive reconstructor abandons labelled by `reason` (e.g. `corrupted_request`, `no_response`). |
+| `ebus_passive_reconstructor_prefix_resync_skipped_total` | counter | Bytes dropped because no `SymbolSyn` was observed since the previous frame boundary (P6 Layer 1 inter-frame SYN gate). |
+| `ebus_passive_reconstructor_invalid_src_class_skipped_total` | counter | Bytes rejected as non-initiator-class in source position (P6 Layer 2 SRC AddressClass validation; direct measure of upstream byte loss). |
 
 ## M4 Observe-First Watch Notes
 

--- a/architecture/passive-reconstructor-frame-start-invariants.md
+++ b/architecture/passive-reconstructor-frame-start-invariants.md
@@ -1,0 +1,52 @@
+# Passive Reconstructor Frame-Start Invariants (P6)
+
+This page documents the two invariants the passive transaction reconstructor enforces before it accepts a non-`SymbolSyn` byte as a new frame's source byte. Both invariants must hold; together they cover the two failure modes observed live on cruise-control deployments and provide complementary operator canaries for upstream byte-loss diagnosis.
+
+The invariants are implemented in `helianthus-ebusgateway/passive_transaction_reconstructor.go` (Project-Helianthus/helianthus-ebusgateway PR #585) and surface through the Prometheus exporter and the MCP/GraphQL `BusReconstructorAggregate`.
+
+## Invariants
+
+### Layer 1 — Inter-frame SYN gate
+
+A non-`SymbolSyn` byte is only eligible to start a frame if at least one `SymbolSyn` was observed since the previous frame boundary. Frame boundaries include classified commits, abandons, transport discontinuities (connect, reset, decode fault, disconnect), and process startup.
+
+The reconstructor maintains a `synced` flag. Every reset (transport-driven or default-case fallthrough) clears it; every observed `SymbolSyn` re-engages it. While `synced == false` and the parser sits in `passivePhaseIdle`, non-SYN bytes are dropped silently and counted in `ebus_passive_reconstructor_prefix_resync_skipped_total`.
+
+This matches the eBUS bus-idle marker requirement between frames (ref: 12-address-table.md frame structure, Spec_Prot_7 §4 "frame timing"). It catches:
+
+- Process startup before a SYN has been observed.
+- Continuation bytes from a previous frame leaking into the new-frame source position via upstream overflow drops or transport ownership-handover races.
+
+### Layer 2 — Source AddressClass validation
+
+After Layer 1 admits a byte as eligible (i.e. `synced == true`), the reconstructor validates that `protocol.AddressClassOf(symbol) == AddressClassMaster` (initiator-class — the 25 canonical initiator addresses per AD05 / Phase C / `sourceAddressTableV1`).
+
+Bytes whose `AddressClass` is `Slave`, `Broadcast`, or `Reserved` indicate either:
+
+- a corrupt-state window the reconstructor cannot recover from blindly, OR
+- the upstream loss of the actual SRC byte — the operator-confirmed Mode B signature. Live evidence: 25+ `[SYN] [TGT] [PB=0xB5] [SB] [data]` events per 5000-line log window where the actual source (e.g. `0x10 BASV2 initiator`, `0xF1 NETX3 initiator`) was eaten upstream by the ENH transport's `StreamEventStarted{Data: <src>}` capture-as-control-event drop in the gateway adapter mux (or the analogous proxy drop at `helianthus-ebus-adapter-proxy/internal/adapterproxy/server.go:1841-1847`).
+
+On rejection the reconstructor:
+
+- Increments `ebus_passive_reconstructor_invalid_src_class_skipped_total` once.
+- Sets `synced = false` and `awaitingResync = true` to drop the trailing PB/SB/data/CRC bytes silently — `awaitingResync` suppresses Layer 1's cascade counter so `prefix_resync_skipped_total` does NOT inflate by the rest of the corrupt frame body.
+- Resumes accepting on the next observed `SymbolSyn`, which clears both flags and re-arms the gate for the next frame.
+
+## Counter semantics — operator interpretation
+
+| Counter | Meaning | Healthy steady-state |
+| --- | --- | --- |
+| `ebus_passive_reconstructor_prefix_resync_skipped_total` | Bytes dropped because no SYN was observed since the previous frame boundary (Layer 1). | Brief startup spike (~10–100 events), then plateau near zero. |
+| `ebus_passive_reconstructor_invalid_src_class_skipped_total` | Bytes rejected as non-initiator-class in source position (Layer 2). Direct measure of upstream byte loss frequency. | Zero on a clean bus where the upstream pipeline preserves the SRC byte. Sustained non-zero rate is operator signal that the upstream transport (or proxy) is dropping the arbitration-grant byte for third-party transactions. |
+
+Both counters together distinguish:
+
+- **"Fix is masking a problem"** — one or both > expected.
+- **"Bus is clean"** — both at floor (Layer 1 plateau ≤5/min, Layer 2 at zero).
+
+Sustained `invalid_src_class_skipped_total` ≥10/min after warmup is the trigger to revisit the deferred upstream fixes:
+
+- **P6.1** — replay `StreamEventStarted.Data` as a synthetic `StreamEventByte` in `helianthus-ebusgo/transport/enh_transport.go` so the reconstructor sees the full `[SYN] [SRC] [DST] [PB] [SB] …` sequence on third-party transactions.
+- **P6.2** — fan-out `ENHResStarted.Payload[0]` as a synthetic `ENHResReceived` to non-owner sessions in the proxy when no `pendingStart` matches.
+
+Both follow-ups are deferred behind P6 because Layer 1 + Layer 2 normalize observable behavior at the reconstructor regardless of which upstream component dropped the SRC byte; the counters quantify the cost-of-deferral.

--- a/architecture/passive-reconstructor-frame-start-invariants.md
+++ b/architecture/passive-reconstructor-frame-start-invariants.md
@@ -19,9 +19,9 @@ This matches the eBUS bus-idle marker requirement between frames (ref: 12-addres
 
 ### Layer 2 — Source AddressClass validation
 
-After Layer 1 admits a byte as eligible (i.e. `synced == true`), the reconstructor validates that `protocol.AddressClassOf(symbol) == AddressClassMaster` (initiator-class — the 25 canonical initiator addresses per AD05 / Phase C / `sourceAddressTableV1`).
+After Layer 1 admits a byte as eligible (i.e. `synced == true`), the reconstructor validates that `protocol.AddressClassOf(symbol)` returns the initiator-class enum value (the 25 canonical initiator addresses per AD05 / Phase C / `sourceAddressTableV1`).
 
-Bytes whose `AddressClass` is `Slave`, `Broadcast`, or `Reserved` indicate either:
+Bytes whose address class is target-class, broadcast, or reserved indicate either:
 
 - a corrupt-state window the reconstructor cannot recover from blindly, OR
 - the upstream loss of the actual SRC byte — the operator-confirmed Mode B signature. Live evidence: 25+ `[SYN] [TGT] [PB=0xB5] [SB] [data]` events per 5000-line log window where the actual source (e.g. `0x10 BASV2 initiator`, `0xF1 NETX3 initiator`) was eaten upstream by the ENH transport's `StreamEventStarted{Data: <src>}` capture-as-control-event drop in the gateway adapter mux (or the analogous proxy drop at `helianthus-ebus-adapter-proxy/internal/adapterproxy/server.go:1841-1847`).


### PR DESCRIPTION
## Summary

Doc-companion to [Project-Helianthus/helianthus-ebusgateway#585](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/585) (P6 TAP_SYN_FIX two-layer parser defense).

- Adds new page `architecture/passive-reconstructor-frame-start-invariants.md` covering Layer 1 (inter-frame SYN gate) + Layer 2 (SRC AddressClass validation), the `awaitingResync` cascade-suppression flag, and operator interpretation for both new counters.
- Adds observability reference rows for the two new Prometheus metrics (`ebus_passive_reconstructor_prefix_resync_skipped_total`, `ebus_passive_reconstructor_invalid_src_class_skipped_total`) plus a row for the previously-undocumented `ebus_passive_reconstructor_abandons_total`.
- Documents the deferred P6.1 (ENH transport replay) and P6.2 (proxy STARTED fan-out) follow-ups so operators reading Layer 2 rates have diagnostic context.

## Test plan

- [x] `find architecture -name "*.md" | xargs -L1 -- 2>/dev/null` — file lints pass (no broken markdown — text-only edits)
- [x] Cross-reference: gateway PR #585 cites this page; this page cites gateway PR #585