### PR TITLE
docs+scripts: PR #297 residual fixes (LAN-IP redaction, IPv4 gate, taxonomy-hash awk)

### DIFF
--- a/architecture/atr/07-live-validation-acceptance.md
+++ b/architecture/atr/07-live-validation-acceptance.md
@@ -132,7 +132,7 @@ PR #565 (gateway, merged 2026-05-06 as 2281196) closes the gap:
 - Subscription failure is non-fatal — logged and skipped, consistent with
   the `PassiveDiscoveryPromoter` init pattern.
 
-Live evidence captured 2026-05-06 against HA at 192.168.100.4:
+Live evidence captured 2026-05-06 against HA at `<ha-host>`:
 
 - ✅ Source-selection completed (`active_probe_passed`, `selected_source=127`,
   `companion_target=132`).

--- a/architecture/ebus_standard/12-address-table.md
+++ b/architecture/ebus_standard/12-address-table.md
@@ -624,14 +624,17 @@ Phase C M-C0):
 ```bash
 #!/usr/bin/env bash
 # Recomputes the taxonomy + frame-type-contract hash from this file.
+# Block boundaries: from `## 256-Byte Address Taxonomy` (inclusive) to
+# `## Hash Contract (taxonomy + frame-type contract)` (exclusive),
+# matching the prose algorithm above.
 set -euo pipefail
 file="${1:-architecture/ebus_standard/12-address-table.md}"
 awk '
-  /^## 256-Byte Address Taxonomy[[:space:]]*$/ { inblock = 1 }
-  inblock { print }
   /^## Hash Contract \(taxonomy \+ frame-type contract\)[[:space:]]*$/ {
     inblock = 0
   }
+  inblock { print }
+  /^## 256-Byte Address Taxonomy[[:space:]]*$/ { inblock = 1; print }
 ' "$file" | sed -E 's/[[:space:]]+$//' | shasum -a 256 | cut -d' ' -f1
 ```
 
@@ -640,9 +643,13 @@ this one are frozen for a release). Phase C M-C0 acceptance requires the
 hash recorded here to match the script output bit-for-bit.
 
 Normalized hash:
-`316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec`
+`c19124aca8b42c1dcae659c37e7b21b20a4538dc7bc2bd785b5643b3f70503cc`
 
-Computed from this file post-operator-freeze (Phase C M-C0 close).
+Computed from this file post-operator-freeze (Phase C M-C0 close;
+hash recomputed under PR #297 thread `PRRT_kwDORGW9z86ATOzD`
+follow-up after the awk extractor was corrected so the
+`## Hash Contract` heading is excluded — matching the prose
+algorithm above).
 The validator CI script (post-M-C0) hard-fails if the script's
 recomputed hash does not match this value — any subsequent edit
 to the taxonomy / frame-type-contract / validator-contract blocks

--- a/scripts/check_address_table_taxonomy_hash.sh
+++ b/scripts/check_address_table_taxonomy_hash.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOC_PATH="${REPO_ROOT}/architecture/ebus_standard/12-address-table.md"
-EXPECTED_HASH="316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec"
+EXPECTED_HASH="c19124aca8b42c1dcae659c37e7b21b20a4538dc7bc2bd785b5643b3f70503cc"
 
 if [[ ! -f "${DOC_PATH}" ]]; then
   echo "ERROR: address-table doc not found at ${DOC_PATH}" >&2
@@ -27,11 +27,11 @@ fi
 # Trailing whitespace stripped per line, exactly one terminal LF.
 ACTUAL_HASH="$(
   awk '
-    /^## 256-Byte Address Taxonomy[[:space:]]*$/ { inblock = 1 }
-    inblock { print }
     /^## Hash Contract \(taxonomy \+ frame-type contract\)[[:space:]]*$/ {
       inblock = 0
     }
+    inblock { print }
+    /^## 256-Byte Address Taxonomy[[:space:]]*$/ { inblock = 1; print }
   ' "${DOC_PATH}" \
     | sed -E 's/[[:space:]]+$//' \
     | shasum -a 256 \

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -97,7 +97,7 @@ import subprocess
 import sys
 
 md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
-ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
+ipv4_re = re.compile(r"\b(?:(?:\d{1,3})\.){3}(?:\d{1,3})\b")
 
 PRIVATE_NETS = [
     ipaddress.ip_network("10.0.0.0/8"),


### PR DESCRIPTION
## Summary

Closes the three remaining unresolved threads on PR #297. Threads 1 and 2 are already fixed on `main` by #297 + #298 themselves; this PR addresses threads 3 and 4 plus a related latent CI bug discovered while verifying thread 3.

- **Thread `PRRT_kwDORGW9z86ATOy_` (P2 — redact live HA address)**: `architecture/atr/07-live-validation-acceptance.md:135` had a real LAN IP `192.168.100.4`. Replaced with placeholder `` `<ha-host>` ``.
- **Latent CI bug discovered while fixing thread 3**: `scripts/ci_local.sh`'s `private IPv4 address gate` was a no-op — the regex was double-escaped (`r"\\b...\\d..."`) so it matched literal `\b` / `\d` rather than the intended word-boundary / digit metacharacters. Every previous run reported "Private IPv4 gate passed" without scanning a single IPv4 literal. Fixed to single-escape; verified `192.168.100.4` is now caught (and no other private IP literals remain in tracked markdown).
- **Thread `PRRT_kwDORGW9z86ATOzD` (P2 — awk stop-rule)**: the awk extractor in `scripts/check_address_table_taxonomy_hash.sh` (mirrored in the doc snippet) printed the `## Hash Contract` heading line because `inblock { print }` ran before the stop-rule on the same line. Reordered rules so the stop heading sets `inblock=0` first; the prose algorithm and the snippet now agree. Recomputed pin updated in both the script and the doc:
  - old: `316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec`
  - new: `c19124aca8b42c1dcae659c37e7b21b20a4538dc7bc2bd785b5643b3f70503cc`

## Test plan

- [x] `./scripts/ci_local.sh` — all gates green (terminology, IPv4-now-actually-scanning, source-address-table, taxonomy-hash, deployment wording, NM service names).
- [x] Verified the awk extractor no longer prints the `## Hash Contract` heading (`tail -5` of the awk output ends with `Self-addressing rejection: src == dst for every ft.`).
- [x] Confirmed no other private IPv4 literals remain in tracked markdown (`git ls-files '*.md' | xargs grep -nE '\b(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)[0-9]+\.[0-9]+\b'` empty).

PR #297 threads 1 and 2 (terminology-gate wrap, checker DOC_PATH rename) were already addressed by #297 itself + #298; will resolve those threads with a status comment, no code change needed.