### PR TITLE
docs(observability): adaptermux session frame pipeline latency histogram

### DIFF
--- a/architecture/observability.md
+++ b/architecture/observability.md
@@ -158,6 +158,51 @@ These variables exist in-process today but are not mounted as a public HTTP endp
 | --- | --- | --- |
 | `semantic_bus_collisions_total` | int | Count of bus collision events during scan |
 
+### Adaptermux Session Frame Pipeline Latency
+
+The gateway's external-session multiplexer (`adaptermux`) measures the
+enqueue→TCP-write latency for every frame delivered to a connected
+client (e.g. ebusd). The intent is to surface gateway-side pipeline
+stalls that correlate with downstream "send to fe: ERR: read timeout"
+events on ebusd, whose default `--receivetimeout` is 25 ms.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `adaptermux_session_frame_latency_us_bucket_total` | map | Cumulative latency histogram. Keys are `le_1000`, `le_5000`, `le_25000`, `le_100000`, and `gt_100000`. |
+
+The histogram is **Prometheus-style cumulative**: each `le_X` counter
+holds the total number of frame samples whose elapsed enqueue→write
+time was ≤ X microseconds. A sample at 500 µs increments `le_1000`,
+`le_5000`, `le_25000`, and `le_100000`. The `gt_100000` counter is the
+**non-cumulative overflow bin** for samples exceeding every `le_*`
+boundary.
+
+| Quantity | Formula |
+| --- | --- |
+| Total samples | `le_100000 + gt_100000` |
+| Frames within ebusd's 25 ms budget | `le_25000` |
+| Frames over the 25 ms budget | `(le_100000 + gt_100000) - le_25000` |
+| Frames over 100 ms (tail) | `gt_100000` |
+
+The latency measurement uses a monotonic clock anchor captured at
+process start, so wall-clock steps (NTP/chrony correction, manual
+`date -s`) cannot produce negative or inflated samples. The metric is
+exposed via the in-process Go `expvar` map and is currently **not
+mounted on a public HTTP endpoint** — it backs internal observability
+and slow-frame log markers below.
+
+In addition to the histogram, frames with latency above
+**25 ms** emit a structured log line:
+
+```
+adaptermux: session <ID> frame delivery slow: kind=<K> latency=<USES>us
+   (threshold=25000us — exceeds ebusd's default --receivetimeout)
+```
+
+These log markers exist so operators can pinpoint concrete slow samples
+without needing histogram tooling. (F-10 diagnostic — see
+`_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`.)
+
 ## Structured Log Markers
 
 Bus observability warmup and dedup health are metric-first today. The structured log markers currently emitted by gateway are the semantic lifecycle and merge markers below.


### PR DESCRIPTION
## Summary

Documents the new `adaptermux_session_frame_latency_us_bucket_total` expvar surface introduced in [helianthus-ebusgateway#619](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/619) (F-10 diagnostic instrumentation per `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`).

Adds a new subsection to `architecture/observability.md` under **Internal `expvar` State**:

- Metric definition with Prometheus-style **cumulative** semantics (each `le_X` counts all frames ≤ X µs; `gt_100000` is the non-cumulative overflow bin).
- Derived-quantity formulas — total samples, frames within ebusd's 25 ms budget, frames over budget, tail (> 100 ms).
- Note on monotonic-clock anchoring (wall-clock NTP/chrony steps cannot distort samples — Codex P2 round 2 on the gateway PR).
- Companion structured slow-frame log line emitted when a frame's enqueue→write latency exceeds 25 ms.

## Doc-gate context

This PR closes the doc-gate trigger flagged by Codex P2 round 4 on helianthus-ebusgateway#619:

> This line exposes a new `/debug/vars` metric with non-obvious cumulative bucket semantics, which is externally visible behavior; the repo AGENTS.md doc-gate requires updating the corresponding docs in `helianthus-docs-ebus` and merging them alongside code.

## Test plan

- [x] `./scripts/ci_local.sh` passes locally (runtime-state schema gate, source-address wording, NM 07FE/07FF service names — all green; exit 0).
- [x] Markdown structure preserved; new section placed after **Bus Health** and before **Structured Log Markers** to match the existing ordering pattern of the **Internal `expvar` State** group.
- [x] Cross-link to `EBUSD-VERIFICATION-2026-05-10.md` (F-10) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)