### PR TITLE
docs(api): P3.5 — document discovery_source/verification_state on registry.devices

### DIFF
--- a/api/mcp.md
+++ b/api/mcp.md
@@ -329,6 +329,25 @@ Note: This inventory reflects the current known tool surface. The gateway may ex
   - `ebus.v1.adapter_info.get`
   - `ebus.v1.registry.devices.list`
   - `ebus.v1.registry.devices.get`
+    - JSON response items carry `discovery_source` and
+      `verification_state` fields (P3.5). `discovery_source` is one of
+      `passive_observed | static_seed | active_confirmed`;
+      `verification_state` is one of
+      `candidate | corroborated_pending | identity_confirmed`.
+      Both are omitted when the registry has no slot record for the
+      address. For `devices.list` the labels reflect the entry's
+      primary address; for `devices.get(address=X)` the labels
+      reflect the queried address X — important for merged entries
+      whose aliases may be at different DiscoverySource levels (e.g.
+      NETX3's broadcast face `0x04` stays at `static_seed/candidate`
+      while the `0xF1` face advances to
+      `active_confirmed/identity_confirmed` via active scan).
+      Per the
+      [`05-static-seed-provenance`](../architecture/atr/05-static-seed-provenance.md)
+      ATR, addresses planted by the productids static seed table MUST
+      surface as `static_seed/candidate` until corroborated by passive
+      observation (→ `corroborated_pending`) or identity-confirmed by
+      active scan (→ `active_confirmed/identity_confirmed`).
   - `ebus.v1.registry.planes.list`
   - `ebus.v1.registry.methods.list`
   - `ebus.v1.semantic.zones.get`


### PR DESCRIPTION
## Summary

Doc-companion to [Project-Helianthus/helianthus-ebusgateway#586](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/586) (P3.5 — \`applyStaticSeedTable\` uses \`RegisterStaticSeed\`; MCP \`devices.list/get\` JSON projection extended with \`discovery_source\` / \`verification_state\` fields).

Documents the new MCP response fields:
- `discovery_source`: \`passive_observed | static_seed | active_confirmed\`
- `verification_state`: \`candidate | corroborated_pending | identity_confirmed\`

Notes the per-address projection invariant for merged entries (\`devices.get(0x04)\` on a NETX3 entry returns the 0x04 slot's labels, not the primary's) and cross-links to the existing [`05-static-seed-provenance`](../architecture/atr/05-static-seed-provenance.md) ATR which already specifies the static_seed/candidate contract.

Closes Codex bot Thread 1 on gateway PR #586 (doc-gate requirement under AGENTS.md).

## Test plan

- [x] `scripts/ci_local.sh` passes (markdown lints, terminology gate, IPv4 gate, taxonomy hash gate, etc.)