### PR TITLE
Phase 3 Step B3.7: HelianthusV8ShadowWouldHaveDroppedGrowing alert

### DIFF
--- a/architecture/adaptermux/frame-atomic-syn-padding-math.md
+++ b/architecture/adaptermux/frame-atomic-syn-padding-math.md
@@ -1,0 +1,431 @@
+# Frame-Atomic Visibility — SYN Padding and Timing Derivations
+
+> Companion to `frame-atomic-visibility.md`. Status: design sketch.
+> Branch: `frame-atomic-visibility` (multi-repo).
+
+This document formalizes the per-session timing model that backs §3 and
+§4 of the parent design. The parent doc states *what* the proxy emits;
+this one states *exactly when, in what order, and based on which
+measurements*. The intent is to be precise enough that an adversarial
+reviewer can locate any unsoundness without re-deriving the math from
+the parent doc's prose.
+
+---
+
+## 1. Notation
+
+All quantities are in SI units unless otherwise stated. Time is wall
+clock as observed on the proxy host.
+
+| Symbol         | Meaning                                                                            | Typical range          |
+|----------------|------------------------------------------------------------------------------------|------------------------|
+| `T₀`           | wall-clock instant client A submits a write to the proxy                          | —                      |
+| `L_up`         | wifi latency proxy → adapter (uplink), per transaction                            | 5–30 ms, spikes >100 ms |
+| `L_dn`         | wifi latency adapter → proxy (downlink), per transaction                          | 5–30 ms, spikes >100 ms |
+| `W_F`          | wire-time of telegram F on the physical bus                                       | 30–200 ms              |
+| `N_F`          | byte count of telegram F (all phases: master + response + ACKs + terminator)      | 6–40 bytes             |
+| `σ_global`     | transport-side wire-observed symbol-rate EMA (bytes/sec from adapter)             | 50–240 sym/s           |
+| `σ_s`          | per-session symbol-rate EMA (bytes/sec drained to session s)                      | 5–240 sym/s            |
+| `τ_byte_wire`  | nominal wire bit-time for one byte at 2400 baud                                   | 4.17 ms                |
+| `τ_byte_s`     | per-session emission period per byte = 1 / `σ_s`                                  | 4.17–200 ms            |
+| `α`            | EMA smoothing coefficient (applied per observation window)                        | 0.1–0.3                |
+| `Δt_obs`       | observation window for instant-rate measurement                                   | 100–1000 ms            |
+| `K_s`          | per-session telegram queue depth bound                                            | 4–16                   |
+
+---
+
+## 2. Symbol-rate estimators
+
+### 2.1 Transport-side σ_global
+
+Computed once on the adapter-facing side, shared by all sessions only
+as a bootstrap reference (see §2.3). Updated every `Δt_obs`:
+
+```
+instant_global = bytes_received_from_adapter(Δt_obs) / Δt_obs
+σ_global ← α · instant_global + (1 − α) · σ_global
+σ_global clamped to [σ_min, σ_max]   where σ_min = 5, σ_max = 240
+```
+
+`σ_global` represents the actual rate at which symbols leave the wire
+toward the proxy. It is the upper bound on what any session can
+perceive — no session can see more symbols per second than the wire
+delivered.
+
+### 2.2 Per-session σ_s
+
+Each cross-proxy session maintains its own EMA, driven by the rate at
+which the proxy successfully drains bytes to that session's TCP
+egress:
+
+```
+instant_s = bytes_emitted_to_session(Δt_obs) / Δt_obs
+σ_s ← α · instant_s + (1 − α) · σ_s
+σ_s clamped to [σ_min, σ_global]
+```
+
+The upper clamp at `σ_global` enforces the physical truth that the
+session cannot observe a bus busier than the wire actually is. The
+lower clamp prevents divide-by-zero in the pacing math (§4).
+
+### 2.3 Bootstrap
+
+At session connect time, the per-session EMA has no history. Seed:
+
+```
+σ_s(t = 0) ← σ_global(t = 0)
+```
+
+After bootstrap, σ_s diverges naturally as the session's actual drain
+behaviour manifests. After ~3–5 EMA half-lives the per-session value
+fully reflects per-session conditions and the bootstrap seed has
+decayed out.
+
+### 2.4 Why per-session is the right scope
+
+A worked example: two sessions A and B observe the same bus.
+
+  - Session A is on a fast loopback link. Effective drain rate = 240
+    sym/s. σ_s_A → σ_global ≈ 115 sym/s (bounded by wire).
+  - Session B is on a congested wifi link. Effective drain rate = 60
+    sym/s. σ_s_B → 60 sym/s (drain-limited, below σ_global).
+
+A and B should each see a bus density consistent with their own link
+characteristics. A real ENS adapter on B's link would deliver bytes at
+60 sym/s — both filler SYNs and telegram bytes alike. Per-session σ_s
+reproduces this faithfully.
+
+---
+
+## 3. Latency estimators
+
+### 3.1 L_dn
+
+Measured from the proxy's own outbound exchanges with the adapter.
+Existing ENH primitive `RequestInfo` returns a small fixed-size reply
+the adapter computes locally (no wire activity). The round-trip is
+therefore dominated by `L_up + L_dn`. With symmetry assumption:
+
+```
+L_dn_EMA ≈ (T_RequestInfo_reply − T_RequestInfo_sent) / 2
+```
+
+Refreshed periodically (e.g., every 30 s) and on transport reset. The
+symmetry assumption is approximate but sufficient at SYN-period
+resolution (~9 ms granularity at σ ≈ 115).
+
+### 3.2 L_up (per transaction)
+
+Measured per-transaction when the proxy itself originates a write
+(token-holder mode). For an outbound first byte sent at `T_write_sent`,
+the first echo arrives at `T_first_echo_arrival`. The end-to-end path
+is `L_up + τ_byte_wire + L_dn`, so:
+
+```
+L_up_estimate(F) = T_first_echo_arrival − T_write_sent
+                 − τ_byte_wire
+                 − L_dn_EMA
+```
+
+Clamped at 0 (cannot be negative; on negative result, assume jitter
+absorbed L_up to within measurement noise).
+
+For cross-proxy sessions where THIS session was not the originator,
+L_up still applies — but it is the L_up of WHOEVER originated the
+telegram. The proxy attributes L_up to the originating session and
+propagates it to all cross-proxy observers of the same telegram. (See
+§4.2.)
+
+### 3.3 L_up_EMA per-session
+
+The proxy maintains `L_up_EMA[s]` for each session s, updated only on
+transactions where s was the token holder. This is the value used as
+the "L_up of telegrams originated by s" when computing prefix SYN
+counts for other sessions observing s's telegrams.
+
+```
+L_up_EMA[s] ← α · L_up_estimate(F) + (1 − α) · L_up_EMA[s]
+```
+
+---
+
+## 4. Prefix SYN count derivation
+
+### 4.1 The geometric argument
+
+Consider two cross-proxy observers, B-physical (hypothetical: B
+connected directly to an adapter on the same bus) and B-cross-proxy
+(actual: B connected through the proxy). Both observe the same
+telegram F originated by session A.
+
+B-physical's perceived idle period immediately before F's first
+visible byte:
+
+```
+idle_before_F (B-physical) = (T_F_wire_start − T_F_prev_end)
+                              + L_dn_B-physical
+```
+
+The wire was idle from the end of F-prev until A's first byte hit the
+wire (at `T_F_wire_start = T₀_A + L_up_A`). B-physical sees this idle
+window via its own adapter, length unchanged modulo its own L_dn.
+
+B-cross-proxy's perceived idle period:
+
+```
+idle_before_F (B-cross-proxy) = (T_F_emit_start_B − T_F_prev_emit_end_B)
+```
+
+For B-cross-proxy to perceive the same idle gap as B-physical (which
+is the transparency invariant of §0), the proxy must arrange for
+`T_F_emit_start_B − T_F_prev_emit_end_B` to equal the wire-side idle
+gap plus L_up_A.
+
+The "plus L_up_A" component is precisely what is invisible in the
+cross-proxy timing if no prefix SYNs are inserted: the proxy receives
+the first byte of F at `T₀_A + L_up_A + L_dn`, but the wire idle
+period actually started L_up_A earlier than that (during the wifi
+uplink transit). B-cross-proxy cannot directly witness that gap and
+the proxy must reproduce it synthetically.
+
+### 4.2 Prefix count formula
+
+The number of synthetic SYN bytes the proxy prepends to telegram F
+when emitting to session s (where s did NOT originate F; if s did
+originate F, see §6 below):
+
+```
+prefix_filler_count(F → s) = round( L_up_EMA[originator(F)] × σ_s )
+```
+
+with floor 0.
+
+Worked example:
+  - L_up_EMA[originator] = 18 ms
+  - σ_s = 90 sym/s
+  - prefix_filler_count = round(0.018 × 90) = round(1.62) = 2 SYNs
+
+The use of σ_s (per-session, not σ_global) is deliberate: it produces
+the same proportional idle window for the session, matched to its
+density model. A slow session gets fewer prefix SYNs but proportional
+to its slower clock.
+
+### 4.3 Postfix accounting
+
+There is no separate postfix count. Once telegram F's last byte is
+emitted to session s, the idle generator (§5) resumes for session s
+at rate σ_s. The "postfix" is just the natural continuation of the
+inter-telegram idle stream.
+
+If the next telegram F+1 starts before the idle generator has emitted
+any filler byte to s, that's fine — F+1's emission begins
+back-to-back, with F+1's own prefix accounting for the wifi uplink of
+F+1's originator. There is no concept of "trailing padding" needed
+after a telegram completes.
+
+---
+
+## 5. Idle generator
+
+When session s has no active telegram emission in progress, the proxy
+emits one synthetic SYN byte to s every `τ_byte_s = 1/σ_s` ms.
+
+```
+schedule_idle_byte(s, T) :
+    emit SYN to session s at time T
+    schedule next emission at T + τ_byte_s
+```
+
+Implementation: a per-session timer with period `τ_byte_s`, refreshed
+when `σ_s` changes by more than X% (avoid timer thrash on small
+fluctuations).
+
+If a telegram becomes ready to emit during an idle interval, the
+pending idle timer is cancelled, the telegram (with its prefix) is
+emitted, and the idle timer is rearmed from the end of the telegram
+emission.
+
+---
+
+## 6. Intra-telegram pacing
+
+When telegram F is ready to emit to session s, the proxy schedules
+each of its `N_F` bytes at:
+
+```
+T_byte_i(F, s) = T_F_emit_start + i × τ_byte_s
+               where i ∈ [0, N_F − 1]
+```
+
+`T_F_emit_start` = wall-clock instant emission of the first byte of F
+begins. This is precisely after the prefix SYNs (if any) have been
+emitted.
+
+Total emission time:
+
+```
+W_F_emit(s) = N_F × τ_byte_s = N_F / σ_s
+```
+
+Note `W_F_emit(s)` is NOT equal to `W_F` (the wire time on the actual
+bus). On the wire, bytes flow at the bus baud rate (~240 sym/s for
+contiguous bytes, but with inter-byte gaps the effective rate is
+lower). On session s, bytes flow at `σ_s` which is the
+session-perceived rate. The two can differ; the session sees its own
+time-base, consistent with §0.
+
+### 6.1 Originator visibility (token-holder case)
+
+When session s IS the originator of F, s is in `token-holder` mode for
+F and receives byte-level real-time visibility per §2 of the parent
+doc. The pacing math of §6 above does NOT apply to s for this F; s
+sees its own echoes byte by byte as they come back from the adapter.
+
+The pacing math applies only to the OTHER sessions (the cross-proxy
+observers of F).
+
+---
+
+## 7. Per-session emission queue
+
+### 7.1 Structure
+
+For each session s the proxy maintains:
+
+  - `queue_s`: bounded FIFO of telegrams pending emission, capacity `K_s`.
+  - `current_emission_s`: the telegram currently being paced out, plus
+    a byte index of next byte to emit.
+  - `idle_timer_s`: per-session timer for filler SYN generation.
+
+### 7.2 Enqueue path
+
+When the FSM (§5 of parent doc) reaches `DONE` for telegram F:
+
+```
+for each cross-proxy session s :
+    if len(queue_s) == K_s :
+        drop_oldest_telegram_from(queue_s)
+        record_overflow_admin_event(s, F_dropped)
+    enqueue F into queue_s with metadata { L_up_EMA[originator(F)], N_F }
+```
+
+### 7.3 Drain path
+
+```
+loop forever for each session s :
+    if current_emission_s is in progress :
+        emit next byte at scheduled time
+        if telegram fully emitted, set current_emission_s = None
+        continue
+    if queue_s is non-empty :
+        dequeue F
+        emit prefix_filler_count(F → s) SYN bytes (paced at τ_byte_s)
+        set current_emission_s = (F, byte_index=0)
+        continue
+    # nothing to emit: idle generator runs at τ_byte_s
+    wait until next idle tick
+    emit SYN to session s
+```
+
+### 7.4 Drop policy
+
+Telegram drops are always whole-telegram and oldest-first, justified
+in §9.4 of the parent doc. The admin-channel `OVERFLOW` record carries
+session id, telegram identifier, timestamp; no in-stream notice.
+
+---
+
+## 8. Worked numerical examples
+
+### Example A — fast loopback session
+
+  - Session A on Unix domain socket. σ_s_A = σ_global = 115 sym/s.
+  - L_up_EMA[originator] = 12 ms.
+  - Telegram F: B5 24 read-by-register, N_F = 22 bytes.
+
+```
+τ_byte_A           = 1 / 115 ≈ 8.7 ms
+prefix_filler_count = round(0.012 × 115) = round(1.38) = 1 SYN
+W_F_emit(A)         = 22 / 115 ≈ 191 ms
+
+emission timeline for A:
+  T_F_emit_start (relative)            : 0 ms
+  prefix SYN 1                          : 0 ms
+  telegram byte 0                       : 8.7 ms
+  telegram byte 1                       : 17.4 ms
+  …
+  telegram byte 21                      : 191.4 ms
+  idle generator resumes                : 200.1 ms
+```
+
+### Example B — slow congested session
+
+  - Session B on a high-latency WiFi-bridged TCP link.
+  - σ_s_B = 60 sym/s (drain-limited).
+  - L_up_EMA[originator] = 12 ms (same telegram from same originator).
+  - Same telegram F, N_F = 22 bytes.
+
+```
+τ_byte_B            = 1 / 60 ≈ 16.7 ms
+prefix_filler_count = round(0.012 × 60) = round(0.72) = 1 SYN
+W_F_emit(B)         = 22 / 60 ≈ 367 ms
+
+B's view of the bus is slower — telegrams take longer to emerge, idle
+intervals stretch by the same factor. A real ENS adapter delivering to
+B over its slow link would look identical.
+```
+
+### Example C — extreme jitter
+
+  - Session C, same as A's link but bus is mid-burst.
+  - σ_global momentarily spikes to 200 sym/s (heavy traffic period).
+  - σ_s_C EMA lags, sits at 130 sym/s.
+  - L_up spike measured at 80 ms for this transaction (wifi glitch).
+
+```
+prefix_filler_count = round(0.080 × 130) = round(10.4) = 10 SYNs
+```
+
+The prefix grows large to absorb the unusually long wifi uplink. The
+client sees 10 filler SYNs immediately preceding the telegram, which
+matches what a physical observer would have seen on the wire during
+the L_up window.
+
+---
+
+## 9. Invariants the model must preserve
+
+The math is correct if and only if the following invariants hold at
+all times for every cross-proxy session s:
+
+  - **I1 (rate):** The long-term rate of bytes emitted to s equals
+    `σ_s`, including filler SYNs and telegram bytes.
+  - **I2 (telegram order):** Telegrams are delivered to s in completion
+    order (the order in which FSM reached `DONE` for them).
+  - **I3 (no inter-leave):** A telegram's bytes are emitted
+    contiguously to s — no filler SYN or other telegram bytes
+    interpose mid-telegram.
+  - **I4 (proxy invisibility):** Diagnostic events, drops, overflows,
+    and proxy errors are NEVER emitted in the session byte stream.
+  - **I5 (causal):** A byte attributable to telegram F is never emitted
+    to s before F reached `DONE` on the proxy FSM.
+  - **I6 (bounded buffering):** Per-session memory is `O(K_s × N_F_max)`,
+    a small constant.
+
+If any of I1–I6 is violated, the design is wrong, not the
+implementation.
+
+---
+
+## 10. Known approximations
+
+These are deliberate simplifications. Each is listed with the
+worst-case error it introduces.
+
+| Approximation                                       | Worst-case error                                | Acceptable because                                  |
+|-----------------------------------------------------|-------------------------------------------------|----------------------------------------------------|
+| L_dn symmetric with L_up                            | ±5 ms on L_up estimate                          | below 1 SYN at σ = 115                              |
+| EMA-smoothed σ_s rather than instantaneous          | session-perceived density lags real density     | intentional — clients prefer stable view            |
+| τ_byte_s constant within a telegram                 | jitter not modeled per byte                     | telegrams are short (<200 ms); jitter averages out  |
+| Single L_up_EMA per originator                      | per-telegram L_up may differ from EMA           | smoothing across telegrams is the point             |
+| Prefix only, no postfix                             | inter-telegram idle slightly off if back-to-back | next telegram's prefix handles it                   |

--- a/architecture/adaptermux/frame-atomic-syn-padding-math.md
+++ b/architecture/adaptermux/frame-atomic-syn-padding-math.md
@@ -3,6 +3,15 @@
 > Companion to `frame-atomic-visibility.md`. Status: design sketch.
 > Branch: `frame-atomic-visibility` (multi-repo).
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 This document formalizes the per-session timing model that backs §3 and
 §4 of the parent design. The parent doc states *what* the proxy emits;
 this one states *exactly when, in what order, and based on which
@@ -429,3 +438,5 @@ worst-case error it introduces.
 | τ_byte_s constant within a telegram                 | jitter not modeled per byte                     | telegrams are short (<200 ms); jitter averages out  |
 | Single L_up_EMA per originator                      | per-telegram L_up may differ from EMA           | smoothing across telegrams is the point             |
 | Prefix only, no postfix                             | inter-telegram idle slightly off if back-to-back | next telegram's prefix handles it                   |
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v2.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v2.md
@@ -1,0 +1,396 @@
+# Frame-Atomic Visibility v2 — Echo-Gated Forwarding with Explicit Provenance
+
+> Status: design sketch v2, supersedes v1 (`frame-atomic-visibility.md`).
+> Branch: `frame-atomic-visibility` · Date: 2026-05-18
+>
+> v1 was adversarially reviewed by Codex (gpt-5.5 high-reasoning) and
+> Claude Opus (consultant). Both returned `major-rethink`. Five blockers
+> emerged from the convergent finding set:
+>
+>   B1. σ_s semantic conflation (TCP-drain ≠ perceived bus density)
+>   B2. Synthetic failure markers contradict §0 ("no proxy-injected events")
+>   B3. NACK retransmit budget unbounded
+>   B4. Wall-clock time source (must be CLOCK_MONOTONIC)
+>   B5. Byte provenance not plumbed through telegram buffer
+>
+> Plus the structural finding that **active clients cannot be insulated
+> from byte-level wire visibility** because arbitration is intrinsically
+> a byte-level protocol — any telegram-atomic abstraction at the
+> byte-stream layer creates a temporal split-brain for active sessions
+> (M5).
+>
+> v2 takes those findings as constraints and reformulates the design.
+
+---
+
+## 1. Keep the intent, drop the wrong primitive
+
+What we genuinely want, from the operator's original framing:
+
+  - The **AA-injection bug must die at root**, not be patched at byte-level for the tenth time.
+  - **Cross-client visibility must look coherent.** When the gateway writes a telegram, ebusd must not see the request bytes appearing before the wire actually transmitted them.
+  - **No client should see the proxy.** Every client behaves as if it has its own ENS-WiFi adapter on the bus.
+
+What v1 got wrong: it tried to deliver these by changing the
+*observation unit* from byte to telegram. That broke under active
+arbitration, which is byte-level by nature.
+
+v2 keeps the byte-stream observation unit (because that's what active
+clients need) and changes **two narrow things instead**:
+
+  - **(A) Provenance** — every byte carries `(value, was_escaped,
+    is_wire_syn)`. Plumbed end-to-end from adapter through proxy
+    through transport into the gateway's echo matcher.
+  - **(B) Echo-gated forwarding** — the proxy holds an outbound write
+    in its forwarder queue until the adapter echoes it back, confirming
+    wire transmission. Other clients see the byte only at echo time.
+    The originator gets the echo through the existing read path.
+
+These two changes deliver the operator's three goals without inventing
+synthetic emissions, per-session symbol rates, or telegram-atomic
+buffer queues.
+
+---
+
+## 2. What v2 is not
+
+  - **Not** a telegram-atomic byte-stream layer.
+  - **Not** a synthetic-SYN generator.
+  - **Not** a per-session symbol-rate model.
+  - **Not** a new visibility tier above the existing transport.
+  - **Not** introducing a new state machine at the proxy. The existing
+    `passive_reconstructor` and the existing adaptermux session FSM
+    cover the proxy's needs already.
+
+v2 is an instrumented byte forwarder with two narrow contracts (A) and
+(B) above.
+
+---
+
+## 3. Provenance contract (A)
+
+Every byte event the proxy emits to any client carries:
+
+```
+ByteEvent {
+    value            byte    // the actual byte
+    was_escaped      bool    // true if logical 0xAA decoded from wire 0xA9 0x01
+    is_wire_syn      bool    // true if this is a wire-level SYN (0xAA, was_escaped=false)
+    source           {own_echo, foreign_initiator, slave_response, wire_idle}
+    t_wire_observed  monotonic_nano
+}
+```
+
+Invariants on provenance:
+
+  - **I-prov-1.** `is_wire_syn` is true iff `value == 0xAA` AND
+    `was_escaped == false`.
+  - **I-prov-2.** `was_escaped` is preserved across all layers — the
+    adapter's escape decoder annotates each byte once and the
+    annotation is never lost or recomputed.
+  - **I-prov-3.** `source` is computable deterministically from the
+    arbitration FSM state at the moment of receipt — `own_echo` when
+    the session is the post-`STARTED` active initiator; otherwise
+    derived from the most recent arbitration outcome on the wire.
+
+Consequence for the AA-injection bug:
+
+  - When the adapter spontaneously injects an AUTO-SYN into the
+    gateway's mid-frame echo stream, that byte arrives at the gateway
+    with `value=0xAA, was_escaped=false, is_wire_syn=true`.
+  - The gateway's echo matcher, before round-9, treated this as an
+    echo-position byte and triggered echo_mismatch. Round-9 partially
+    handled it via a side-channel "absorb" loop that had drift bugs.
+  - Under v2, the echo matcher consumes the provenance directly:
+    `is_wire_syn=true` means **drop without advancing the expected
+    echo position**. This is a one-line semantic in matchEcho, not a
+    drain loop. No position counter shift, no timeout escalation.
+
+This is the structural fix for the AA-injection class of bug. The
+mechanism is the explicit provenance bit, not a heuristic.
+
+---
+
+## 4. Echo-gated forwarding contract (B)
+
+Today the proxy forwards every outbound byte to every connected client
+the moment it arrives from the originating client. That produces the
+"frame ripped in half" effect: ebusd sees the gateway's request bytes
+at T₀ (proxy-receive time), then nothing for `L_up + W + L_dn`, then
+the response.
+
+Under v2, outbound forwarding is gated on echo arrival:
+
+```
+When a session A writes byte b at proxy-receive time T_recv :
+  enqueue b on A's outbound staging buffer
+  forward b to the adapter immediately
+  --- adapter eventually echoes b back ---
+  when adapter delivers echo of b at T_echo :
+    dequeue b from A's staging
+    forward b to all OTHER sessions at T_echo
+    forward echo to A through the normal read path (so A can match)
+```
+
+For inbound wire activity (foreign-initiator bytes, slave responses,
+spontaneous adapter events) there is no gating — those events are
+forwarded to all sessions immediately as they were observed.
+
+Consequence:
+
+  - ebusd, when not the active initiator, sees the gateway's
+    transaction at the timing a real adapter would deliver: an idle
+    period (filler SYNs from adapter, observed and forwarded
+    immediately), then the gateway's bytes (echo-gated, arrive at
+    wire-realistic moment), then the slave response, then more idle.
+  - The "frame ripped in half" pattern disappears.
+  - No buffer queue per client — gating happens once per outbound byte
+    and the byte either lands on the wire (echoed → forwarded) or
+    didn't (arbitration FAILED → dropped, never forwarded to others,
+    matching wire reality).
+
+For arbitration losers specifically:
+
+  - Gateway sends byte 0 → adapter STARTED → adapter FAILED (some
+    other initiator won).
+  - Bytes already in A's staging buffer are silently discarded; not
+    forwarded to other clients. Other clients see the winning
+    initiator's bytes via the normal inbound path. No synthetic
+    "failure" event needed — the absence of bytes from A is the
+    natural wire signal.
+  - A itself gets the FAILED event through the existing transport
+    path. Same as today.
+
+---
+
+## 5. NACK retransmit bound (B3 from v1 review)
+
+Per eBUS V1.3.1 spec: **exactly one retransmit per phase**.
+
+This is enforced in the **active client's** FSM (e.g., the gateway's
+existing send logic), not at the proxy. The proxy is a byte mirror; it
+does not interpret NACK semantics.
+
+The active-client FSM tracks `master_retx_count` and `slave_retx_count`
+independently:
+
+```
+WAIT_MASTER_ACK on NACK with master_retx_count == 0 :
+    master_retx_count := 1
+    resend full master telegram (QQ ZZ PB SB NN DB CRC)
+    return to WAIT_MASTER_ACK
+
+WAIT_MASTER_ACK on NACK with master_retx_count >= 1 :
+    abort telegram (ErrNACK), surface to caller, emit terminator yield
+
+WAIT_SLAVE_ACK on NACK with slave_retx_count == 0 :
+    slave_retx_count := 1
+    request slave to resend response
+    return to SLAVE_LENGTH
+
+WAIT_SLAVE_ACK on NACK with slave_retx_count >= 1 :
+    abort telegram (ErrNACK), surface to caller
+```
+
+This is already approximately what `helianthus-ebusgo/protocol/bus.go`
+implements (`sendInitiatorTelegram` retries once on NACK). v2 just
+formalizes the bound explicitly and adds a unit test that proves
+unbounded retransmission cannot occur.
+
+---
+
+## 6. Time source (B4 from v1 review)
+
+All timing operations — echo-gate deadlines, retransmit timeouts,
+inter-byte gap measurement, EMA windows of the few small things we
+still measure (see §8) — use Go's `time.Now()` which is **explicitly
+monotonic on Linux** (the kernel uses CLOCK_BOOTTIME internally for
+monotonic readings on Go ≥ 1.9 on platforms where it exists, with
+CLOCK_MONOTONIC fallback).
+
+Wall-clock times are used **only** for log lines and admin-channel
+telemetry, never for scheduling or correlation logic. Negative deltas
+are unreachable by construction.
+
+---
+
+## 7. What v2 deletes from the codebase
+
+Once v2 ships, these layers can be removed from active-client paths:
+
+  - `helianthus-ebusgo/protocol/bus.go` round-9 `payloadAaAutoSyn*`
+    absorb loop and atomic counters. Replaced by the
+    `is_wire_syn`-aware echo matcher.
+  - `helianthus-ebusgateway/internal/adaptermux/mux.go` P10.2 gate,
+    `betweenWritesSyn` gate, postGrantPreEcho windowing — these all
+    exist to hide AUTO-SYN bytes from byte-stream consumers who
+    couldn't distinguish them. With explicit provenance, consumers
+    distinguish them directly.
+  - `helianthus-ebus-adapter-proxy/internal/scheduler/write/shared_path.go`
+    suppression heuristics for SYN-during-active-write.
+
+The active-client FSM stays. The transport layer stays. The
+arbitration multiplexer stays. The byte stream stays. The fixes are
+**narrowly inside echo matching and proxy forwarding**.
+
+---
+
+## 8. What v2 still measures
+
+Only what's necessary for echo-gate deadline tuning:
+
+  - **`L_dn_EMA`** — adapter→proxy latency, estimated from
+    `RequestInfo` round-trip with the symmetry assumption acknowledged
+    as approximate (see §10).
+  - **Per-byte echo arrival timeout** — bounded at `2 × L_dn_EMA +
+    spec wire byte time + safety margin`. If echo doesn't arrive
+    within this, declare wire transmission failure and drop the byte
+    from staging (matches real adapter behavior: lost byte = wire
+    didn't transmit).
+
+No per-session symbol-rate. No synthetic SYN generator. No
+prefix/postfix counting. No queue of telegrams. The proxy is
+stateless beyond the per-session staging buffer (which holds at most
+the bytes of an in-flight write — typically <20 bytes).
+
+---
+
+## 9. State diagram (active-client write path)
+
+```mermaid
+stateDiagram-v2
+    [*] --> WRITE_QUEUED
+
+    WRITE_QUEUED --> AWAIT_ARBITRATION : forward byte to adapter
+    AWAIT_ARBITRATION --> WIRE_TX : adapter STARTED
+    AWAIT_ARBITRATION --> ABORT_ARB_LOST : adapter FAILED
+
+    WIRE_TX --> WIRE_TX : echo received (is_wire_syn=false) → forward to other sessions, advance match position
+    WIRE_TX --> WIRE_TX : echo received (is_wire_syn=true) → forward to other sessions, do NOT advance match position
+    WIRE_TX --> ABORT_ECHO_TIMEOUT : echo not received within 2×L_dn_EMA + τ_byte
+
+    WIRE_TX --> WRITE_QUEUED : staging buffer not yet empty, next byte ready
+    WIRE_TX --> DONE_OWN_TELEGRAM : all bytes echoed AND active-client FSM signals telegram-complete
+
+    ABORT_ARB_LOST --> [*] : nothing forwarded to others; originator sees FAILED via read path
+    ABORT_ECHO_TIMEOUT --> [*] : byte not forwarded to others; originator sees timeout via read path
+    DONE_OWN_TELEGRAM --> [*]
+```
+
+This is the proxy's *forwarder* FSM for one outbound write. The
+active-client's own telegram FSM (master-header → master-data →
+master-CRC → wait-ack → ...) runs separately, on the read path, and
+interprets the echo stream the proxy delivered. v2 does not change
+that FSM beyond the provenance-aware NACK retransmit bound (§5).
+
+The forwarder FSM is the smallest possible state machine that
+implements echo-gated forwarding. It has no notion of telegram
+boundaries — it forwards byte-by-byte based on echo arrival.
+
+---
+
+## 10. Invariants
+
+  - **I0 (clock):** All scheduling and correlation timestamps are
+    monotonic. Wall-clock used only for human-readable logs.
+  - **I1 (provenance):** `(was_escaped, is_wire_syn)` is preserved on
+    every byte from adapter receipt to client emission. No layer
+    recomputes it.
+  - **I2 (echo gate):** A byte enqueued for write by session A is
+    forwarded to other sessions **only after** the adapter echoes it.
+  - **I3 (silent drop):** If a queued byte is not echoed within the
+    deadline, it is silently discarded. No synthetic failure event is
+    emitted into the byte stream — the absence of the byte is the
+    natural wire signal.
+  - **I4 (retx bound):** master_retx_count ≤ 1, slave_retx_count ≤ 1
+    per telegram. Enforced in the active client's FSM, unit-tested.
+  - **I5 (no proxy events):** The proxy never inserts a byte into a
+    session's read stream that did not correspond to an actual
+    adapter event. Diagnostic counters live on a separate admin
+    channel.
+  - **I6 (forwarding fan-out):** A wire event is forwarded to all
+    connected sessions equally, modulo the echo-gate filter that
+    suppresses outbound bytes from the originator's view of other
+    initiators (see §11 for the gateway-arbitrates case).
+
+---
+
+## 11. The gateway-arbitrates / ebusd-observes case (operator's original concern)
+
+Worked example with concrete numbers.
+
+Setup: gateway is active initiator, ebusd is connected and observing.
+Both via TCP/ENS to the proxy. L_up = 12 ms, L_dn = 8 ms, wire byte
+time ~4 ms, telegram length 22 bytes.
+
+Timeline (wall-clock from gateway's send):
+
+| t          | gateway                  | proxy                                          | ebusd                          |
+|-----------:|--------------------------|------------------------------------------------|--------------------------------|
+| T₀         | sends byte 0 to proxy    | enqueues b₀ on gateway staging                 | sees nothing for b₀ yet        |
+| T₀ + L_up  | —                        | adapter transmits b₀ on wire                   | —                              |
+| +L_up+~4ms | —                        | wire echo of b₀ arrives at adapter             | —                              |
+| +L_up+L_dn | receives echo of b₀     | adapter delivers echo to proxy                 | **forwarded b₀ to ebusd**       |
+| (repeat for b₁..b₂₁ with same offset)                                                                                |
+| T_slave    | reads slave response     | adapter forwards slave bytes                   | forwarded slave bytes          |
+| T_end      | reads terminator         | adapter forwards terminator SYN                | forwarded terminator           |
+
+ebusd's view: filler SYNs (forwarded immediately from adapter idle),
+then the gateway's request bytes arriving at wire-time, then slave
+response, then terminator. Indistinguishable from what ebusd would see
+if it had its own ENS adapter on the same bus.
+
+If an AUTO-SYN injects mid-telegram (the round-9 motivating scenario):
+
+  - Adapter sends AUTO-SYN to proxy with `is_wire_syn=true`.
+  - Proxy forwards immediately to all sessions including gateway and
+    ebusd.
+  - Gateway's echo matcher: `is_wire_syn=true` → drop, no position
+    advance. Continues waiting for the actual echo of its next byte.
+    The actual echo arrives next, matches, advances. No
+    `echo_mismatch`, no `timeout`, no drain loop.
+  - ebusd's parser: same provenance — AUTO-SYN treated as wire idle,
+    no impact on its own telegram parsing.
+
+---
+
+## 12. What this does NOT solve
+
+Honest accounting of what stays open:
+
+  - **Slow client backpressure on outbound staging buffer.** If session
+    A writes faster than the adapter accepts (rare on a 2400-baud wire
+    but possible during burst), the staging buffer grows. v2 caps it
+    at the maximum eBUS telegram size (~40 bytes) and drops the write
+    with a transport-layer `EAGAIN`-equivalent. Same behavior a real
+    adapter would have on a full TX FIFO.
+  - **Multi-initiator wire collisions.** If two clients write
+    simultaneously, the arbitration multiplexer (`adaptermux`) decides
+    the winner via the existing FSM. v2 changes nothing here.
+  - **Slave-response retransmit count enforcement** requires the
+    active-client FSM update (§5) which lands in `helianthus-ebusgo`
+    behind v2's plumbing changes. It is a strict implementation pin,
+    not new design.
+
+---
+
+## 13. Migration path
+
+  1. **Plumb provenance** (`is_wire_syn`) through the existing transport
+     stack. Touch points: ENH transport `ReadByteWithEscape`, proxy's
+     forwarder, adaptermux read loop. Backward compatible with
+     existing matchers (default `is_wire_syn=false`).
+  2. **Switch echo matcher** to consume provenance directly. Remove
+     round-9 absorb loop. Land in `helianthus-ebusgo`. Verify on live
+     bus that AA-injection no longer triggers echo_mismatch or timeout.
+  3. **Echo-gate the proxy forwarder.** Add staging buffer. Modify
+     forward-to-other-sessions to fire on echo, not on receive. Land
+     in `helianthus-ebus-adapter-proxy`. Verify on live bus that ebusd
+     sees coherent telegram timing.
+  4. **Pin NACK retransmit count** to exactly 1 per phase, add unit
+     tests in `helianthus-ebusgo/protocol`.
+  5. **Audit and remove dead gates** (P10.2, betweenWritesSyn,
+     postGrantPreEcho windowing) once steps 1-3 are validated.
+
+Each step is independently verifiable and rollback-able. No "big
+bang" migration.

--- a/architecture/adaptermux/frame-atomic-visibility-v2.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v2.md
@@ -21,6 +21,15 @@
 >
 > v2 takes those findings as constraints and reformulates the design.
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 ---
 
 ## 1. Keep the intent, drop the wrong primitive
@@ -394,3 +403,5 @@ Honest accounting of what stays open:
 
 Each step is independently verifiable and rollback-able. No "big
 bang" migration.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v3.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v3.md
@@ -1,0 +1,421 @@
+# Frame-Atomic Visibility v3 — Proxy-Side AA Filter + Echo-Gated Paced Forwarding
+
+> Status: design sketch v3, supersedes v1 (`frame-atomic-visibility.md`)
+> and v2 (`frame-atomic-visibility-v2.md`). Both predecessors received
+> `major-rethink` from convergent Codex + Opus reviews.
+>
+> Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+## 1. What went wrong in v1 and v2
+
+**v1** tried telegram-atomic visibility at the byte-stream layer with
+synthetic SYN padding. Killed on 5 blockers: σ_s conflation, synthetic
+failure markers, NACK unbounded, wall clock, byte provenance not
+plumbed. Plus structural finding M5: active arbitration is intrinsically
+byte-level; any telegram-atomic abstraction breaks for active clients
+("temporal split brain").
+
+**v2** kept byte-stream and added (A) provenance bit `is_wire_syn`
+plumbed through every event, (B) outbound forwarding gated on echo
+arrival from adapter. Killed on 6 new blockers:
+
+  - **B-v2-1.** `is_wire_syn` conflates wire-terminator SYN (telegram
+    boundary) with adapter-injected idle SYN (mid-frame leak). Same
+    triple `(0xAA, was_escaped=false, is_wire_syn=true)` covers both.
+    Active FSM stuck at terminator.
+  - **B-v2-2.** ebusd and other existing ENS clients **cannot receive**
+    `ByteEvent` metadata — ENS protocol delivers raw bytes, not tagged
+    events. The cross-client claim is false for any client that wasn't
+    rewritten.
+  - **B-v2-3.** Forwarder `DONE_OWN_TELEGRAM` state requires
+    active-client FSM signal → coupling that contradicts the
+    "no proxy state machine" §2 claim.
+  - **B-v2-4.** Echo identity matching unspecified. FIFO ordering broken
+    by interleaved AA-injection if not explicitly handled.
+  - **B-v2-5.** Echo-arrival batching (TCP Nagle + Go scheduler) bursts
+    4-8 bytes within sub-ms; wire actually transmits them 4 ms apart.
+    Inter-byte timing realism lost.
+  - **B-v2-6.** Echo loss ≠ wire didn't transmit. v2 silently suppresses
+    bytes that may have hit the wire when the adapter's reply path
+    drops.
+
+## 2. v3 pivot — move filtering into the proxy, drop client metadata
+
+The core realization: v2 tried to push provenance bits to clients.
+**Clients (especially ebusd) cannot receive them** because ENS is a
+plain byte stream. So the only way to give clients a clean view is for
+the proxy itself to deliver a clean wire-equivalent byte stream —
+**filtering invented bytes (AA-injection) out and pacing real bytes
+correctly**, doing this on behalf of every client.
+
+The proxy becomes a **content-aware wire mirror**: it consumes ENH
+events from the adapter, classifies each byte using its own knowledge
+of what active sessions wrote, and emits a clean wire-equivalent ENH
+byte stream to each connected session. No metadata leaves the proxy.
+
+This is what the operator's original "no client should see the proxy"
+invariant actually requires. v1 and v2 misread it as "clients carry
+provenance" — wrong direction. v3 reads it correctly: clients see
+**only wire-equivalent bytes** as if from a private adapter on the bus.
+
+## 3. Provenance stays **internal** to the proxy
+
+The proxy still uses `(value, was_escaped)` annotation internally — the
+escape-decoder annotation that the ENH transport already produces. This
+is the existing transport-layer contract; v3 does not extend it.
+
+Crucially, the proxy:
+
+  - **Uses** `was_escaped` internally to disambiguate `(0xAA, escaped)`
+    payload from `(0xAA, raw)` wire-SYN candidates.
+  - **Does not forward** the `was_escaped` flag to clients. Clients see
+    raw ENH-protocol bytes (with escape sequence `0xA9 0x01` for
+    payload 0xAA, raw `0xAA` for wire SYN). Clients run their existing
+    escape decoders on receipt. No protocol extension. Full backward
+    compatibility with ebusd, vrc-explorer, etc.
+
+This eliminates B-v2-2 entirely.
+
+## 4. AA-injection filter via per-session FIFO match
+
+Each active session that is currently writing has a **staging
+buffer** in the proxy containing the bytes it has handed to the proxy
+but for which the adapter has not yet echoed.
+
+When an ENH RECEIVED event arrives from the adapter (in any session's
+arbitration window — that is, between adapter `STARTED` and adapter
+`FAILED`/wire-terminator), the proxy classifies:
+
+```
+classify_received(ev: ENHEvent) -> Classification:
+  if active_session_A has nonempty staging AND we are post-STARTED for A:
+      next = staging.peek()
+      if ev.value == next.logical_value AND ev.was_escaped == next.is_escaped_emission:
+          # This is the echo of next.
+          MATCH; staging.pop()
+          return ECHO_OF_OWN_WRITE
+      if ev.value == 0xAA AND ev.was_escaped == false:
+          # 0xAA, raw, but next staged byte is not a wire-SYN-shaped match.
+          # This is an adapter-injected idle byte mid-frame. The wire did
+          # NOT transmit this — the adapter buffered it spontaneously.
+          return AA_INJECTION_DROP
+      # Anything else mid-frame is a hard protocol fault.
+      return PROTOCOL_FAULT
+  else:
+      # No active write outstanding. RECEIVED is foreign-initiator
+      # traffic or wire idle from another initiator's slot.
+      return FOREIGN_OR_IDLE
+```
+
+Each classification has a deterministic dispatch:
+
+  - `ECHO_OF_OWN_WRITE`: forward to originator session A immediately via
+    its read path (A needs it for state). Schedule forwarding to **other**
+    sessions through the pacer (§5).
+  - `AA_INJECTION_DROP`: do nothing. The byte is invented by the adapter
+    buffer; no client should see it. Originator's matchEcho never sees
+    it either — eliminating the round-9 absorb-loop bug at source.
+  - `FOREIGN_OR_IDLE`: forward to all sessions equally through the
+    pacer.
+  - `PROTOCOL_FAULT`: surface as a transport-layer fault on the
+    originator's connection. This is a real fault, not a synthetic
+    event — equivalent to what a real adapter would surface as
+    "transmission corruption".
+
+**Terminator SYN** (the 0xAA that ends a telegram on the wire) falls
+into `FOREIGN_OR_IDLE` if `staging` is empty (active write completed)
+or into `ECHO_OF_OWN_WRITE` if the active client's last staged byte
+was a logical 0xAA. Either way it advances correctly through the
+classifier — no conflation with AA-injection because injection only
+fires when there's a NON-matching pending staged byte. This kills
+B-v2-1.
+
+## 5. Wire-rate pacer for outbound to other sessions
+
+When the classifier produces a byte that must go to **other** sessions
+(non-originator), it is **not** forwarded immediately. It enters a
+per-session outbound queue and is scheduled to flush at **wire byte
+rate**:
+
+```
+τ_wire_byte = 1 / 240 sym/s = 4.17 ms      # constant, from eBUS spec
+```
+
+Each outbound session maintains a single per-session pacer timer. When
+a byte enters the queue:
+
+```
+if queue was empty:
+    schedule first byte at T_now + τ_wire_byte
+else:
+    next byte fires at (last_emit_time + τ_wire_byte)
+```
+
+The pacer is **wire-rate constant**, not a per-session symbol-rate
+EMA. There is no observability metric; the rate is the bus spec.
+
+This kills B-v2-5 (echo batching destroys timing realism) by
+explicitly imposing the wire-side inter-byte gap on outbound forwarding
+regardless of what TCP delivery pattern the adapter produces.
+
+Cost: one timer per session, period 4.17 ms when there is work. With N
+sessions, peak timer firings = N × 240/s = 240N/s in the worst case
+(all sessions saturated with telegrams). At N=10 that's 2400 fires/s
+— well within Go's runtime budget. At idle, queues are empty and the
+timer is parked; no thrash.
+
+If the queue grows faster than the pacer drains (sustained burst beyond
+wire rate, which cannot happen on a real wire but can happen as a
+transient if multiple foreign initiators batched at the adapter):
+drop **oldest queued byte** with a counter increment on the admin
+channel. No in-stream notice — same drop policy a real overflowing
+adapter would have, no proxy-visible event.
+
+## 6. NACK retransmit bound (B3 from v1, still relevant)
+
+Per eBUS V1.3.1: exactly one retransmit per phase.
+
+Two enforcement points:
+
+  - **Active client FSM** enforces its own retransmit count per phase.
+    Already approximately implemented in
+    `helianthus-ebusgo/protocol/bus.go`; v3 formalizes the bound and
+    unit-tests it.
+  - **Proxy** enforces a global cap of **2 retransmit attempts per
+    telegram across all sessions**. If a different (non-Helianthus)
+    client misbehaves and retransmits 4+ times, the proxy drops the
+    third+ retransmit at the staging layer with an admin-channel
+    counter event. This prevents B-v2-3 (B3 not globally eliminated)
+    by giving the proxy its own ceiling.
+
+## 7. Time source
+
+All proxy scheduling uses Go's `time.Now()` (monotonic on Linux via
+`CLOCK_BOOTTIME` / `CLOCK_MONOTONIC` per Go ≥ 1.9 runtime). Wall clock
+appears only in log lines and admin-channel telemetry. No
+correlation logic uses wall clock.
+
+## 8. Echo timeout vs wire transmission ambiguity (B-v2-6)
+
+v2 said "if echo doesn't arrive, the byte wasn't transmitted." Codex
+correctly flagged this is false: adapter could transmit then lose its
+own reply path.
+
+v3 resolution: **distinguish three echo-timeout cases**:
+
+  - **Soft timeout** (echo expected within `L_dn_EMA + 50ms` window
+    but not yet arrived): hold byte in staging, do NOT forward to
+    others yet, do NOT abort. Wait one more window.
+  - **Hard timeout** (`2 × L_dn_EMA + 200ms` after byte sent to
+    adapter): declare adapter transport degraded. Surface
+    `ADAPTER_DEGRADED` to **admin channel** (not byte stream). Drop
+    staging. Originator's transport-layer read deadline (managed by
+    its own ENS implementation) fires independently.
+  - **Adapter RESETTED event arrives**: drop all staging across all
+    sessions. Forward RESETTED to all sessions on the byte stream —
+    this IS a real adapter event the wire would deliver. Not
+    synthetic. Not a proxy invention.
+
+This eliminates B-v2-6: the proxy never silently invents a
+"transmission failure" — it surfaces adapter-real degradation
+explicitly on admin channel, and lets clients' own transport
+deadlines handle correctness independently. The byte stream
+delivered to clients remains 100% wire-derived.
+
+## 9. Pipelining and per-session invariant
+
+**One outbound write in flight per session**. If a session attempts a
+second write before the first has fully completed (staging emptied or
+RESETTED), the second write blocks at the proxy's TCP receive layer
+(socket back-pressure) until staging clears. No queueing of multiple
+writes within a single session. Eliminates B-v2-2-equivalent (Opus's
+"pipelined writes vs single staging buffer" race).
+
+## 10. Session disconnect during in-flight write
+
+On TCP disconnect:
+
+  - Bytes still in staging buffer: drop. They cannot be echoed to a
+    nonexistent connection, and they were not yet confirmed on the
+    wire to forward to others.
+  - Bytes already classified `ECHO_OF_OWN_WRITE` but still in pacer
+    queue toward other sessions: continue emission. These represent
+    wire activity that has already happened; other sessions should
+    see them per wire reality. The disconnected session is gone, but
+    its already-emitted-on-wire bytes are committed.
+
+Matches what would happen if a real adapter had a session cable yanked
+mid-write: bytes on wire stay on wire, bytes still in adapter buffer
+are lost.
+
+## 11. State diagram — proxy classifier (the only proxy FSM)
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE_AT_PROXY
+
+    IDLE_AT_PROXY --> ADAPTER_STARTED_FOR_SESSION_A : ENH STARTED for session A's write
+    IDLE_AT_PROXY --> FOREIGN_OR_IDLE_FORWARD : ENH RECEIVED with no active session writing
+
+    ADAPTER_STARTED_FOR_SESSION_A --> ECHO_CLASSIFIER : ENH RECEIVED arrives
+    ECHO_CLASSIFIER --> ECHO_FORWARD_TO_OTHERS : ev matches staging head
+    ECHO_CLASSIFIER --> DROP_AA_INJECTION : ev = (0xAA, raw) AND head != 0xAA-shaped
+    ECHO_CLASSIFIER --> PROTOCOL_FAULT_TO_ORIGINATOR : ev mismatches head, not AA-injection
+
+    ECHO_FORWARD_TO_OTHERS --> ADAPTER_STARTED_FOR_SESSION_A : staging not empty
+    ECHO_FORWARD_TO_OTHERS --> IDLE_AT_PROXY : staging empty (last byte's echo consumed)
+
+    DROP_AA_INJECTION --> ADAPTER_STARTED_FOR_SESSION_A : continue
+
+    PROTOCOL_FAULT_TO_ORIGINATOR --> IDLE_AT_PROXY : surface fault, drop staging
+
+    ADAPTER_STARTED_FOR_SESSION_A --> ADAPTER_RESETTED : ENH RESETTED event
+    IDLE_AT_PROXY --> ADAPTER_RESETTED : ENH RESETTED event
+    FOREIGN_OR_IDLE_FORWARD --> IDLE_AT_PROXY : forwarded to all
+
+    ADAPTER_RESETTED --> IDLE_AT_PROXY : drop all staging, forward RESETTED to all
+```
+
+No "DONE_OWN_TELEGRAM" state. No notion of telegram boundary in the
+proxy FSM. The proxy is pure byte-by-byte classifier. Telegram
+boundaries are entirely an active-client FSM concern (in
+`helianthus-ebusgo/protocol/bus.go`). Kills B-v2-3.
+
+## 12. Invariants
+
+  - **I0 (clock):** All scheduling uses monotonic time.
+  - **I1 (no synthetic bytes):** Every byte forwarded to a session was
+    derived from a real ENH event from the adapter. The proxy never
+    invents bytes.
+  - **I2 (AA-injection invisible to all):** A byte classified as
+    `DROP_AA_INJECTION` is forwarded to **zero** sessions, including
+    the originator. The originator's matchEcho therefore never sees
+    AA-injection; round-9 absorb logic becomes dead code.
+  - **I3 (wire-rate pacing):** Outbound bytes to non-originator sessions
+    are emitted with inter-byte gap ≥ τ_wire_byte (4.17 ms).
+    Originator gets its echo via the read path with no extra delay
+    (originator needs immediate feedback for state).
+  - **I4 (fault visibility):** Real adapter events (RESETTED, FAILED,
+    STARTED) are forwarded to all sessions on the byte stream.
+    Proxy-internal diagnostics (queue overflow, classifier fault,
+    L_dn anomalies) appear only on the admin channel.
+  - **I5 (one in-flight write per session):** Pipelined writes
+    block at TCP receive layer until staging clears.
+  - **I6 (retransmit cap):** Active-client FSM enforces 1 retransmit
+    per phase. Proxy enforces 2 retransmit attempts per telegram as
+    a backstop.
+  - **I7 (disconnect):** On session disconnect, drop in-flight staging;
+    already-classified `ECHO_OF_OWN_WRITE` bytes already in pacer
+    queue toward others are committed and continue emission.
+  - **I8 (memory):** Per-session staging ≤ 80 bytes (one telegram with
+    full escape allowance + retransmit overhead). Per-session pacer
+    queue ≤ 240 bytes (one second of wire traffic worst-case). Total
+    proxy memory bound: O(N × 320) where N is connected session count.
+
+## 13. L_dn_EMA concrete tuning
+
+  - **Initial value at startup:** 15 ms (typical wifi-bridge latency
+    for our deployment).
+  - **EMA update:** every `RequestInfo` exchange (existing primitive,
+    fires every 30 s and on transport reset). Smoothing α = 0.25.
+  - **Bounds:** clamped to `[2 ms, 200 ms]`. Spike beyond 200 ms is
+    counted as outlier (admin counter) and ignored for EMA update.
+  - **Used only for:** echo timeout windows in §8 (soft = `L_dn + 50`,
+    hard = `2L_dn + 200`).
+  - **Not used for:** byte pacing (which uses constant τ_wire_byte),
+    prefix calculation (which doesn't exist), or any visibility logic.
+
+L_dn precision below 5 ms is irrelevant since the next granularity up
+(the echo deadline window) has a 50 ms safety margin.
+
+## 14. Locking discipline
+
+Single proxy-wide mutex protects:
+
+  - The active-session pointer (which session, if any, is currently
+    post-STARTED).
+  - Each session's staging buffer.
+
+Per-session pacer timers fire on their own goroutine and acquire only
+the session's own pacer queue lock (not the proxy-wide mutex).
+
+Adapter read goroutine acquires proxy-wide mutex once per classified
+RECEIVED event. Lock window is bounded by classifier evaluation
+(O(1)). No nested locks. No condition variables.
+
+## 15. What v3 deletes
+
+Once landed:
+
+  - **All of round-9** (`payloadAaAutoSyn*` absorb + atomic counters
+    in `helianthus-ebusgo/protocol/bus.go`).
+  - **All of round-7** (`P10.2` gate, `betweenWritesSyn`,
+    `queueJustDrained` sentinel in
+    `helianthus-ebusgateway/internal/adaptermux/`).
+  - **The `postGrantPreEcho` window** in
+    `helianthus-ebusgo/transport/enh_transport.go`.
+  - All suppression heuristics in
+    `helianthus-ebus-adapter-proxy/internal/scheduler/write/shared_path.go`.
+
+These layers exist to handle leaks that v3 eliminates upstream of
+them.
+
+## 16. What v3 does NOT solve
+
+Honest accounting:
+
+  - **Adapter that loses bytes after physical transmission.** If the
+    adapter transmits on the wire but its own internal reply path
+    drops the echo before the proxy receives it, the proxy treats it
+    as never transmitted and other sessions never see it. This
+    matches what an independent adapter on the same bus would do
+    (without echo loopback there's no way to know what was
+    transmitted). Tradeoff: cross-client view loses bytes the wire
+    did transmit. Mitigation: real wifi adapters have ≪0.1% byte loss
+    on the proxy path; the rate is bounded.
+  - **Cross-session **clock** skew.** Two sessions with different TCP
+    link latencies see the same wire byte at slightly different
+    wall-clock times on their side. This is inherent to TCP; a real
+    adapter scenario would also have it. Not a v3 problem.
+  - **The proxy is now stateful.** It maintains the active-session
+    pointer, the staging buffer, L_dn_EMA, and N pacer queues. Crash
+    recovery: on proxy restart, all sessions reconnect, all staging
+    is empty by definition. No persistence needed.
+
+## 17. Migration
+
+  1. Plumb the classifier into the proxy. Touch:
+     `helianthus-ebus-adapter-proxy/internal/adapterproxy/server.go`.
+     Provenance (was_escaped) is already produced by the ENH
+     transport's escape decoder — wire it into the classifier.
+  2. Add per-session staging buffer + pacer.
+  3. Verify on live bus: AA-injection metric drops to zero, no
+     echo_mismatch in either active or cross-proxy reads, ebusd's
+     view of gateway transactions is coherent (no "frame ripped in
+     half" pattern).
+  4. Delete round-9, round-7, postGrantPreEcho, shared_path
+     heuristics. Verify Prometheus error rates stay at v3 levels.
+  5. Unit-test NACK retransmit cap and admin-channel counters.
+
+Each step independently verifiable. No big-bang migration.
+
+## 18. How v3 maps onto the convergent v1+v2 findings
+
+| Finding from v1+v2 reviews | v3 resolution |
+|---|---|
+| v1 B1 σ_s conflation | No σ_s anywhere. Wire-rate constant τ_wire_byte. |
+| v1 B2 synthetic failure markers | No synthetic events; faults via admin channel or real adapter events. |
+| v1 B3 NACK retransmit unbounded | Pinned at 1 per phase (active-client) + 2 per telegram (proxy backstop). |
+| v1 B4 wall clock | Monotonic everywhere. |
+| v1 B5 byte provenance not plumbed | Provenance stays INTERNAL to proxy; clients see raw wire bytes. |
+| v1 M1 cross-session ordering | All sessions paced at same wire rate; ordering preserved. |
+| v1 M2 role transition leak | No telegram-atomic mode — no role transition needed. |
+| v1 M3 L_dn symmetry | L_dn used only for echo-timeout window (50/200 ms margin), not for visibility math. |
+| v1 M4 per-byte timers | One per-session pacer at 4.17 ms; bounded. |
+| v1 M5 temporal split-brain | No replay queue, no telegram-atomic — no split-brain. |
+| v2 B-v2-1 is_wire_syn conflates | Classifier uses staging-aware FIFO; no static "is_wire_syn" bit. |
+| v2 B-v2-2 clients can't get metadata | Provenance stays in proxy; clients get raw bytes (unchanged ENS protocol). |
+| v2 B-v2-3 forwarder couples to active-client FSM | Proxy classifier has no telegram concept. |
+| v2 B-v2-4 echo identity matching unspecified | Explicit FIFO match using (value, was_escaped) on staging head. |
+| v2 B-v2-5 echo batching destroys timing | Pacer at τ_wire_byte (4.17 ms) on outbound to others. |
+| v2 B-v2-6 echo loss ≠ wire didn't transmit | Acknowledged in §16 as residual, admin-channel reported. |

--- a/architecture/adaptermux/frame-atomic-visibility-v4.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v4.md
@@ -1,0 +1,503 @@
+# Frame-Atomic Visibility v4 — Proxy with Minimal Active-Telegram FSM
+
+> Status: design sketch v4. Supersedes v1, v2, v3. All three predecessors
+> received `major-rethink` from convergent Codex + Opus reviews.
+> Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+## 1. What v3 got wrong
+
+v3 inverted the model correctly (proxy holds intelligence, clients get
+clean wire-equivalent stream) but tried to do it **without any
+telegram-structure state** at the proxy. The reviews showed this is
+provably insufficient. The convergent findings between Codex and Opus
+on v3:
+
+  - **idle-state AA-injection invisible to classifier (both flagged).**
+    When no active session is writing, `FOREIGN_OR_IDLE` forwards every
+    0xAA byte to all clients indistinguishably — adapter-spurious AA
+    and wire-real AUTO-SYN have the same encoding. The motivating bug
+    survives v3 exactly in the steady-state case.
+  - **escape-pair-interrupted-by-AA (Codex unique).** Wire sequence
+    `0xA9 0xAA 0x01` is what AA-injection mid-escape looks like. The
+    escape decoder consumes `0xA9`, sees `0xAA` as invalid escape
+    continuation, resets state, emits `0x01` as a raw byte. The
+    AA-injection event never reaches the classifier as an AA-injection.
+  - **NACK retransmit cap requires telegram state (both flagged).**
+    v3 §6 promises proxy-side bound of "2 retransmits per telegram"
+    while §11 forbids any telegram concept at the proxy. Contradiction.
+  - **inter-write empty-staging window (Codex strawman, Opus B-v3-3).**
+    Between echo-of-byte-K and the proxy's TCP receive of byte-K+1,
+    staging is empty. Adapter-injected AA in this window is forwarded
+    as `FOREIGN_OR_IDLE`. This is the round-7 `queueJustDrained` hole
+    v3 explicitly claims to delete — but v3 doesn't actually fix it.
+  - **L_dn outlier-ignore loses real bytes (both flagged).**
+    Sustained WiFi spike with outliers clamped out leaves EMA low →
+    hard timeout fires → real bytes dropped from staging → late
+    echoes orphaned as `FOREIGN_OR_IDLE`.
+
+Plus from Codex: the `was_escaped` annotation **does not exist** in
+the current proxy code (`internal/southbound/enh/codec.go` parses ENH
+frames but does not run the eBUS escape decoder). v3 referenced a
+feature the codebase doesn't have.
+
+Plus from Opus: pacer-as-metronome at constant τ_wire_byte = 4.17ms
+creates a detectable regime change at the idle↔active boundary; and
+the pacer head-of-line blocks cross-session traffic on slow drain.
+
+## 2. v4 pivot — minimal active-telegram FSM, pacer as rate-limiter
+
+v4 accepts a small concession v3 refused: **the proxy maintains a
+minimal eBUS telegram structure FSM for each active session**, mirroring
+the existing `passive_reconstructor` in `helianthus-ebusgo`. The FSM
+tracks phase position (master header → master data → master CRC → ACK
+→ slave response → ... → terminator) based on what the active client
+has sent and what the adapter has echoed.
+
+This FSM is the SINGLE state machine that replaces every previous
+heuristic gate (round-7 `queueJustDrained`, round-9 absorb loop,
+`P10.2`, `betweenWritesSyn`, `postGrantPreEcho`). It is also the SAME
+state machine used by the existing `passive_reconstructor`; v4 extracts
+it into a shared library and instantiates one per active session in the
+proxy.
+
+Additionally:
+
+  - **Pacer is a rate-limiter, not a metronome.** It enforces
+    `inter-byte gap ≥ τ_wire_byte` but does not generate inter-byte
+    gaps when none are needed. Wire-natural gaps (idle SYN at 35ms)
+    pass through at their natural rate; only TCP-batched echo bursts
+    get artificially slowed.
+  - **Escape decoder is AA-aware.** When waiting for the second byte
+    of an escape pair (`0xA9` seen, awaiting next), any intervening
+    `0xAA` bytes are recognized as AA-injection and dropped from the
+    escape collection. Decoder state survives the injection.
+  - **L_dn tracks all samples** in a wide bound, no outlier-ignore.
+  - **Cadence-based idle filter.** When the FSM is in IDLE state, the
+    proxy applies a minimum inter-SYN gap of 25ms. Any 0xAA byte
+    arriving sooner than 25ms after the previous 0xAA is identified
+    as adapter-spurious and dropped.
+
+## 3. The FSM (single source of truth)
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> ARBITRATING : ENH STARTED received
+    ARBITRATING --> MASTER_HEADER : grant resolved + first echo byte
+    ARBITRATING --> IDLE : ENH FAILED
+
+    MASTER_HEADER --> MASTER_DATA : header bytes (QQ ZZ PB SB NN) consumed, NN>0
+    MASTER_HEADER --> MASTER_CRC : header consumed, NN=0
+    MASTER_DATA --> MASTER_CRC : NN data bytes consumed
+    MASTER_CRC --> WAIT_TERMINATOR_SYN : ZZ=0xFE (broadcast)
+    MASTER_CRC --> WAIT_MASTER_ACK : otherwise
+
+    WAIT_MASTER_ACK --> MASTER_RETX : NACK, master_retx_count=0
+    WAIT_MASTER_ACK --> ABORTED_NACK : NACK, master_retx_count>=1
+    WAIT_MASTER_ACK --> WAIT_TERMINATOR_SYN : ACK + master-master
+    WAIT_MASTER_ACK --> SLAVE_LENGTH : ACK + master-slave
+
+    MASTER_RETX --> MASTER_HEADER : master_retx_count := 1, resend master block
+    SLAVE_LENGTH --> SLAVE_DATA : NN'>0
+    SLAVE_LENGTH --> SLAVE_CRC : NN'=0
+    SLAVE_DATA --> SLAVE_CRC : NN' bytes consumed
+    SLAVE_CRC --> WAIT_SLAVE_ACK
+
+    WAIT_SLAVE_ACK --> SLAVE_RETX : NACK, slave_retx_count=0
+    WAIT_SLAVE_ACK --> ABORTED_NACK : NACK, slave_retx_count>=1
+    WAIT_SLAVE_ACK --> WAIT_TERMINATOR_SYN : ACK
+
+    SLAVE_RETX --> SLAVE_LENGTH : slave_retx_count := 1, slave resends
+
+    WAIT_TERMINATOR_SYN --> IDLE : SYN observed (terminator)
+
+    ABORTED_NACK --> IDLE
+```
+
+**RESETTED transitions (from any state):** ENH RESETTED event causes
+the FSM to drop to IDLE, drop staging, drop pacer queue. RESETTED is
+forwarded to all sessions as a real adapter event (not synthetic).
+
+**ABORTED on timeout (from any state with deadline):** per-state
+timeout exceeded → IDLE. Timeout exit is observed by absence of bytes;
+no synthetic byte event injected.
+
+Implementation: this FSM is the **same code** as
+`helianthus-ebusgo/protocol/passive_reconstructor.go`. Extracted into a
+shared library; the proxy and the passive reconstructor instantiate
+the same machine for different purposes.
+
+## 4. AA-injection classifier (driven by FSM phase)
+
+The classifier replaces v3's staging-emptiness rule with FSM-state
+rule. For each ENH event:
+
+```
+classify(ev: ENHEvent, fsm_state: FSM):
+  switch fsm_state:
+    case IDLE:
+      if ev is RECEIVED(0xAA, raw):
+        if (T_now - T_last_syn_at_proxy) < 25ms:
+          return AA_INJECTION_SPURIOUS_DROP
+        else:
+          T_last_syn_at_proxy := T_now
+          return WIRE_REAL_IDLE_SYN_FORWARD
+      else if ev is STARTED:
+        return FSM_TRANSITION_ARBITRATING
+
+    case ARBITRATING, MASTER_HEADER, MASTER_DATA, MASTER_CRC,
+         SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC:
+      expected_logical = staging.peek_or_predict_from_fsm()
+      if ev is RECEIVED(expected_logical.value, expected_logical.was_escaped):
+        staging.pop()
+        fsm.advance()
+        return ECHO_OF_OWN_WRITE_FORWARD
+      else if ev is RECEIVED(0xAA, raw) AND expected_logical != logical_0xAA:
+        return AA_INJECTION_MID_FRAME_DROP
+      else:
+        return PROTOCOL_FAULT_TO_ORIGINATOR
+
+    case WAIT_MASTER_ACK, WAIT_SLAVE_ACK:
+      expected ∈ {ACK=0x00, NACK=0xFF}
+      if ev is RECEIVED(ACK) or RECEIVED(NACK):
+        fsm.advance_per_value()
+        return ECHO_OR_ACK_FORWARD
+      else if ev is RECEIVED(0xAA, raw):
+        return AA_INJECTION_MID_FRAME_DROP   # ACK phase doesn't have SYNs
+      else:
+        return PROTOCOL_FAULT
+
+    case WAIT_TERMINATOR_SYN:
+      if ev is RECEIVED(0xAA, raw):
+        fsm.advance_to_IDLE()
+        T_last_syn_at_proxy := T_now
+        return TERMINATOR_SYN_FORWARD
+      else if ev is RECEIVED(other):
+        # Foreign initiator already starting? Should not happen mid-
+        # terminator-wait; treat as protocol fault. Real wire enforces
+        # arbitration only after terminator SYN.
+        return PROTOCOL_FAULT
+
+    case ABORTED_NACK, MASTER_RETX, SLAVE_RETX:
+      # Transient states; handled by FSM internals.
+      ...
+```
+
+**Key properties:**
+
+  - **IDLE-state AA-injection is filterable by cadence.** Real wire
+    AUTO-SYNs come at ≥35ms intervals (eBUS spec). Adapter-spurious
+    AA bursts at sub-35ms cadence. The 25ms threshold is conservative.
+    Kills v3 B-v3-1.
+  - **Mid-frame staging-empty inter-write gaps are correctly
+    classified because FSM phase says we're mid-frame.** Even with
+    staging temporarily empty between bytes from the same session,
+    the FSM stays in MASTER_DATA (or whichever current phase) until
+    NN bytes are consumed. AA-injection in this window is recognized.
+    Kills v3 round-7 leak (Codex strawman).
+  - **Escape-pair interrupted by AA is caught by the AA-aware escape
+    decoder** (§5 below), not by the classifier — the AA-injection is
+    removed before it ever reaches the classifier as a confusing event.
+
+## 5. AA-aware escape decoder
+
+Replaces the current ENH escape decoder. State machine:
+
+```
+[NORMAL]
+  on byte b:
+    if b == 0xA9: state := ESCAPE_PENDING; T_a9_seen := T_now
+    else if b == 0xAA: emit (0xAA, was_escaped=false)
+    else: emit (b, was_escaped=false)
+
+[ESCAPE_PENDING]
+  on byte b:
+    if b == 0x01: emit (0xAA, was_escaped=true); state := NORMAL
+    elif b == 0x00: emit (0xA9, was_escaped=true); state := NORMAL
+    elif b == 0xAA AND (T_now - T_a9_seen) < 10ms:
+        # Adapter injected AUTO-SYN mid-escape. Drop the AA. Stay in
+        # ESCAPE_PENDING. Continue waiting for the real second byte.
+        # The 10ms window is a safety bound; real escape pairs land
+        # within ~8ms on a 2400-baud wire.
+        return  (no emission)
+    else:
+        # Genuinely malformed escape. Emit 0xA9 as raw (recover), then
+        # process b as new input.
+        emit (0xA9, was_escaped=false)
+        state := NORMAL; recurse on b
+```
+
+This handles Codex's `0xA9 0xAA 0x01` blocker: the middle 0xAA is
+absorbed silently within the escape decoder; the classifier sees a
+clean `(0xAA, was_escaped=true)` event. The injected AA never reaches
+the classifier, never becomes a PROTOCOL_FAULT.
+
+The escape decoder lives in the proxy, on the adapter-facing side.
+The current `southbound/enh/codec.go` will be extended to include it.
+This is the layer that produces the `(value, was_escaped)` annotation
+the classifier consumes — making good on the v3 §3 promise that the
+review correctly flagged as referring to a non-existent feature.
+
+## 6. Pacer as rate-limiter
+
+The pacer enforces `inter-byte gap ≥ τ_wire_byte = 4.17ms` on each
+session's outbound stream. It does NOT generate gaps. Algorithm:
+
+```
+queue_byte(s, b):
+  T_emit_earliest := max(T_now, last_emit_time(s) + τ_wire_byte)
+  schedule emit(s, b) at T_emit_earliest
+```
+
+If the queue is empty and the byte's natural arrival time is well
+past `last_emit_time + τ_wire_byte`, the byte emits immediately. Idle
+SYNs at 35ms cadence pass through with their natural gap preserved.
+Bursty echo arrivals (TCP-batched) get spread out at the 4.17ms cap.
+Telegram-boundary transitions experience no regime change because the
+rule is the same in both states.
+
+Cost: per-session timer fires at most every 4.17ms when queue is
+nonempty. Idle queue → no firing. Bounded.
+
+## 7. L_dn EMA, repaired
+
+  - **Initial value:** 15ms.
+  - **EMA update:** every `RequestInfo` round-trip (every 30 s, on
+    transport reset). α = 0.15 (slower than v3's 0.25 to absorb
+    bursts).
+  - **Bounds:** clamped to `[2ms, 1000ms]` — wide enough to track
+    sustained WiFi spikes; outliers are NOT ignored.
+  - **Used for:** echo-deadline windows in §8 only.
+
+If L_dn sustained at 500ms (genuine WiFi degradation), EMA tracks up
+within minutes. Echo timeouts widen automatically. No staging-drop
+from estimator drift.
+
+## 8. Echo-deadline regime
+
+Three timeouts per in-flight byte:
+
+  - **Soft** at `L_dn_EMA + 100ms`: log a warning on admin channel.
+    Do NOT drop staging. Keep waiting.
+  - **Hard** at `4 × L_dn_EMA + 500ms`: declare adapter transport
+    degraded on admin channel. Drop staging. Forward
+    `ADAPTER_DEGRADED` on admin channel (NOT in byte stream).
+  - **RESETTED event from adapter** at any time: drop staging across
+    all sessions, forward RESETTED to all client byte streams (real
+    adapter event).
+
+If a "late echo" arrives AFTER hard timeout has dropped staging, the
+classifier sees an ENH event with no FSM context for it. Resolution:
+the FSM stays in IDLE (post-drop reset), the late byte is classified
+as `WIRE_REAL_IDLE_SYN_FORWARD` if it's a raw 0xAA passing the cadence
+check, or `PROTOCOL_FAULT` otherwise. Orphan bytes are a real
+phenomenon (adapter reset mid-write), and surfacing them as
+PROTOCOL_FAULT is correct — it mirrors what a real adapter would
+deliver after a reset.
+
+## 9. Cross-session foreign traffic
+
+Two sessions, A and B. A is in MASTER_DATA (writing); B is observing.
+ENH protocol prevents foreign initiator C from preempting A mid-
+transmission (arbitration ends at SOF). So A's transmission completes
+before C can begin. After A's terminator SYN, the FSM returns to
+IDLE; C's STARTED triggers a new ARBITRATING; C's bytes flow through
+normally.
+
+The pacer-as-rate-limiter does not head-of-line-block: when A's last
+byte has been paced toward B and the queue is empty, C's bytes arrive
+and are paced immediately (rate-limited, but not artificially
+delayed beyond τ_wire_byte from C's actual arrival).
+
+The B-v3-3 head-of-line scenario relied on pacer-as-metronome (which
+would force gaps even when queue is empty). With pacer-as-limiter,
+this can't happen.
+
+## 10. NACK retransmit cap, properly bounded
+
+The FSM tracks `master_retx_count` and `slave_retx_count` as part of
+its state. On NACK:
+
+  - `count == 0`: transition to `MASTER_RETX` or `SLAVE_RETX`, set
+    count := 1, expect retransmit.
+  - `count == 1`: transition to `ABORTED_NACK`.
+
+This is enforced at the proxy. The active client may run its own
+identical FSM and self-enforce; the proxy's enforcement is the
+backstop independent of client behavior.
+
+Per spec V1.3.1: exactly one retransmit per phase. The FSM is the
+single source of this rule, applied to all active sessions equally.
+
+## 11. The classifier is the existing passive_reconstructor
+
+`helianthus-ebusgo/protocol/passive_reconstructor.go` already
+implements this FSM for passive (read-only) observation. v4 extracts
+the FSM into a shared library and adds active-session instances.
+
+Reconstructor's existing capabilities used by v4:
+  - eBUS telegram structure recognition (header bytes, NN counter,
+    CRC computation, terminator detection).
+  - Abandon-on-timeout for stuck phases.
+  - Phase-aware byte classification.
+
+Active-session adapter for v4:
+  - Adds NACK retransmit counters (already conceptually present;
+    formalized).
+  - Adds `expected_logical` lookahead from active client's TCP staging.
+  - Drives the AA-injection classifier in §4.
+
+The implementation lift is a refactor of existing code, not new
+machinery.
+
+## 12. Backward compatibility with existing clients
+
+Clients (ebusd, vrc-explorer, gateway-as-client) connect over ENS/ENH
+just as today. They receive the same ENH byte event stream — no
+protocol extension. The proxy delivers wire-equivalent bytes:
+
+  - All wire-real bytes (master header, data, ACK, slave response,
+    CRC, terminator SYN, foreign-initiator bytes, real idle SYNs at
+    natural cadence).
+  - **No** adapter-spurious AA-injection bytes.
+  - **No** synthetic markers, no proxy-injected events.
+
+ebusd specifically: its `bushandler.cpp` SYN-watchdog requires idle
+SYNs at wire cadence to stay happy. v4 preserves wire-real idle SYNs
+in IDLE state; only adapter-spurious bursts are filtered. ebusd's
+watchdog sees the same cadence it would see on a direct adapter.
+
+## 13. Invariants
+
+  - **I0** (clock): all scheduling on monotonic time.
+  - **I1** (no synthetic events): every byte forwarded was derived
+    from a real adapter event. The proxy never invents events.
+  - **I2** (AA-injection invisible): bytes classified as
+    AA_INJECTION_* are forwarded to zero sessions.
+  - **I3** (pacer-cap): outbound rate per session ≤ 1 byte / 4.17ms;
+    natural gaps preserved.
+  - **I4** (FSM authoritative): all phase decisions derive from the
+    FSM; no heuristic shortcuts.
+  - **I5** (retx cap): master_retx ≤ 1, slave_retx ≤ 1 per phase;
+    enforced by FSM.
+  - **I6** (idle cadence): in IDLE state, 0xAA bytes are forwarded
+    only if `T_now - T_last_syn ≥ 25ms`. Sub-25ms 0xAA is dropped as
+    adapter-spurious.
+  - **I7** (one-write-per-session): active session may have only one
+    write in flight; further writes block at TCP receive.
+  - **I8** (RESETTED is real): RESETTED is forwarded; FSM drops to
+    IDLE; staging cleared.
+  - **I9** (escape pair atomicity): escape sequence `0xA9 0x__` is
+    treated as one logical byte at the classifier layer; intervening
+    0xAA bytes are absorbed by the escape decoder.
+
+## 14. Memory and locking
+
+  - Per active session: FSM state + staging buffer (≤200 bytes worst
+    case including escape doubling + retransmit) + pacer queue
+    (≤200 bytes).
+  - Global: L_dn EMA, monotonic clock reference, admin channel
+    counters.
+  - Lock topology: per-session mutex protects FSM and staging.
+    Adapter read goroutine acquires one per-session mutex per event
+    (O(1)). Pacer goroutine acquires only its session's pacer-queue
+    lock.
+
+No proxy-wide global lock. No nested locking.
+
+## 15. What v4 deletes (final cleanup list)
+
+After v4 lands and is validated on live bus:
+
+  - `helianthus-ebusgo/protocol/bus.go` round-9 `payloadAaAutoSyn*`
+    absorb loop and atomic counters.
+  - `helianthus-ebusgateway/internal/adaptermux/mux.go` round-7
+    `betweenWritesSyn` gate, `queueJustDrained` sentinel, `P10.2`
+    suppression.
+  - `helianthus-ebusgo/transport/enh_transport.go` `postGrantPreEcho`
+    window logic.
+  - `helianthus-ebus-adapter-proxy/internal/scheduler/write/shared_path.go`
+    SYN-during-active-write suppression heuristics.
+
+Each removal is verifiable: replay the same wire scenarios that
+motivated the original layer; v4's FSM-driven classifier handles
+each one through its single mechanism.
+
+## 16. What v4 still does not solve
+
+Honest residuals:
+
+  - **Adapter-internal byte loss after physical transmission.** If
+    the adapter places a byte on the wire and then loses its echo on
+    the reply path, the proxy never sees it. Other sessions don't
+    see it. Matches what a separate physical adapter would
+    experience under the same fault (no way to know wire activity
+    that didn't reach you). Admin-channel counter tracks adapter
+    health.
+  - **Spec violations on wire (malformed eBUS telegrams from a buggy
+    third-party master).** FSM enters PROTOCOL_FAULT; the wire-level
+    truth is forwarded as-observed; clients see what wire sent. v4
+    does not synthesize correctness on wire faults.
+  - **Pacer can only space `proxy.Write()` calls.** Client-side
+    `recv()` spacing is subject to TCP and client kernel scheduling.
+    v4 makes the proxy's emission wire-realistic; the rest is
+    standard TCP transport realism, same as any real adapter behind
+    a TCP link.
+
+## 17. Migration
+
+  1. Extract `passive_reconstructor`'s FSM into shared library
+     `helianthus-ebusgo/protocol/telegram_fsm`. Add NACK retx
+     counters and active-session-adapter facade.
+  2. Add AA-aware escape decoder to `helianthus-ebus-adapter-proxy/
+     internal/southbound/enh/codec.go`. Test isolated: feed it
+     `0xA9 0xAA 0x01`, verify single `(0xAA, was_escaped=true)`
+     event emitted.
+  3. Plumb the FSM-per-active-session in the proxy classifier. Add
+     IDLE-state cadence filter (25ms threshold).
+  4. Implement pacer-as-rate-limiter (per-session timer, fires on
+     queue head, schedules at `max(now, last_emit + τ_byte)`).
+  5. Implement L_dn EMA and echo-deadline tiers.
+  6. Live-bus validation: AA-injection metric → 0 (both active and
+     idle), echo_mismatch → 0, timeout → no increase beyond
+     pre-existing wire-defect baseline. ebusd parses telegrams
+     coherently. SYN-cadence watchdog stable.
+  7. Delete the five layers listed in §15.
+  8. Final re-validation.
+
+Each step independently testable and rollback-able.
+
+## 18. Mapping previous reviews → v4 resolutions
+
+| Finding | v4 resolution |
+|---|---|
+| **v1 B1** σ_s conflation | No σ_s anywhere; pacer is constant τ_wire_byte rate-cap. |
+| **v1 B2** synthetic failure markers | Admin channel only; never injected in client stream. |
+| **v1 B3** NACK retx unbounded | FSM tracks retx_count; bound enforced by FSM transitions. |
+| **v1 B4** wall clock | Monotonic Go time.Now() everywhere. |
+| **v1 B5** byte provenance not plumbed | Provenance stays internal to proxy; classifier uses it; clients see raw wire bytes. |
+| **v1 M1–M5** | FSM removes session-mode transitions; pacer-as-limiter removes head-of-line; no telegram-atomic emission. |
+| **v2 B-v2-1** is_wire_syn conflates | FSM phase distinguishes terminator vs idle-AA vs injection. |
+| **v2 B-v2-2** clients can't get metadata | Provenance internal; clients unchanged. |
+| **v2 B-v2-3** forwarder coupling | Forwarder driven by FSM phase, FSM is unified single state machine, no proxy-vs-client FSM split. |
+| **v2 B-v2-4** echo identity matching | FSM predicts expected next event; staging head matches FSM phase. |
+| **v2 B-v2-5** echo batching | Pacer-as-rate-limiter caps bursts; preserves natural gaps. |
+| **v2 B-v2-6** echo loss ≠ wire didn't transmit | Acknowledged as residual; admin-channel surfaced; no orphan emission. |
+| **v3 B-v3-1** idle AA-injection | Cadence filter in IDLE state (25ms min). |
+| **v3 B-v3-2** pacer regime change | Rate-limiter, not metronome; no regime change. |
+| **v3 B-v3-3** cross-session ordering | Rate-limiter doesn't HoL-block; FSM enforces wire-arbitration order. |
+| **v3 B-v3-4** escape decoder placement | Explicit AA-aware decoder in §5. |
+| **v3 B-v3-5** L_dn outlier | Track all samples in [2ms, 1000ms]; no clamp-ignore. |
+| **v3 Codex** was_escaped doesn't exist in proxy code | §5 explicit: new decoder added to `southbound/enh/codec.go`. |
+| **v3 Codex** escape-pair AA injection | §5 absorbs intervening 0xAA in ESCAPE_PENDING state. |
+| **v3 Codex** retransmit cap requires telegram state | FSM provides it; v4 accepts proxy-side minimal FSM. |
+| **v3 Codex** inter-write empty-staging window | FSM stays in MASTER_DATA across staging-empty gaps. |
+| **v3 Codex** ebusd SYN-timeout regression | Wire-real idle SYNs preserved at natural cadence; only spurious dropped. |
+| **v3 Codex** §15 deletion list false (round-7 not replaced) | FSM correctly handles inter-write gap (§4 MASTER_DATA case). |
+
+Every blocker and major finding from v1, v2, v3 has a concrete v4
+resolution. The single architectural concession over v3 is admitting
+the proxy needs a minimal eBUS telegram FSM — but this is the same
+FSM already implemented for passive observation, just instanced for
+active sessions.

--- a/architecture/adaptermux/frame-atomic-visibility-v4.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v4.md
@@ -4,6 +4,15 @@
 > received `major-rethink` from convergent Codex + Opus reviews.
 > Branch: `frame-atomic-visibility` · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 ## 1. What v3 got wrong
 
 v3 inverted the model correctly (proxy holds intelligence, clients get
@@ -501,3 +510,5 @@ resolution. The single architectural concession over v3 is admitting
 the proxy needs a minimal eBUS telegram FSM — but this is the same
 FSM already implemented for passive observation, just instanced for
 active sessions.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v5.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v5.md
@@ -1,0 +1,346 @@
+# Frame-Atomic Visibility v5 — Active-Phase FSM Filter, Idle Pass-Through
+
+> Status: design sketch v5. Supersedes v1, v2, v3, v4. Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+## 1. Convergent findings from v4 review that v5 must resolve
+
+Codex and Opus both returned `major-rethink` on v4 with overlapping findings:
+
+  - Cadence threshold at **proxy receive time** cannot distinguish wire-real fast SYNs from adapter-spurious AA. TCP batching plus normal Vaillant master cadence (~21 ms) breaks the 25 ms heuristic both ways.
+  - The AA-aware escape decoder's **10 ms time window** loses legitimate escape pairs under WiFi jitter; widening loses the converse case.
+  - **postGrantPreEcho deletion scope is wrong** — it lives in `helianthus-ebusgo/transport/enh_transport.go` and is consumed by direct-adapter clients (no proxy), not deletable by a proxy-side change.
+  - **FSM consensus framing as "backstop"** misrepresents the architecture; proxy and active-client FSMs are autonomous observers of the wire, not master/slave.
+  - **Initial L_dn hard timeout false positive** during the first 30 s after a degradation onset; tracking-all-samples doesn't help convergence speed.
+  - **Pacer algorithm bug** (Codex unique): `last_emit_time` doesn't update until first byte fires, so queued bursts all schedule for the same timestamp → bursts arrive unspaced at the client.
+  - **`passive_reconstructor` referenced location is wrong** (`helianthus-ebusgo/protocol/` vs actual `helianthus-ebusgateway/internal/adaptermux/passive_transaction_reconstructor.go`), and active-mode classification is new code, not pure refactor.
+  - **Slave-phase classifier** has no value to match against (slave bytes are wire-driven, proxy doesn't know what to expect) → AA-injection in SLAVE_DATA falls through unfiltered.
+  - **Per-state FSM timeouts unspecified.**
+
+v5 resolves these by tightening scope and dropping two ideas v4 still carried from earlier rounds.
+
+## 2. v5 scope — what's in, what's out
+
+**In v5:**
+
+  - The proxy maintains an active-session FSM that handles AA-injection filtering **only during phases where the active client is the initiator** (MASTER_HEADER through WAIT_MASTER_ACK and the slave-response phases that follow it). During these phases the proxy knows what bytes the client wrote and can FIFO-match.
+  - The proxy maintains an AA-aware escape decoder with a count-bounded (no time-bounded) injection absorber.
+  - The proxy paces outbound bytes to **every** client uniformly at a `τ_wire_byte` cap.
+  - L_dn EMA bootstraps to a conservative value and is updated per-byte from each echo's measured round-trip.
+  - NACK retransmit cap enforced via FSM state.
+
+**Out of v5:**
+
+  - **IDLE-state filtering.** v5 forwards every byte the adapter delivers when the FSM is in IDLE. Wire-real idle SYNs and adapter-spurious AA in idle are indistinguishable at the proxy without wire-time information that we don't have. Honest residual.
+  - **Cross-FSM consensus protocol.** v5 reframes the FSMs (proxy, active client, passive observers) as autonomous. They observe the same wire-derived event stream and reach the same state by construction; RESETTED is the only resync signal needed.
+  - **Telegram-atomic emission.** Bytes are forwarded as they're classified; no buffering for batch emission.
+  - **Scope-violating deletions.** `postGrantPreEcho` is owned by the direct-adapter transport (`helianthus-ebusgo/transport/enh_transport.go`) and stays. v5 only deletes proxy-side gates that the new classifier subsumes.
+
+This is the core scope reduction from v4. The reviewer-flagged ambiguities in v4 evaporate when each sub-problem is solved at exactly the layer that has the necessary information, not at the layer where the intent originated.
+
+## 3. The FSM
+
+Same mermaid as v4 §3 (omitted here for brevity; canonical copy in
+`frame-atomic-visibility-v4.md`). Two changes from v4:
+
+  - `IDLE` state has **no filtering rules**. Every received byte during IDLE is forwarded to all sessions. This is the central scope reduction.
+  - Per-state timeouts pinned from eBUS V1.3.1 spec:
+    - `MASTER_HEADER`, `MASTER_DATA`, `SLAVE_LENGTH`, `SLAVE_DATA`: inter-byte timeout 6.7 ms (≈10 bit times worst-case wire spec).
+    - `WAIT_MASTER_ACK`, `WAIT_SLAVE_ACK`: 12.5 ms (slave turnaround window).
+    - `WAIT_TERMINATOR_SYN`: 100 ms (allows up to two missed AUTO-SYN slots before declaring abandon).
+    - Slave-response-start (ACK → SLAVE_LENGTH transition): 50 ms (typical load tolerance).
+    - Per-state timeouts measured against monotonic clock; on expiry, FSM aborts to IDLE.
+
+## 4. Classifier — active phases only
+
+```
+classify(ev: ENHEvent, fsm_state: FSM):
+  if fsm_state == IDLE or fsm_state == ARBITRATING:
+    # Forward unconditionally; no AA filtering possible without
+    # wire-time information.
+    return FORWARD_TO_ALL
+
+  if fsm_state in (MASTER_HEADER, MASTER_DATA, MASTER_CRC):
+    # Active client is writing; staging holds expected bytes.
+    expected = staging.peek()  # logical (value, was_escaped) tuple
+    if ev.matches(expected):
+      staging.pop()
+      fsm.advance()
+      return FORWARD_TO_ALL
+    elif ev.value == 0xAA and ev.was_escaped == false:
+      # AA-injection from adapter buffer interference.
+      return DROP_AA_INJECTION
+    else:
+      return PROTOCOL_FAULT
+
+  if fsm_state in (WAIT_MASTER_ACK, WAIT_SLAVE_ACK):
+    # ACK phase; expect 0x00 (ACK) or 0xFF (NACK), nothing else.
+    if ev.value in (0x00, 0xFF):
+      fsm.advance_per_ack_value(ev.value)
+      return FORWARD_TO_ALL
+    elif ev.value == 0xAA and ev.was_escaped == false:
+      return DROP_AA_INJECTION
+    else:
+      return PROTOCOL_FAULT
+
+  if fsm_state in (SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC):
+    # Slave is writing; proxy does NOT know slave's payload values.
+    # Filter the one ambiguous byte (raw 0xAA) — slave does not
+    # legitimately emit raw 0xAA mid-frame (it escape-encodes payload
+    # 0xAA as 0xA9 0x01). Any raw 0xAA in mid-slave-frame is either
+    # adapter buffer artifact or a premature terminator (protocol
+    # fault on the slave side, indistinguishable from proxy view).
+    if ev.value == 0xAA and ev.was_escaped == false:
+      return DROP_AA_INJECTION
+    fsm.advance()  # counter-based, value-agnostic
+    return FORWARD_TO_ALL
+
+  if fsm_state == WAIT_TERMINATOR_SYN:
+    if ev.value == 0xAA and ev.was_escaped == false:
+      fsm.advance_to_IDLE()
+      return FORWARD_TO_ALL  # terminator IS the SYN, forward it
+    return PROTOCOL_FAULT  # any other byte mid-terminator-wait
+
+  # Transient FSM states (MASTER_RETX, SLAVE_RETX, ABORTED_NACK)
+  # handled by FSM internal transitions.
+```
+
+The key insight: the classifier filters raw 0xAA bytes in ALL non-IDLE
+phases. This is sound because:
+
+  - **Master phases:** raw 0xAA only legitimate as terminator. If we're in MASTER_*, terminator hasn't arrived yet, so raw 0xAA mid-master is AA-injection.
+  - **ACK phases:** legitimate values are 0x00 or 0xFF only; raw 0xAA is AA-injection.
+  - **Slave phases:** payload 0xAA arrives as escape-decoded `(0xAA, was_escaped=true)`; raw 0xAA mid-slave is AA-injection or premature terminator.
+  - **WAIT_TERMINATOR_SYN:** raw 0xAA IS the terminator we're waiting for; forward and advance.
+
+This resolves v4's F-v4-9 (slave-phase classifier without predicted value): we filter the **one ambiguous byte** (raw 0xAA), not the entire stream. We don't need to know slave payload values.
+
+## 5. AA-aware escape decoder — count-bounded, no time window
+
+```
+[NORMAL]
+  on byte b:
+    if b == 0xA9: state := ESCAPE_PENDING; absorbed_count := 0
+    elif b == 0xAA: emit (0xAA, was_escaped=false)
+    else: emit (b, was_escaped=false)
+
+[ESCAPE_PENDING]
+  on byte b:
+    if b == 0x01: emit (0xAA, was_escaped=true); state := NORMAL
+    elif b == 0x00: emit (0xA9, was_escaped=true); state := NORMAL
+    elif b == 0xAA and absorbed_count < 8:
+      # AA-injection within escape pair. Absorb; stay ESCAPE_PENDING.
+      absorbed_count += 1
+    elif b == 0xAA and absorbed_count >= 8:
+      # 8 consecutive AA absorptions — the wire is genuinely broken
+      # or this isn't really an escape sequence.
+      emit (0xA9, was_escaped=false)
+      state := NORMAL
+      # process this 0xAA in NORMAL state:
+      emit (0xAA, was_escaped=false)
+    else:
+      # Genuinely malformed escape — emit 0xA9 as raw, then process b.
+      emit (0xA9, was_escaped=false)
+      state := NORMAL
+      recurse on b
+```
+
+No time window. The bound is **8 consecutive AA absorptions** before declaring escape failure. At ~4 ms wire-byte time, 8 AAs = 32 ms of wire activity — more than the slow-slave window, more than realistic adapter buffer drain. If 8 AAs land between `0xA9` and the completion byte, something is genuinely wrong.
+
+This resolves both v4's F-v4-2 (10ms window loses legitimate pairs under jitter) and the counter case (multiple AAs in pair window).
+
+## 6. Pacer — corrected algorithm
+
+```
+PER-SESSION pacer state:
+  last_scheduled_emit: monotonic time (initially -infinity)
+  emit_queue: FIFO of bytes
+
+enqueue(b):
+  emit_at = max(now(), last_scheduled_emit + τ_wire_byte)
+  emit_queue.push((b, emit_at))
+  last_scheduled_emit = emit_at
+  if no pacer timer is armed:
+    arm_timer(emit_at)
+
+on pacer_timer_fire:
+  (b, scheduled) = emit_queue.pop_oldest()
+  write_to_session_socket(b)
+  if queue not empty:
+    arm_timer(queue.head.emit_at)
+```
+
+The fix from v4: `last_scheduled_emit` is updated **on enqueue**, not on fire. This means each new byte's `emit_at` is correctly chained from the prior byte's scheduled time, not from whatever the last-actual-emit was. Bursts get correctly spaced.
+
+`τ_wire_byte = 4.17 ms` (2400 baud, 10 bits per byte). All sessions paced uniformly, **including the originator**, eliminating v4's F-v4-5 timing asymmetry.
+
+The pacer is rate-LIMITING: if real bytes arrive slower than 4.17 ms apart (e.g., wire idle SYN at 35 ms cadence), the pacer's `max(now, last_scheduled + τ_byte)` falls back to `now()` and emission is immediate. Natural gaps preserved.
+
+## 7. L_dn — bootstrap conservative, update per byte
+
+```
+L_dn_EMA initial = 50 ms     # generous bootstrap; covers WiFi typical
+                              # round-trip without false hard timeouts
+α = 0.3                       # faster convergence than v4's 0.15
+
+per-byte L_dn measurement:
+  on each FSM-classified ECHO_OF_OWN_WRITE event:
+    L_dn_sample = T_received_at_proxy - T_sent_to_adapter
+                  - τ_byte_wire   # rough wire transit estimate
+    if L_dn_sample in [2 ms, 1000 ms]:
+      L_dn_EMA = α * L_dn_sample + (1-α) * L_dn_EMA
+
+echo deadlines:
+  soft = L_dn_EMA + 100 ms     # log only
+  hard = 4 * L_dn_EMA + 200 ms # drop staging, log ADAPTER_DEGRADED
+
+  initial values (L_dn=50 ms):
+    soft = 150 ms
+    hard = 400 ms
+
+  if L_dn rises to 200 ms (sustained):
+    soft = 300 ms
+    hard = 1000 ms
+```
+
+Per-byte measurement means EMA converges within ~3-5 bytes of any
+shift (vs. v4's 30 s RequestInfo cadence). The 50 ms bootstrap and
+α=0.3 also mean initial hard timeout is 400 ms — well above typical
+echo times — eliminating v4's F-v4-4 first-window false positive.
+
+If L_dn jumps to 500 ms sustained, hard timeout converges to 2200 ms
+within ~4 echo cycles (~50 ms of bus activity). Real bytes don't get
+dropped because the timeout catches up faster than the degradation.
+
+## 8. FSM autonomy — no consensus protocol
+
+Three FSMs may exist concurrently:
+
+  - **Proxy's FSM** for each active session.
+  - **Active client's FSM** (gateway's existing one in `helianthus-ebusgo/protocol/bus.go`).
+  - **Passive observer's FSM** (`helianthus-ebusgateway/internal/adaptermux/passive_transaction_reconstructor.go`), one per passive client.
+
+Each FSM observes a wire-derived event stream from its own vantage:
+
+  - Proxy: events directly from adapter, with L_dn=L_dn_proxy_adapter.
+  - Active client: events forwarded by proxy (or directly from adapter in non-proxy paths), with L_dn=L_dn_proxy_adapter + L_dn_proxy_client.
+  - Passive observer: events forwarded by proxy, with similar latency.
+
+**They are autonomous.** Each FSM independently transitions based on its observed events. No coordination protocol exists.
+
+**Misalignment cases and recovery:**
+
+  - **Same wire, different observed events:** impossible by construction. The proxy forwards all classified `FORWARD_TO_ALL` events to all observers identically. The same FSM logic on the same events produces the same state.
+  - **One FSM aborts on timeout, others don't:** the FSM with the shorter timeout aborts to IDLE. Others continue. The proxy's classification continues per its own FSM state. If an active client's FSM is in WAIT_MASTER_ACK and the proxy's FSM is in IDLE (post-abort), the next bytes arrive at the active client in WAIT_MASTER_ACK context — but the bytes are wire-real (forwarded by proxy because proxy is in IDLE which means no filtering). Active client's deadline tracking fires, it aborts independently. Both reach IDLE; recovery complete.
+  - **RESETTED event:** forwarded to all observers by the proxy as a real adapter event. All FSMs transition to IDLE. Hard resync.
+  - **A non-conforming client emits unexpected bytes:** proxy's FSM detects PROTOCOL_FAULT; reports via admin channel; proxy emits ENH FAILED to that specific client (a real, observable adapter-level error). Other observers see the bytes the proxy already forwarded before the fault; they may also detect fault via their own FSM.
+
+The "proxy backstop" framing from v4 was wrong. v5 frames it correctly: each FSM is a witness, not a controller. RESETTED is the only state-coordination primitive.
+
+This resolves v4's F-v4-1 and F-v4-6.
+
+## 9. PROTOCOL_FAULT contract
+
+When the classifier returns PROTOCOL_FAULT:
+
+  - Toward the **originator** (active session whose write produced the fault): emit `ENH RESETTED` event on the originator's connection. This is a defined ENH-protocol event; receiving clients (gateway, ebusd) treat it as a transport-layer reset and recover via their own FSM's RESETTED-handling.
+  - Toward **other sessions:** forward whatever bytes the proxy already classified before the fault. The fault doesn't propagate to non-originator clients in the byte stream (their FSMs may detect the same fault from the wire-real bytes they see).
+  - Admin channel: log `PROTOCOL_FAULT` with originator session id, FSM phase, offending byte.
+
+This resolves v4's F-v4-Codex MINOR ("no delivery contract for protocol faults").
+
+`ENH RESETTED` is a real, defined ENH-protocol event — not a proxy-synthesized one. The proxy issues it because the adapter would have issued one in the same situation (RESETTED is the adapter's transport-reset signal). I1 invariant ("no synthetic events") is preserved because RESETTED IS something the adapter would emit on protocol fault.
+
+## 10. NACK retransmit cap — silent drop becomes admin event
+
+v4's design silently dropped client retransmits beyond the cap. v5
+makes the drop observable via admin channel AND surfaces an error to
+the offending client:
+
+  - On NACK count reaching 2: FSM transitions to `ABORTED_NACK`.
+  - Subsequent bytes from same active session in same telegram: NOT forwarded to adapter, NOT silently dropped. Instead: TCP-receive side returns to a per-session "telegram-aborted" state, where any further writes from the client are rejected with explicit `EPIPE`-equivalent at the client's TCP socket (write fails). Client's TCP layer surfaces the error.
+
+This resolves v4's F-v4-6 silent-drop class.
+
+## 11. Layer boundaries — escape decoder explicitly
+
+The escape decoder is a **new sub-component** added to the proxy's
+ENH-receive path, NOT a modification of `southbound/enh/codec.go`'s
+existing event-emitting logic. Specifically:
+
+```
+adapter →[ENH transport bytes]→ codec.go (parses ENH framing) →
+   [eBUS escape-encoded bytes] → escape_decoder.go (NEW) →
+      [(value, was_escaped) tuples] → FSM classifier (NEW) →
+         [classified events] → per-session emission
+```
+
+The existing `codec.go` event types stay; the new decoder consumes
+the payload bytes and produces a new event type for downstream
+consumers. Old consumers of `codec.go` continue to receive
+escape-encoded bytes if they need them.
+
+This resolves v4's F-v4-7 layer-boundary critique.
+
+## 12. Scope of deletions
+
+After v5 lands and is validated:
+
+  - Delete from `helianthus-ebusgo/protocol/bus.go`: round-9 `payloadAaAutoSyn*` absorb loop and atomic counters (the active-client side now sees clean echoes from proxy, no absorb needed).
+  - Delete from `helianthus-ebusgateway/internal/adaptermux/mux.go`: round-7 `betweenWritesSyn` gate, `queueJustDrained` sentinel.
+  - **Do NOT delete** `postGrantPreEcho` from `helianthus-ebusgo/transport/enh_transport.go`. This is direct-adapter transport logic, used by paths that don't go through the proxy. Out of v5's scope.
+
+This resolves v4's F-v4-10 scope-overreach.
+
+## 13. Invariants
+
+  - **I0** (clock): all scheduling on monotonic time.
+  - **I1** (no synthetic events): every byte and ENH event forwarded was derived from a real adapter event. `ENH RESETTED` issued on protocol fault is a real ENH-defined event the adapter would issue. Admin channel is NOT part of the byte stream.
+  - **I2** (active-phase AA filter): in non-IDLE non-ARBITRATING FSM states, raw 0xAA bytes (was_escaped=false) that don't match expected wire role are dropped. Other bytes forwarded.
+  - **I3** (idle pass-through): in IDLE and ARBITRATING states, all bytes forwarded. No filtering, no cadence checks.
+  - **I4** (escape decoder): the decoder absorbs up to 8 consecutive AA bytes mid-escape-pair before declaring escape failure.
+  - **I5** (pacer correctness): outbound bytes to a session are emitted with `inter-byte gap ≥ τ_wire_byte = 4.17 ms`. Bursts queued faster than this are spread by the pacer using `last_scheduled_emit` accounting.
+  - **I6** (FSM autonomy): each FSM instance is independent. Coordination happens only through wire-real events (RESETTED, STARTED, FAILED). No out-of-band sync.
+  - **I7** (retx cap): FSM transitions to ABORTED_NACK at retx_count=2; subsequent client writes are rejected at TCP receive with EPIPE.
+  - **I8** (memory): per-session FSM + staging + pacer queue ≤ 500 bytes. Total proxy memory O(N × 500) for N sessions.
+
+## 14. What v5 still does not solve
+
+Honest residuals:
+
+  - **Adapter-spurious AA visible during IDLE state.** When no active session is writing, the proxy cannot distinguish adapter-injected AA from wire-real AUTO-SYNs. Both forwarded. Operational impact: clients see occasional extra AA bytes during idle stretches. ebusd handles this natively (its SYN parser tolerates AUTO-SYN cadence variance). vrc-explorer doesn't care (it's not real-time-stream-sensitive).
+  - **Inter-session timing skew on different TCP links.** Two clients on links with different L_dn see the same wire byte at slightly different wall-clock times. Inherent to TCP; same as if they were on physically separate adapters with different network paths.
+  - **Wire-spec violations (malformed eBUS from third-party master).** Proxy forwards what wire emitted; doesn't try to repair.
+  - **Adapter byte loss after physical transmission.** If adapter emits on wire but its reply path drops, proxy doesn't see it. Same residual as if the client had its own adapter on the same bus.
+
+## 15. Migration path
+
+  1. Add escape decoder (new file in `helianthus-ebus-adapter-proxy/internal/southbound/enh/escape_decoder.go`).
+  2. Add FSM-per-active-session in proxy (new file; uses logic shared with `passive_transaction_reconstructor.go`).
+  3. Implement pacer per §6 algorithm.
+  4. Implement L_dn EMA per §7.
+  5. Wire classifier per §4.
+  6. Live-bus validation: AA-injection metric for active-write phases → 0; cross-client telegram parsing coherent; IDLE-state AA forwarding doesn't break ebusd SYN watchdog.
+  7. Delete round-9 (`bus.go`) and round-7 (`mux.go`) layers; verify no regression.
+  8. NOT touching `postGrantPreEcho`; it stays.
+
+Each step independently testable and rollback-able. No big-bang migration.
+
+## 16. Summary mapping
+
+| v4 finding | v5 resolution |
+|---|---|
+| F-v4-1 FSM consensus | §8: FSMs are autonomous, RESETTED is only resync. |
+| F-v4-2 Escape decoder 10ms window | §5: count-bounded (8 AAs), no time window. |
+| F-v4-3 25ms cadence threshold | §2, §3 IDLE: drop IDLE filter entirely. |
+| F-v4-4 L_dn convergence | §7: bootstrap 50ms, per-byte measurement, α=0.3. |
+| F-v4-5 Originator timing skew | §6: pacer applies to all sessions including originator. |
+| F-v4-6 NACK silent drop | §10: ABORTED_NACK → TCP write rejected with EPIPE, admin event logged. |
+| F-v4-7 Escape decoder layer | §11: new sub-component, doesn't modify existing codec.go. |
+| F-v4-8 Per-state timeout unspec | §3: pinned from spec. |
+| F-v4-9 Slave-phase classifier | §4: filters raw 0xAA in all non-IDLE non-WAIT-TERMINATOR states; value-agnostic FSM advance. |
+| F-v4-10 postGrantPreEcho scope | §12: NOT deleted. |
+| F-v4-11 Admin channel vs I1 | §13 I1: explicit carve-out for admin channel. |
+| Codex pacer queued-burst | §6: `last_scheduled_emit` updated on enqueue. |
+| Codex terminator vs idle cadence | §2: no IDLE cadence filter at all. |
+| Codex passive_reconstructor location | §8: corrected to `helianthus-ebusgateway/internal/adaptermux/passive_transaction_reconstructor.go`. |
+| Codex PROTOCOL_FAULT contract | §9: ENH RESETTED to originator + admin event. |

--- a/architecture/adaptermux/frame-atomic-visibility-v5.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v5.md
@@ -2,6 +2,15 @@
 
 > Status: design sketch v5. Supersedes v1, v2, v3, v4. Branch: `frame-atomic-visibility` · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 ## 1. Convergent findings from v4 review that v5 must resolve
 
 Codex and Opus both returned `major-rethink` on v4 with overlapping findings:
@@ -344,3 +353,5 @@ Each step independently testable and rollback-able. No big-bang migration.
 | Codex terminator vs idle cadence | §2: no IDLE cadence filter at all. |
 | Codex passive_reconstructor location | §8: corrected to `helianthus-ebusgateway/internal/adaptermux/passive_transaction_reconstructor.go`. |
 | Codex PROTOCOL_FAULT contract | §9: ENH RESETTED to originator + admin event. |
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v6.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v6.md
@@ -1,0 +1,347 @@
+# Frame-Atomic Visibility v6 — Always-On FSM, Admin-Only Faults, Scoped Deletions
+
+> Status: design sketch v6. Supersedes v1–v5. Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+## 1. Convergent v5 findings v6 must resolve
+
+Codex and Opus converged on five blockers/majors against v5:
+
+  1. **ENH RESETTED on PROTOCOL_FAULT is synthetic** — Codex BLOCKER + Opus F-v5-2 MAJOR. Per ENH spec, RESETTED fires only on adapter reboot or INIT. Synthesizing it for wire-level faults violates I1.
+  2. **Round-9 deletion regresses direct-adapter paths** — Codex BLOCKER + Opus F-v5-6 MAJOR. `bus.go` is consumed by ALL gateway modes, including no-proxy direct-adapter. Deleting unconditionally regresses T01/T02 transport-matrix configurations.
+  3. **L_dn formula is round-trip, not one-way** — Codex MAJOR + Opus F-v5-4 MAJOR. Nomenclature wrong, downstream tuning confused.
+  4. **IDLE AA pass-through not proven benign for ebusd** — Codex MAJOR + Opus F-v5-1 MAJOR. ebusd source `ps_recv` aborts on extra SYN; `SYN_TIMEOUT = 51ms` is a HARD ceiling. v5's "ebusd tolerates" claim is empirically false.
+  5. **Timeout-to-IDLE leaves observers with unreconstructable post-timeout telegrams** — Codex BLOCKER. Proxy timeout abandons FSM context; late slave ACK arrives in IDLE state and falls through unfiltered; passive observer FSMs that already entered WAIT_MASTER_ACK can't reconcile.
+
+Plus minor/medium tightening for pacer locking, escape-decoder recovery, gateway-side timeout coordination, EPIPE mechanism, and ARBITRATING filter.
+
+## 2. v6 architectural shift — always-on FSM with three modes
+
+v5's central scope reduction was "drop IDLE filter." That bought rid of the cadence-threshold problem but left a hole: when the wire is mid-telegram (either our client's or a foreign master's), the proxy MUST filter AA-injection or the cross-client visibility goal collapses.
+
+v6 reformulates: **the proxy's FSM is always on**. It distinguishes three runtime modes:
+
+  | Mode      | When                                                              | Staging-aware match | AA-injection filter |
+  |-----------|-------------------------------------------------------------------|--------------------|---------------------|
+  | `active`  | between ENH STARTED for our client and that telegram's terminator | yes (FIFO match)   | FSM phase + staging |
+  | `passive` | foreign master telegram detected on wire (first non-SYN byte after IDLE without STARTED-for-us) | no (no prediction) | FSM phase only      |
+  | `idle`    | between telegrams, wire genuinely idle                            | n/a                | none (pass through) |
+
+`passive` mode is the v6 addition. It addresses both finding #4 (IDLE pass-through false-benign) and #5 (timeout-to-IDLE unreconstructable) in one move: the proxy ALWAYS tracks wire state, and when a foreign master starts a telegram, the proxy follows along via the same FSM, filtering AA-injection per phase even though it can't predict byte values.
+
+`passive` mode classifier is the same as the slave-phase classifier in `active` mode:
+
+  - In phase MASTER_HEADER, MASTER_DATA, MASTER_CRC, SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC: drop raw 0xAA (was_escaped=false), forward everything else, advance FSM counter.
+  - In phase WAIT_MASTER_ACK, WAIT_SLAVE_ACK: forward 0x00 / 0xFF, drop raw 0xAA.
+  - In phase WAIT_TERMINATOR_SYN: forward raw 0xAA (terminator), advance to IDLE.
+
+Mode transitions:
+
+```
+idle
+ │
+ ├── ENH STARTED for our client → active
+ │
+ └── first non-SYN byte from adapter (no STARTED preceding) → passive
+        │
+        └── terminator SYN observed → idle
+
+active
+ │
+ └── terminator SYN OR abort OR timeout → idle (or passive if foreign traffic immediately follows)
+```
+
+`idle` is now a genuinely-wire-idle state, occupied only between telegrams. Adapter-spurious AA in this state is forwarded (residual, but bounded — it's the gap between telegrams, ~tens of ms at most). Bursts of AA-injection during `active` or `passive` mode are filtered.
+
+This resolves Opus F-v5-1 (ebusd intolerance in `ps_recv` corresponds to proxy `passive` mode now filtering correctly) and Codex BLOCKER on §8/§3 (post-timeout, proxy re-enters `passive` mode on the next non-SYN byte, tracks the telegram, forwards correctly).
+
+## 3. The FSM (unchanged from v5 §3 + passive-mode transitions)
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> ARBITRATING : ENH STARTED for our client (active)
+    IDLE --> PASSIVE_TRACKING : first non-SYN byte (foreign master)
+
+    ARBITRATING --> MASTER_HEADER : grant resolved
+    ARBITRATING --> IDLE : ENH FAILED
+
+    MASTER_HEADER --> MASTER_DATA : NN>0
+    MASTER_HEADER --> MASTER_CRC : NN==0
+    MASTER_DATA --> MASTER_CRC : NN bytes consumed
+    MASTER_CRC --> WAIT_TERMINATOR_SYN : broadcast
+    MASTER_CRC --> WAIT_MASTER_ACK : otherwise
+
+    WAIT_MASTER_ACK --> MASTER_RETX : NACK, retx<1
+    WAIT_MASTER_ACK --> ABORTED : NACK, retx>=1
+    WAIT_MASTER_ACK --> WAIT_TERMINATOR_SYN : ACK + master-master
+    WAIT_MASTER_ACK --> SLAVE_LENGTH : ACK + master-slave
+    MASTER_RETX --> MASTER_HEADER : resend
+    SLAVE_LENGTH --> SLAVE_DATA : NN'>0
+    SLAVE_LENGTH --> SLAVE_CRC : NN'==0
+    SLAVE_DATA --> SLAVE_CRC : NN' consumed
+    SLAVE_CRC --> WAIT_SLAVE_ACK
+    WAIT_SLAVE_ACK --> SLAVE_RETX : NACK, retx<1
+    WAIT_SLAVE_ACK --> ABORTED : NACK, retx>=1
+    WAIT_SLAVE_ACK --> WAIT_TERMINATOR_SYN : ACK
+    SLAVE_RETX --> SLAVE_LENGTH : resend
+    WAIT_TERMINATOR_SYN --> IDLE : SYN observed
+
+    PASSIVE_TRACKING --> IDLE : terminator SYN observed
+    PASSIVE_TRACKING --> PASSIVE_TRACKING : FSM phase advances per byte (no staging)
+
+    ABORTED --> IDLE
+```
+
+**`PASSIVE_TRACKING`** is a composite state internally running the full sub-FSM (MASTER_HEADER → ... → WAIT_TERMINATOR_SYN) but without staging-based echo matching. The same per-state timeout values apply. On any timeout in PASSIVE_TRACKING, return to IDLE — the foreign telegram is abandoned (matches what a passive observer would see if it had its own adapter).
+
+Per-state timeouts pinned from eBUS V1.3.1 spec:
+  - `MASTER_HEADER`, `MASTER_DATA`, `SLAVE_LENGTH`, `SLAVE_DATA`, `SLAVE_CRC`: inter-byte 10 ms (conservative; spec minimum 4.17 ms).
+  - `WAIT_MASTER_ACK`, `WAIT_SLAVE_ACK`: 200 ms (per V1.3.1 master allowed-wait; v5's 12.5 ms was wrong).
+  - `WAIT_TERMINATOR_SYN`: 100 ms.
+  - `ARBITRATING`: 50 ms.
+
+Gateway-side FSM (`helianthus-ebusgo/protocol/bus.go`) is pinned to the same values. v6 §17 makes this an explicit migration task to align gateway-side bus.go with these constants.
+
+## 4. Classifier
+
+Same as v5 §4 plus `PASSIVE_TRACKING` branch:
+
+```
+if fsm_state == IDLE:
+    return FORWARD_TO_ALL  # genuinely idle, forward AA at adapter cadence
+
+if fsm_state == ARBITRATING:
+    # No bytes legitimate during ARBITRATING — adapter holds wire briefly.
+    # Any byte during this window is adapter-spurious or bug.
+    if ev.value == 0xAA and ev.was_escaped == false:
+        return DROP_AA_INJECTION
+    return PROTOCOL_FAULT   # non-AA in ARBITRATING is genuinely faulty
+
+if fsm_state == PASSIVE_TRACKING:
+    # Foreign master telegram in flight. Filter raw 0xAA per phase.
+    # See `passive_phase_classifier`:
+    phase = fsm.sub_phase()
+    if phase in {MASTER_HEADER, MASTER_DATA, MASTER_CRC, SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC}:
+        if ev.value == 0xAA and ev.was_escaped == false:
+            return DROP_AA_INJECTION
+        fsm.advance()
+        return FORWARD_TO_ALL
+    if phase in {WAIT_MASTER_ACK, WAIT_SLAVE_ACK}:
+        if ev.value in {0x00, 0xFF}:
+            fsm.advance_per_ack()
+            return FORWARD_TO_ALL
+        if ev.value == 0xAA and ev.was_escaped == false:
+            return DROP_AA_INJECTION
+        return PROTOCOL_FAULT
+    if phase == WAIT_TERMINATOR_SYN:
+        if ev.value == 0xAA and ev.was_escaped == false:
+            fsm.advance_to_IDLE()
+            return FORWARD_TO_ALL  # terminator is itself a SYN
+        return PROTOCOL_FAULT
+
+# active mode classifier per v5 §4 (staging-aware for master/ACK phases,
+# value-agnostic with raw-0xAA filter for slave phases).
+... [same as v5 §4 active branches] ...
+```
+
+This resolves v5 F-v5-9 (ARBITRATING forward unconditionally) too — ARBITRATING now filters raw 0xAA.
+
+## 5. AA-aware escape decoder — recovery non-fabricating
+
+v5's escape-decoder recovery path emitted `(0xA9, was_escaped=false)` on malformed escape (e.g., `0xA9` followed by non-`0x00`/`0x01`/`0xAA`). That fabricates a byte the wire likely never sent (the 0xA9 may have been pure AA-injection noise, in which case emitting it is data invention).
+
+v6 replaces recovery: on malformed escape, **emit nothing**, log to admin channel, drop both bytes (the orphaned 0xA9 and the unexpected continuation). The classifier downstream sees the absence as a phase mismatch, classifies as PROTOCOL_FAULT, FSM aborts gracefully.
+
+```
+[ESCAPE_PENDING]
+  on byte b:
+    if b == 0x01: emit (0xAA, was_escaped=true); state := NORMAL
+    elif b == 0x00: emit (0xA9, was_escaped=true); state := NORMAL
+    elif b == 0xAA and absorbed_count < 8:
+      absorbed_count += 1   # absorb AA-injection in escape pair
+    else:
+      # Malformed escape OR 8+ AA absorptions exhausted.
+      admin.log("escape_decoder_recovery", details)
+      state := NORMAL  # drop both 0xA9 and b; emit nothing
+```
+
+No data fabrication. Resolves Opus F-v5-7 inheriting from v4.
+
+## 6. Pacer with last_actual_emit and last_scheduled_emit
+
+```
+PER-SESSION pacer state (under per-session mutex):
+  last_scheduled_emit: monotonic time (init -infinity)
+  last_actual_emit:    monotonic time (init -infinity)
+  emit_queue:          FIFO of (byte, scheduled_emit_time)
+
+enqueue(b):
+  scheduled_emit = max(now(), last_actual_emit + τ_wire_byte,
+                              last_scheduled_emit + τ_wire_byte)
+  emit_queue.push((b, scheduled_emit))
+  last_scheduled_emit = scheduled_emit
+  if pacer_timer not armed:
+    arm_timer_for(emit_queue.head.scheduled_emit)
+
+on pacer_timer_fire:
+  acquire per-session mutex
+  (b, scheduled) = emit_queue.pop_oldest()
+  write_to_session_socket(b)
+  last_actual_emit = now()  # real wall-clock emission time
+  if emit_queue not empty:
+    arm_timer_for(emit_queue.head.scheduled_emit)
+  release per-session mutex
+```
+
+The fix from v5: include `last_actual_emit` in the `scheduled_emit` computation. Under Go scheduler jitter, if a previous byte was emitted late, the next scheduled byte's gap is computed against the actual late emission, not against the original (earlier) scheduled time. The pacer's `≥ τ_wire_byte` invariant holds robustly.
+
+Locking explicit: per-session mutex protects `emit_queue`, `last_scheduled_emit`, `last_actual_emit`. Pacer timer acquires it on fire. Enqueue acquires it on call. No nested locks.
+
+Resolves Codex F-v5-3 (jitter violates cap) and Codex MINOR §6 (locking spec needed).
+
+## 7. L_rtt — renamed and corrected
+
+```
+L_rtt_EMA  = round-trip latency from proxy.send-to-adapter through
+             wire-byte transmission and back to proxy.receive.
+
+Bootstrap: 100 ms (covers typical WiFi RTT 30-50 ms with 2× headroom).
+α = 0.3.
+Per-byte measurement: L_rtt_sample = T_recv - T_sent - τ_wire_byte
+  (the wire-byte time is real wire transit; everything else is host-
+   adapter link round-trip).
+
+Echo deadlines:
+  soft = L_rtt_EMA + 100 ms   (warn on admin)
+  hard = 2 * L_rtt_EMA + 200 ms (drop staging, log ADAPTER_DEGRADED)
+
+Initial values (L_rtt=100 ms):
+  soft = 200 ms
+  hard = 400 ms
+
+Sustained 500 ms RTT degradation: EMA converges to 500 ms within ~5
+per-byte updates (≈25 ms of bus activity). hard = 1200 ms.
+
+When no echoes for >30 s (long IDLE): re-bootstrap to 100 ms on the
+next active phase (avoids stale-EMA spurious timeouts).
+```
+
+Resolves both reviewers' L_dn nomenclature complaint and Opus F-v5-4 stale-EMA-during-idle hazard.
+
+## 8. PROTOCOL_FAULT contract — admin-only, no synthetic ENH events
+
+v5 §9 emitted ENH RESETTED toward the originator on PROTOCOL_FAULT. Per ENH spec (verified by Codex against `enhanced_proto.md` and Opus against the same source), RESETTED fires only on adapter reboot or INIT. Synthesizing it elsewhere is a protocol semantic violation.
+
+v6:
+
+```
+on PROTOCOL_FAULT:
+  proxy.admin_channel.emit("protocol_fault", {
+    session_id, fsm_phase, offending_byte, fsm_state_before_fault })
+  proxy.fsm.transition_to_IDLE()  # internal proxy state reset
+  # NO ENH event injected into ANY session's byte stream
+  # Originator's own protocol-level timeout (in bus.go) detects
+  #   absence of expected response and aborts via its own FSM
+  # Observer sessions' FSMs likewise detect via their own timeouts
+```
+
+This preserves I1 strictly. No synthetic ENH events. The fault is admin-observable and operator-debuggable, but invisible to the byte stream. Clients recover via their own deadline tracking — which they must implement anyway for transport robustness.
+
+Resolves both reviewers' RESETTED-synthetic BLOCKER.
+
+## 9. NACK-abort: admin-event + return to FSM IDLE; no socket-level abort
+
+v5's "EPIPE on TCP write" was structurally wrong (TCP has no per-telegram abort, only connection-level). v6 simplification:
+
+```
+on FSM transitioning to ABORTED (NACK retx exhausted, or timeout, or
+  protocol fault during active write):
+  proxy.admin_channel.emit("session_telegram_aborted", { session_id,
+    reason, telegram_phase })
+  proxy.fsm.transition_to_IDLE()
+  proxy continues to accept bytes from this session's TCP socket
+    (these now go into a fresh staging buffer; if the session sends
+     a new write, that's a new telegram, fresh FSM cycle)
+```
+
+No socket-level abort. No connection close. The originator's own FSM (in bus.go) detects telegram abort via its own deadline tracking and signals upward. The proxy is purely a byte mirror with FSM-driven AA filter; it doesn't escalate transport-level abuse.
+
+If a session repeatedly sends malformed writes, admin channel accumulates `protocol_fault` events. Operator decides whether to terminate the misbehaving client (out-of-band action).
+
+Resolves Opus F-v5-5 and Codex MAJOR §10.
+
+## 10. Round-9 deletion scoped to proxy-mediated path
+
+`helianthus-ebusgo/protocol/bus.go` round-9 absorb logic stays as-is for **direct-adapter mode** (no-proxy transport configurations T01, T02 per transport-matrix). The deletion in v6 §15 is **conditional on the active proxy classifier being in path**.
+
+Mechanism: `bus.go` reads its echo stream from the transport layer (ENS/ENH). When the transport is in proxy-mediated mode, the bytes it reads have ALREADY been AA-filtered by the proxy classifier. Round-9's absorb predicate (`raw == 0xAA && echo == 0xAA && !echoWasEscaped`) never matches because such bytes never reach `bus.go` anymore. Round-9 becomes inert at runtime.
+
+For direct-adapter mode, the same predicate continues to match against the raw adapter byte stream. Round-9 stays active. Operational behavior unchanged.
+
+**v6 does NOT delete round-9 code.** It marks it as legacy-fallback (a comment block at the top), notes that the predicate is expected to be inert under proxy-mediated transports, and adds a Prometheus counter `helianthus_round9_absorb_fired_proxy_mediated_total` that should stay at zero in proxy-mediated deployments — a regression indicator if proxy filter has a hole.
+
+Future work (out of v6 scope): rebuild direct-adapter mode to use FSM-aware echo matching at `bus.go` level (mirror of proxy-side classifier). Until then, round-9 stays as the direct-adapter safety net.
+
+Resolves both reviewers' BLOCKER/MAJOR on round-9 deletion regression.
+
+## 11. Layer boundaries — escape decoder still a new sub-component
+
+Same as v5 §11. The escape decoder is a new file under `helianthus-ebus-adapter-proxy/internal/southbound/enh/escape_decoder.go`, sitting between the existing `codec.go` ENH-frame parser and the classifier. Existing consumers of `codec.go` are untouched.
+
+## 12. Invariants
+
+  - **I0** (clock): all scheduling on monotonic time.
+  - **I1** (no synthetic events): every byte forwarded was derived from a real adapter event. Admin channel is explicitly EXCLUDED from "byte stream" scope of I1 — it is a separate diagnostic plane, not part of any client's transport.
+  - **I2** (FSM-driven filter): the FSM mode (`active`/`passive`/`idle`) is the sole authority for AA-injection classification.
+  - **I3** (pacer cap robust): outbound inter-byte gap ≥ τ_wire_byte = 4.17 ms, measured against `max(last_actual_emit, last_scheduled_emit)`, robust under Go scheduler jitter.
+  - **I4** (escape decoder): absorbs up to 8 AAs mid-escape-pair; on malformed escape, emits nothing and logs to admin.
+  - **I5** (FSM autonomy): each FSM instance is independent. Resync via wire-real events (RESETTED from actual adapter, observable terminator SYN, etc.). No out-of-band coordination.
+  - **I6** (retx cap): FSM enforces 1 retx per phase per spec V1.3.1.
+  - **I7** (gateway-side timeout alignment): `helianthus-ebusgo/protocol/bus.go` per-state timeouts pinned to same spec values as proxy FSM.
+  - **I8** (round-9 backward-compatible): round-9 absorb logic in `bus.go` stays for direct-adapter; becomes inert under proxy-mediated transports. Counter `helianthus_round9_absorb_fired_proxy_mediated_total` monitors regression.
+
+## 13. What v6 still does not solve (honest residual)
+
+  - **Adapter-spurious AA during genuinely-idle wire.** This is the narrow case the IDLE-mode pass-through exposes: between telegrams, when truly nothing is happening on the wire, an adapter-spurious AA is forwarded as if it were a wire-real AUTO-SYN. The window is bounded — typically tens of ms between telegrams on a busy bus, longer on a quiet bus. ebusd's `ps_idle` parser is OK with this (it's just counting AAs as cadence markers; extras are extras). The bug only manifests during ACTIVE/PASSIVE/ARBITRATING phases, all of which are filtered.
+  - **Foreign-master telegrams initiated WHILE adapter is mid-buffering our outbound.** Theoretically the wire could have arbitration between our STARTED-but-not-yet-on-wire bytes and a foreign master's win. ENH protocol prevents this in practice (STARTED is post-arbitration), but if it ever happened, proxy's `active` FSM would mismatch. Mitigation: ENH STARTED/FAILED arrives BEFORE any byte data on the wire, so the proxy always knows which session won.
+  - **Adapter byte loss after physical transmission.** Same as v3, v4, v5: if adapter loses an echo on its reply path, proxy doesn't see it, other clients don't see it. Bounded by adapter reliability (≪0.1% byte loss observed).
+
+These residuals are explicitly bounded and operator-observable.
+
+## 14. Migration
+
+  1. **Add passive FSM tracking** to proxy classifier. New mode `PASSIVE_TRACKING` activates on first non-SYN byte from adapter after IDLE without STARTED. Reuses existing `passive_transaction_reconstructor.go` phase tracking logic.
+  2. **Add AA-aware escape decoder** as new sub-component in `southbound/enh/`.
+  3. **Wire active-mode FSM** with staging buffer per active session.
+  4. **Implement pacer** per §6 (with `last_actual_emit` and per-session mutex).
+  5. **Implement L_rtt EMA** per §7.
+  6. **Pin gateway-side timeouts** in `helianthus-ebusgo/protocol/bus.go` to match proxy values per §3.
+  7. **Live-bus validation:**
+     - AA-injection rate (`payloadAaAutoSyn*` counter) → 0 in proxy-mediated mode.
+     - Cross-client telegram parsing coherent for both gateway-initiated AND foreign-initiated telegrams.
+     - ebusd's `ps_recv` doesn't abort during foreign telegrams.
+     - `helianthus_round9_absorb_fired_proxy_mediated_total` remains 0.
+  8. **Mark round-9 as legacy-fallback** with the regression-detector counter. Do NOT delete.
+  9. **NOT deleting** `postGrantPreEcho` (out of scope, used by direct-adapter).
+
+Each step independently testable and rollback-able.
+
+## 15. Mapping v5 findings → v6 resolutions
+
+| v5 finding (Codex + Opus) | v6 resolution |
+|---|---|
+| Codex BLOCKER §8/§3 timeout-to-IDLE unreconstructable | §2 PASSIVE_TRACKING — proxy never abandons wire-state. |
+| Codex BLOCKER §9 / Opus F-v5-2 ENH RESETTED synthetic | §8 admin-channel-only on PROTOCOL_FAULT; no synthetic ENH events. |
+| Codex BLOCKER §12 / Opus F-v5-6 round-9 deletion regression | §10 round-9 STAYS, marked legacy-fallback, becomes inert under proxy. |
+| Codex MAJOR §7 / Opus F-v5-4 L_dn formula nomenclature | §7 renamed L_rtt with correct round-trip semantics. |
+| Codex MAJOR §10 / Opus F-v5-5 EPIPE on TCP | §9 no socket-level abort; admin event + FSM IDLE reset only. |
+| Codex MAJOR §14 / Opus F-v5-1 IDLE pass-through unverified | §2 PASSIVE_TRACKING filters foreign telegrams; IDLE residual narrowed to genuine gaps. |
+| Opus F-v5-3 pacer cap under jitter | §6 `last_actual_emit` and explicit locking. |
+| Opus F-v5-7 escape recovery garbage | §5 admin-log + emit nothing on malformed escape. |
+| Opus F-v5-8 gateway-side timeout coordination | §3 I7 + §14 step 6 — explicit alignment. |
+| Opus F-v5-9 ARBITRATING forward unconditionally | §4 ARBITRATING filters raw 0xAA. |
+| Opus F-v5-10 I1 admin-channel carve-out | §12 I1 explicit exclusion of admin channel. |
+| Codex MINOR §6 locking | §6 explicit per-session mutex + scope. |
+
+Every v5 blocker and major has an explicit v6 resolution. Mediums and minors likewise.

--- a/architecture/adaptermux/frame-atomic-visibility-v6.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v6.md
@@ -2,6 +2,15 @@
 
 > Status: design sketch v6. Supersedes v1–v5. Branch: `frame-atomic-visibility` · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 ## 1. Convergent v5 findings v6 must resolve
 
 Codex and Opus converged on five blockers/majors against v5:
@@ -345,3 +354,5 @@ Each step independently testable and rollback-able.
 | Codex MINOR §6 locking | §6 explicit per-session mutex + scope. |
 
 Every v5 blocker and major has an explicit v6 resolution. Mediums and minors likewise.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v7.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v7.md
@@ -1,0 +1,340 @@
+# Frame-Atomic Visibility v7 — Localized Tightening of v6
+
+> Status: design sketch v7. Tightens v6 per round-6 review findings.
+> Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+v6 received split verdicts on round 6:
+
+  - **Opus: minor-fixes** ("genuinely minor-fixes territory but with two MAJOR holes that must close before ship... isn't a rethink — it's a localized tightening").
+  - **Codex: major-rethink** with 4 BLOCKERS (3 real, 1 likely arch-misreading) + 4 MAJORs.
+
+The convergent items (both reviewers found independently) are real and fixable in a localized rewrite of v6 §3, §4, §8. v7 is that rewrite. It supersedes nothing structurally — the v6 design is preserved; only specific under-specified mechanics are tightened.
+
+## 1. Items fixed in v7 (all v6 findings)
+
+### 1.1 PROTOCOL_FAULT byte fate (Opus F-v6-6 MAJOR + Codex BLOCKER §4/§8)
+
+**v6 issue:** classifier returns `PROTOCOL_FAULT`; §8 says admin-channel only; the offending byte's fate is ambiguous. The default reading drops the byte from observer streams, violating wire fidelity.
+
+**v7 fix:** explicit rule:
+
+```
+On PROTOCOL_FAULT classification:
+    forward the offending byte to ALL observer sessions (wire fidelity)
+    emit admin.protocol_fault event with diagnostics
+    transition FSM to IDLE
+```
+
+The byte stream remains wire-faithful. Clients' own FSMs detect the fault via their own logic. The admin channel surfaces the fault for operator observation. I1 still holds: forwarded byte was a real adapter event; admin event is not in the byte stream.
+
+### 1.2 PASSIVE_TRACKING entry via FAILED control event (Codex BLOCKER §2/§3)
+
+**v6 issue:** v6 §2/§3 enters PASSIVE_TRACKING on "first non-SYN byte after IDLE without STARTED-for-us". But ENH adapters surface foreign-arbitration via `FAILED(winner_addr)` control events that arrive BEFORE the first data byte. v6 misses the foreign master's QQ byte (it's already in the wire-byte stream when the proxy notices the first data byte).
+
+**v7 fix:** PASSIVE_TRACKING enters on EITHER:
+
+```
+IDLE → PASSIVE_TRACKING : ENH FAILED(winner_addr) event arrives
+                          OR first non-SYN byte arrives (fallback)
+                          — whichever happens first.
+
+On FAILED(winner_addr):
+    fsm.passive_winner_addr := winner_addr
+    fsm.mode := PASSIVE_TRACKING, sub_phase := MASTER_HEADER, byte_index := 0
+    expected_QQ := winner_addr
+    forward FAILED event to all sessions per ENH protocol semantics
+```
+
+When the first data byte arrives (which IS the foreign master's QQ), the classifier in MASTER_HEADER consumes it normally. If `winner_addr` was provided by FAILED, the proxy can additionally **validate** that byte_index=0 byte == winner_addr — a cheap soundness check.
+
+If first data byte arrives WITHOUT a preceding FAILED (some ENH adapters may not surface FAILED for non-our-session arbitrations), the fallback rule applies: enter PASSIVE_TRACKING with the byte as QQ, no winner_addr available.
+
+### 1.3 Byte-batch atomicity at mode transitions (Opus F-v6-1 MAJOR)
+
+**v6 issue:** TCP `Read()` delivers byte batches. FSM transition timing relative to byte classification is unspecified.
+
+**v7 fix:** explicit in §4:
+
+```
+for each escape-decoded byte b in batch (sequential, one-at-a-time):
+    fsm.feed(b)              # may transition mode
+    classify_under(fsm.mode_after_feed, b)
+```
+
+Per-byte serial processing within the FSM. Batched TCP reads are deframed and fed serially to the FSM. The FSM transition is committed BEFORE the byte is classified, so byte_0 that triggers IDLE→PASSIVE_TRACKING is classified under PASSIVE_TRACKING's MASTER_HEADER rule.
+
+### 1.4 Inter-byte timeout vs escape decoder budget (Opus F-v6-2 MAJOR)
+
+**v6 issue:** `MASTER_DATA` inter-byte timeout 10 ms collides with escape-decoder 8-AA absorption budget (8 × 4 ms ≈ 32 ms).
+
+**v7 fix:** inter-byte timer **pauses across ESCAPE_PENDING duration**. Concrete:
+
+```
+inter-byte timer state:
+  last_decoded_byte_emit_time = T
+  timer fires at T + 10 ms IF escape decoder is in NORMAL state
+
+  when escape decoder enters ESCAPE_PENDING:
+      pause inter-byte timer (don't clear, just stop counting)
+
+  when escape decoder exits ESCAPE_PENDING (success or fail):
+      resume inter-byte timer; effective deadline becomes
+        last_decoded_byte_emit_time + 10 ms + escape_pending_duration
+```
+
+The 10 ms inter-byte budget is measured against decoded-byte emission, not adapter-byte arrival. Escape-pair-pending time doesn't count against the budget. Spec text added to §3 + §5.
+
+### 1.5 PASSIVE_TRACKING NACK/MASTER_RETX/SLAVE_RETX (Opus F-v6-3 + F-v6-8 strawman MAJOR + Codex MAJOR §3/§4)
+
+**v6 issue:** PASSIVE_TRACKING sub-FSM is "composite running full sub-FSM" but mermaid + §4 didn't enumerate NACK retransmit paths. NACK from foreign slave triggers master retx; v6 doesn't track.
+
+**v7 fix:** PASSIVE_TRACKING explicitly runs the FULL sub-FSM including MASTER_RETX and SLAVE_RETX. Classifier in §4 for passive WAIT_MASTER_ACK / WAIT_SLAVE_ACK distinguishes ACK (0x00) from NACK (0xFF):
+
+```
+PASSIVE_TRACKING WAIT_MASTER_ACK:
+    on 0x00 (ACK):
+        forward; advance per master-master vs master-slave rule
+    on 0xFF (NACK):
+        forward; if retx_count<1: advance to MASTER_RETX
+                  else: advance to ABORTED → IDLE
+    on raw 0xAA:
+        drop (AA-injection)
+    otherwise:
+        PROTOCOL_FAULT (forward byte + admin event, FSM → IDLE)
+
+PASSIVE_TRACKING MASTER_RETX:
+    expected: foreign master resends master block (QQ ZZ PB SB NN DB CRC)
+    sub-phase resets to MASTER_HEADER, byte_index = 0
+    same classifier rules apply
+```
+
+`SLAVE_RETX` symmetric. NACK retx now correctly handled in PASSIVE_TRACKING — the foreign master's retransmission is followed, not abandoned.
+
+### 1.6 PASSIVE_TRACKING phase validation (Codex MAJOR §3/§4)
+
+**v6 issue:** PASSIVE_TRACKING composite state treats phases as byte counters without validating source-class / target-class / NN bounds / CRC / ACK correlation.
+
+**v7 fix:** explicit per-phase validation in §4:
+
+```
+PASSIVE_TRACKING MASTER_HEADER (byte_index 0): QQ
+    validate: 0x00 <= QQ <= 0xFF (always true; just byte through)
+    if winner_addr known from FAILED event: validate QQ == winner_addr;
+        on mismatch: PROTOCOL_FAULT
+PASSIVE_TRACKING MASTER_HEADER (byte_index 4): NN
+    validate: NN <= 16 (per eBUS spec)
+    on NN > 16: PROTOCOL_FAULT (forward byte + admin event)
+PASSIVE_TRACKING MASTER_CRC:
+    compute CRC over bytes 0..(4 + NN)
+    compare with received CRC byte
+    on mismatch: forward byte (wire reality) + admin event + FSM → IDLE
+        (do not synthesize NACK; foreign slave will NACK on the wire,
+         which we will observe and follow into MASTER_RETX)
+PASSIVE_TRACKING SLAVE_LENGTH:
+    validate: NN' <= 16
+    on NN' > 16: PROTOCOL_FAULT
+PASSIVE_TRACKING SLAVE_CRC:
+    compute CRC, compare; same treatment as master CRC
+```
+
+This is a small constant-time amount of per-phase logic, mirrored from the existing passive reconstructor.
+
+### 1.7 L_rtt passive-mode sampling (Opus F-v6-5 MINOR + Codex MAJOR §7)
+
+**v6 issue:** L_rtt samples only from echoes of our writes. Long idle periods lead to stale-EMA, first-active-byte may trip spurious timeout.
+
+**v7 fix:** add passive-mode latency sampling. During PASSIVE_TRACKING, the proxy measures `T_byte_received - T_byte_appeared_on_wire`. We can estimate `T_byte_appeared_on_wire` from the FSM's expected inter-byte cadence (4 ms post previous wire byte). The difference is the adapter-to-proxy link latency:
+
+```
+during PASSIVE_TRACKING (per byte):
+    estimated_wire_emit_time = T_previous_wire_byte_estimate + τ_wire_byte
+    L_link_sample = T_received_at_proxy - estimated_wire_emit_time
+    if L_link_sample in [1 ms, 500 ms]:
+        L_link_EMA = α * L_link_sample + (1-α) * L_link_EMA
+
+L_rtt_EMA ≈ 2 * L_link_EMA   (round-trip = uplink + downlink, symmetric assumption)
+```
+
+L_rtt now tracks continuously regardless of whether we're writing or observing. No stale-EMA on first active byte.
+
+### 1.8 Round-9 counter gating (Opus F-v6-4 MINOR)
+
+**v6 issue:** counter `helianthus_round9_absorb_fired_proxy_mediated_total` increments on every IDLE-mode AUTO-SYN beat under proxy. Useless as regression indicator (baseline non-zero).
+
+**v7 fix:** counter is gated on `bus.go FSM phase ≠ IDLE`:
+
+```
+in round-9 absorb predicate, before incrementing counter:
+    if bus.go.fsm.phase == IDLE: skip counter increment
+    else: increment helianthus_round9_absorb_fired_proxy_mediated_total
+```
+
+During active phases on the gateway side, this counter should be zero if proxy filter is healthy. Non-zero in active phase = regression signal.
+
+### 1.9 Counter as regression detector with alerting (Codex MAJOR §10)
+
+**v6 issue:** counter without alerting is silent regression.
+
+**v7 fix:** declare in §10 that the regression counter MUST be wired to a Prometheus alert rule:
+
+```yaml
+# alerts.yaml addition (live-validation phase)
+- alert: HelianthusRound9FiredUnderProxy
+  expr: increase(helianthus_round9_absorb_fired_proxy_mediated_total[5m]) > 0
+  for: 1m
+  severity: critical
+  description: "Round-9 absorb fired under proxy-mediated transport, indicating proxy filter regression"
+```
+
+§14 step 7 (live validation) gates on alert config being deployed before round-9 is considered "inert legacy."
+
+### 1.10 Cross-repo deployment ordering (Opus F-v6-7 MINOR + Codex MAJOR §14 step 6)
+
+**v6 issue:** cross-repo PR for `helianthus-ebusgo/protocol/bus.go` timeout pinning. Deployment order matters.
+
+**v7 fix:** explicit migration sequence in §14:
+
+```
+Step A (helianthus-ebusgo PR): bump bus.go per-state timeouts to
+       spec V1.3.1 values (WAIT_MASTER_ACK 200ms etc.). Independent
+       and rollback-able. Operational risk: gateway tolerates longer
+       slave latencies (relaxation only, no behavioral tightening).
+
+Step B (2-week soak after Step A merges): proxy ships v7 with
+       PASSIVE_TRACKING + classifier + escape decoder. By now bus.go
+       timeouts are pinned to the values proxy expects. No
+       cross-repo timing divergence.
+
+Step C: live-bus validation per §14 criteria. Counter alerts active.
+
+Step D: mark round-9 as legacy-fallback (label comment, no deletion).
+```
+
+Step A is pure constants change; Step B is the architectural change; no period where mismatched FSMs cause divergence.
+
+### 1.11 Reuse claim correction (Codex MAJOR §14)
+
+**v6 issue:** v6 §11 said proxy classifier "reuses `passive_transaction_reconstructor.go`". That file is in `helianthus-ebusgateway`, not `helianthus-ebus-adapter-proxy`. And the semantics differ (existing reconstructor requires preceding SYN; v7 enters passive on FAILED control event or first data byte).
+
+**v7 correction:** v7 §11 reworded:
+
+```
+The proxy's PASSIVE_TRACKING sub-FSM is MODELLED ON (not literally
+reusing) the existing passive_transaction_reconstructor.go in
+helianthus-ebusgateway. The migration step is a port + adaptation,
+not a refactor. Semantic differences:
+  - Existing reconstructor: enters tracking on observed SYN (passive
+    consumer of a byte stream that begins with a sync byte).
+  - v7 proxy: enters on ENH FAILED control event (foreign arbitration
+    visible to proxy) OR first non-SYN data byte (fallback). No SYN
+    prefix required.
+The active phases (MASTER_HEADER through WAIT_TERMINATOR_SYN) and
+sub-state transitions are identical in both implementations.
+```
+
+### 1.12 Docs CI terminology (Codex MINOR)
+
+**v6 issue:** `helianthus-docs-ebus/scripts/ci_local.sh` enforces initiator/target terminology over master/slave. v6 used the legacy terms.
+
+**v7 fix:** all uses of "master" → "initiator" and "slave" → "target" in design doc text. (eBUS protocol byte names QQ/ZZ remain unchanged; they are field names, not role names.)
+
+This applies to v7 and all subsequent versions. The mermaid state names retain `MASTER_HEADER` / `SLAVE_LENGTH` etc. because these correspond to spec-defined wire-phase labels, not role descriptions.
+
+## 2. Items NOT fixed in v7 (residuals, with rationale)
+
+### 2.1 Slow-slave edge case (Codex BLOCKER §2/§3 first item — reframed as residual)
+
+**Codex finding:** Proxy times out WAIT_MASTER_ACK at 200 ms; foreign slave's ACK arrives at 210 ms; proxy treats as new master header byte.
+
+**Rationale not-fixed:** 200 ms is the spec V1.3.1 timeout. A slave responding at 210 ms violates spec. ebusd's own bushandler exhibits the same behavior (any post-timeout activity is treated as new telegram start). v7 matches this; the residual is "spec-violating slaves cause one-telegram-misclassification followed by self-correction at next AUTO-SYN".
+
+Acknowledge in §13 explicitly: "Slaves responding outside the spec V1.3.1 200 ms window produce a single-telegram misclassification by all wire observers (including ebusd-on-direct-adapter). Proxy matches the reference behavior. Operationally bounded — next AUTO-SYN re-syncs all observers to IDLE."
+
+### 2.2 Pacer "shared wire" concern (Codex BLOCKER §6 — assessed as arch-misreading)
+
+**Codex finding:** Per-session pacer locks ignore shared wire timing; two sessions can emit too close.
+
+**Rationale not-fixed (clarification in v7 §6):** the proxy emits to **per-session TCP sockets**, not to a shared wire. Each session's pacer caps that session's emission rate. The proxy is downstream of the wire — it has no shared-wire-emission concept. Two sessions emitting bytes to TWO different TCP sockets at T+0ms and T+0.5ms is fine; they're separate streams.
+
+v7 §6 adds clarification: "The pacer is per-session because the bottleneck it regulates is per-session TCP egress; the proxy is not a master-on-wire and has no shared-wire emission resource."
+
+If implementation later finds a shared resource (e.g., serializing all session writes through one goroutine), this can be revisited; not architecturally required.
+
+## 3. Updated FSM (v7 §3 superseding v6 §3)
+
+Mermaid identical to v6 §3 except for explicit transitions:
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> ARBITRATING : ENH STARTED for our client
+    IDLE --> PASSIVE_TRACKING : ENH FAILED(winner) OR first non-SYN byte
+
+    ARBITRATING --> MASTER_HEADER : grant resolved
+    ARBITRATING --> IDLE : ENH FAILED
+
+    MASTER_HEADER --> MASTER_DATA : NN>0
+    MASTER_HEADER --> MASTER_CRC : NN==0
+    MASTER_DATA --> MASTER_CRC : NN bytes consumed
+    MASTER_CRC --> WAIT_TERMINATOR_SYN : broadcast (ZZ=0xFE)
+    MASTER_CRC --> WAIT_MASTER_ACK : otherwise
+
+    WAIT_MASTER_ACK --> MASTER_RETX : NACK, retx<1
+    WAIT_MASTER_ACK --> ABORTED : NACK, retx>=1
+    WAIT_MASTER_ACK --> WAIT_TERMINATOR_SYN : ACK + master-master
+    WAIT_MASTER_ACK --> SLAVE_LENGTH : ACK + master-slave
+    MASTER_RETX --> MASTER_HEADER : retransmit (byte_index reset)
+    SLAVE_LENGTH --> SLAVE_DATA : NN'>0
+    SLAVE_LENGTH --> SLAVE_CRC : NN'==0
+    SLAVE_DATA --> SLAVE_CRC : NN' consumed
+    SLAVE_CRC --> WAIT_SLAVE_ACK
+    WAIT_SLAVE_ACK --> SLAVE_RETX : NACK, retx<1
+    WAIT_SLAVE_ACK --> ABORTED : NACK, retx>=1
+    WAIT_SLAVE_ACK --> WAIT_TERMINATOR_SYN : ACK
+    SLAVE_RETX --> SLAVE_LENGTH : retransmit
+    WAIT_TERMINATOR_SYN --> IDLE : SYN observed
+
+    PASSIVE_TRACKING --> IDLE : terminator SYN observed in sub-FSM
+    PASSIVE_TRACKING --> PASSIVE_TRACKING : sub-FSM advances per byte
+```
+
+PASSIVE_TRACKING runs the FULL sub-FSM including MASTER_RETX and SLAVE_RETX with the same NACK handling. The composite state's exit condition is the sub-FSM reaching its own terminal SYN observed (per WAIT_TERMINATOR_SYN → IDLE in active).
+
+## 4. v7 invariants (unchanged from v6 plus byte-batch atomicity)
+
+  - **I0** (clock): monotonic time everywhere.
+  - **I1** (no synthetic events): admin channel is explicitly separate from byte stream.
+  - **I2** (FSM-driven filter): FSM mode determines classification.
+  - **I3** (pacer): inter-byte gap ≥ τ_wire_byte per session, robust under jitter.
+  - **I4** (escape decoder): count-bounded absorption + inter-byte timer pause during ESCAPE_PENDING.
+  - **I5** (FSM autonomy): observers reconcile via wire-real events.
+  - **I6** (retx cap): 1 retx per phase per spec.
+  - **I7** (gateway-side alignment): bus.go timeouts pinned to spec values.
+  - **I8** (round-9 backward compat): legacy-fallback with gated regression counter + Prometheus alert.
+  - **I9 (NEW)** (byte-batch atomicity): FSM transitions are committed before per-byte classification within a batch.
+  - **I10 (NEW)** (PROTOCOL_FAULT visibility): offending byte is forwarded to all observers; admin event surfaces fault.
+
+## 5. Summary mapping v6 findings → v7 resolutions
+
+| v6 finding | v7 resolution |
+|---|---|
+| Opus F-v6-1 byte-batch atomicity | §1.3 + I9 explicit per-byte serial processing. |
+| Opus F-v6-2 inter-byte vs escape budget | §1.4 inter-byte timer paused during ESCAPE_PENDING. |
+| Opus F-v6-3 + F-v6-8 PASSIVE NACK/RETX | §1.5 + §3 explicit MASTER_RETX/SLAVE_RETX in passive sub-FSM. |
+| Opus F-v6-4 round-9 counter gating | §1.8 counter gated on bus.go FSM ≠ IDLE. |
+| Opus F-v6-5 L_rtt stale-EMA | §1.7 passive-mode L_link sampling. |
+| Opus F-v6-6 PROTOCOL_FAULT byte fate | §1.1 + I10 forward + admin event. |
+| Opus F-v6-7 cross-repo deploy order | §1.10 explicit A→B→C→D sequence. |
+| Codex BLOCKER §2/§3 timeout-to-IDLE | §2.1 documented residual; matches ebusd reference behavior. |
+| Codex BLOCKER §4/§8 PROTOCOL_FAULT drops | §1.1 same as Opus F-v6-6. |
+| Codex BLOCKER §2/§3 FAILED event passive entry | §1.2 PASSIVE_TRACKING enters on FAILED OR first data byte. |
+| Codex BLOCKER §6 shared wire pacer | §2.2 clarification: per-session TCP egress, no shared wire. |
+| Codex MAJOR §7 L_rtt re-bootstrap | §1.7 passive sampling eliminates re-bootstrap need. |
+| Codex MAJOR §14 reuse claim | §1.11 corrected: modelled-on, not reuse. |
+| Codex MAJOR §3/§4 phase validation | §1.6 explicit NN bounds + CRC compute + winner_addr check. |
+| Codex MAJOR §10 counter alerting | §1.9 explicit Prometheus alert rule. |
+| Codex MAJOR §14 step 6 deploy order | §1.10 same. |
+| Codex MINOR docs CI terminology | §1.12 initiator/target throughout doc text. |
+
+Every BLOCKER and MAJOR from both reviewers has an explicit v7 resolution. The two not-fixed items (§2.1 slow-slave edge, §2.2 pacer architecture) are reframed as residual or clarified, with rationale.

--- a/architecture/adaptermux/frame-atomic-visibility-v7.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v7.md
@@ -3,6 +3,15 @@
 > Status: design sketch v7. Tightens v6 per round-6 review findings.
 > Branch: `frame-atomic-visibility` · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 v6 received split verdicts on round 6:
 
   - **Opus: minor-fixes** ("genuinely minor-fixes territory but with two MAJOR holes that must close before ship... isn't a rethink — it's a localized tightening").
@@ -338,3 +347,5 @@ PASSIVE_TRACKING runs the FULL sub-FSM including MASTER_RETX and SLAVE_RETX with
 | Codex MINOR docs CI terminology | §1.12 initiator/target throughout doc text. |
 
 Every BLOCKER and MAJOR from both reviewers has an explicit v7 resolution. The two not-fixed items (§2.1 slow-slave edge, §2.2 pacer architecture) are reframed as residual or clarified, with rationale.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility-v8.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v8.md
@@ -1,0 +1,336 @@
+# Frame-Atomic Visibility v8 — Surgical Fixes to v7
+
+> Status: design sketch v8. Surgical fixes per round-7 split-verdict.
+> Branch: `frame-atomic-visibility` · Date: 2026-05-18
+
+Round 7 verdicts:
+  - **Opus: minor-fixes** ("design has converged"); 1 BLOCKER (§1.2 prose) + 1 MAJOR (§1.4 ESCAPE_PENDING bound) + 4 minors.
+  - **Codex: major-rethink** with 1 "irreducible blocker" (§1.3 byte ordering) + 7 majors + 4 minors.
+
+v8 applies the surgical fixes both reviewers converged on, plus Codex's unique blocker (real correctness bug, not architecture). It preserves v7's structural design entirely.
+
+## 1. Fixes applied
+
+### 1.1 [Codex IRREDUCIBLE] §1.3 byte ordering — classify under CURRENT phase, then transition
+
+**v7 bug:** Per-byte algorithm in v7 §1.3:
+```
+for each byte b:
+    fsm.feed(b)              # may transition phase
+    classify_under(fsm.mode_after_feed, b)
+```
+This classifies the byte under the POST-transition phase. Example failure: WAIT_MASTER_ACK byte 0x00 (the ACK) advances FSM to SLAVE_LENGTH, then we classify 0x00 under SLAVE_LENGTH (treating it as NN'=0, a zero-length response). The byte was meant to be an ACK, not a length field.
+
+**v8 fix:** classify first, then transition:
+```
+for each byte b:
+    current_phase = fsm.current_phase
+    decision = classify_under(current_phase, b)
+    apply_decision(decision, b)   # forward/drop/fault
+    if decision == FORWARD_TO_ALL or decision == ECHO_OF_OWN_WRITE:
+        fsm.consume_byte_in_current_phase(b)
+        # consume may complete a phase boundary; transition fires only after consumption:
+        if phase_complete(current_phase, b):
+            next_phase = fsm.compute_next_phase(current_phase, b)
+            fsm.transition_to(next_phase)
+```
+
+The byte is interpreted under the phase that expected it. The transition is a consequence of the byte's interpretation, applied AFTER classification commits.
+
+Updated invariant **I9 (v8)**: "Per byte: classify under current phase → forward/drop per classification → if classification was forward/echo, consume byte in current phase → if phase boundary is reached, transition to next phase. All four steps execute atomically within a single goroutine per session."
+
+Special case for IDLE→PASSIVE_TRACKING entry: the entering byte is the FIRST byte of MASTER_HEADER. It is classified under PASSIVE_TRACKING/MASTER_HEADER (not under IDLE), because IDLE has no "what to do with this byte" rule beyond "trigger transition". This is the one phase transition that fires on the byte itself rather than after consumption.
+
+### 1.2 [Opus BLOCKER + Codex MAJOR] §1.2 PASSIVE_TRACKING entry — first-non-SYN is primary, FAILED is rare
+
+**v7 prose:** "ENH adapters surface foreign-arbitration via FAILED(winner_addr) control events that arrive BEFORE the first data byte."
+
+**Both reviewers verified (independently) against ENH spec:** FAILED fires only as response to our own arbitration request, not for foreign-master arbitrations where we weren't competing. v7 inverted the architecture under a false premise.
+
+**v8 fix:** Re-order primary/fallback in §1.2:
+
+```
+IDLE → PASSIVE_TRACKING entry rule (v8):
+
+  Primary path: first non-SYN byte from adapter when no STARTED-for-us
+    is in flight. The byte IS the foreign master's QQ. Classify it
+    under PASSIVE_TRACKING/MASTER_HEADER byte_index=0.
+
+  Contention edge case: if we happened to issue a START at the same
+    moment a foreign master won arbitration, ENH adapter emits
+    FAILED(winner_addr). Use winner_addr as a validation hint for
+    the subsequent QQ byte (validate QQ == winner_addr; on mismatch,
+    PROTOCOL_FAULT).
+
+  Most foreign telegrams arrive via the primary path. FAILED-driven
+  validation is a sanity check for contention scenarios only.
+```
+
+This corrects the prose without changing implementation: §1.6's winner_addr validation rule still applies opportunistically when FAILED was observed. The dominant flow uses the byte itself as entry signal.
+
+### 1.3 [Both MAJOR] §1.4 ESCAPE_PENDING duration bounded
+
+**v7 issue:** Inter-byte timer paused during ESCAPE_PENDING, but ESCAPE_PENDING itself has no max duration. Decoder can sit in ESCAPE_PENDING indefinitely if transport stops delivering bytes.
+
+**v8 fix:** explicit hard cap of 32 ms wall-clock on ESCAPE_PENDING:
+
+```
+[ESCAPE_PENDING]
+  T_a9_seen = T (monotonic clock)
+
+  on byte b:
+    if T_now - T_a9_seen > 32 ms:
+      # ESCAPE_PENDING timeout — drop both the 0xA9 and absorbed AAs.
+      # No emission to classifier; admin log only.
+      admin.log("escape_pending_timeout", duration=T_now-T_a9_seen)
+      state := NORMAL
+      drop b too (treat current byte as continuation of corruption);
+      OR re-process b in NORMAL state (if next-byte recovery preferred).
+
+    elif b == 0x01: emit (0xAA, was_escaped=true); state := NORMAL
+    elif b == 0x00: emit (0xA9, was_escaped=true); state := NORMAL
+    elif b == 0xAA and absorbed_count < 8:
+      absorbed_count += 1
+    else:
+      # Malformed escape OR 8 absorptions reached → admin log, emit
+      # nothing, state := NORMAL.
+      admin.log("escape_decoder_recovery", details)
+      state := NORMAL
+```
+
+The 32 ms bound is `8 × τ_wire_byte` (the maximum theoretically achievable absorption window) extended slightly for jitter tolerance. Beyond 32 ms, the wire is genuinely broken; better to abandon and let downstream FSM detect protocol fault.
+
+Updated invariant **I4 (v8)**: "Escape decoder budget: absorb up to 8 AAs OR wait up to 32 ms wall-clock in ESCAPE_PENDING, whichever comes first. On either bound: emit nothing, admin log, return to NORMAL state. Inter-byte timer for the classifier-level FSM is paused during ESCAPE_PENDING and resumes from decoded-byte emission."
+
+### 1.4 [Codex MAJOR] §1.7 abandon passive L_rtt sampling
+
+**v7 attempt:** Sample L_rtt during PASSIVE_TRACKING by computing `T_received - (previous_wire_byte_estimate + τ_wire_byte)`.
+
+**Codex correctly identifies:** This estimate includes foreign-master inter-byte gaps, target think time, OS/TCP jitter, adapter buffering. Cannot separate link latency from foreign-side cadence variability without adapter wire timestamps (which we don't have). Poisons the EMA.
+
+**v8 fix:** Abandon passive sampling entirely. L_rtt is measured ONLY during active mode (echoes of our own writes). For long idle stretches:
+
+```
+v8 L_rtt regime:
+
+  Bootstrap on connect: L_rtt_EMA = 100 ms (conservative).
+  α = 0.3.
+  Per-byte measurement during ACTIVE mode only: round-trip via echo.
+  No measurement during PASSIVE_TRACKING.
+  
+  On entry to ACTIVE mode after long IDLE (>30 s without active write):
+    Use a GRACE_BOOTSTRAP period for the first 3 echoes of the new
+    write. During grace, no hard timeout fires — only soft timeout
+    (log to admin). After 3 grace samples, L_rtt_EMA has converged
+    enough to enable hard timeouts.
+```
+
+Echo deadlines:
+  - **Grace mode (first 3 echoes after long idle):** soft = `L_rtt_EMA + 500 ms` (very loose); hard disabled.
+  - **Normal mode:** soft = `L_rtt_EMA + 100 ms`; hard = `2 × L_rtt_EMA + 200 ms`.
+
+This eliminates Codex's MAJOR §1.7 concern without sacrificing the bootstrap-from-stale issue Opus F-v7-2 raised.
+
+### 1.5 [Codex MAJOR] §1.10 Step A spec citation
+
+**v7 said:** "200 ms is the spec V1.3.1 timeout."
+
+**Codex couldn't find this in spec text.** Honest acknowledgement: 200 ms WAIT_MASTER_ACK is an engineering choice, not strictly mandated by V1.3.1. The spec specifies "respond within AUTO-SYN slot" (which is ~35-45 ms on a healthy bus). 200 ms accommodates slow targets up to ~5× the AUTO-SYN cadence — a defensible engineering choice for tolerance, but not "spec-mandated."
+
+**v8 fix:** Updated §1.10 text:
+
+```
+WAIT_MASTER_ACK timeout = 200 ms (engineering choice, not spec-mandated).
+Rationale: per spec, the target should respond within the AUTO-SYN slot
+(~35-45 ms). 200 ms accommodates targets up to ~5× that envelope while
+still bounding stuck-target detection. Gateway-side bus.go aligned to
+the same value for FSM coherence.
+
+Step A acceptance criteria:
+  - Telegram-completion rate may IMPROVE (latency-class errors hidden
+    behind the longer window). Improvement is acknowledged as a
+    relaxation artifact, not a pass/fail gate.
+  - Pass/fail gate: no NEW error classes appear; pre-existing error
+    classes (echo_mismatch, collision, nack) maintain or reduce.
+  - Specific tests: scan duration bound, no-ACK behavior, slow-ACK
+    (target responding at 100ms), NACK retry sequence, multi-master
+    contention.
+```
+
+This makes the migration step verifiable and avoids the "false positive of improvement" Opus F-v7-5 warned about.
+
+### 1.6 [Codex MAJOR] §1.5 AA-injection filter coverage across all active phases
+
+**Codex finding:** v7's §1.5 retx walk only spells out AA filter in WAIT_MASTER_ACK; retransmitted MASTER_HEADER/DATA/CRC, SLAVE_RETX phases need same provenance-aware SYN policy.
+
+**v8 fix:** explicit in §4 + §1.6:
+
+```
+AA-injection filter applies in ALL active and passive non-IDLE phases:
+  MASTER_HEADER, MASTER_DATA, MASTER_CRC, MASTER_RETX,
+  WAIT_MASTER_ACK,
+  SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC, SLAVE_RETX,
+  WAIT_SLAVE_ACK,
+  ARBITRATING.
+
+The filter rule is uniform: raw 0xAA (was_escaped=false) bytes that do
+not match the phase-expected wire role are dropped as adapter-spurious
+AA-injection.
+
+Exempt phases (raw 0xAA forwarded):
+  IDLE — wire is genuinely idle; AA is real wire AUTO-SYN
+         (residual: cannot distinguish from rare adapter-spurious in idle).
+  WAIT_TERMINATOR_SYN — the terminator IS a raw 0xAA byte; forward and
+         transition to IDLE.
+```
+
+### 1.7 [Codex MAJOR] §1.6 real address validation
+
+**Codex finding:** v7 §1.6 phase validation says "0x00 ≤ QQ ≤ 0xFF" which is tautological.
+
+**v8 fix:** explicit initiator-class and target-class validation:
+
+```
+PASSIVE_TRACKING MASTER_HEADER byte_index=0 (QQ):
+  validate: QQ is an initiator-class address per eBUS spec
+    (low nibble ∈ {0x0, 0x1, 0x3, 0x7, 0xF}; full table per spec V1.3.1
+    section "Adressen-Klassen")
+  on invalid: PROTOCOL_FAULT (forward + admin event + IDLE)
+
+PASSIVE_TRACKING MASTER_HEADER byte_index=1 (ZZ):
+  validate: ZZ is broadcast (0xFE), initiator-class, or target-class
+    address per spec
+  on invalid: PROTOCOL_FAULT
+```
+
+Implementation: a single static lookup table of address-class validity. Cheap constant-time check.
+
+### 1.8 [Codex MAJOR] §1.8 counter gate concrete location
+
+**Codex finding:** "`bus.go.fsm.phase == IDLE`" is not a real exported contract in helianthus-ebusgo. bus.go is call-stack driven.
+
+**v8 fix:** concrete code location:
+
+```
+Round-9 absorb predicate (in helianthus-ebusgo/protocol/bus.go):
+
+  if absorb_predicate_matches && in_sendRawWithEcho_active_echo_wait():
+    increment helianthus_round9_absorb_fired_proxy_mediated_total
+
+where in_sendRawWithEcho_active_echo_wait() is a boolean that is true
+during the inner echo-read loop of sendRawWithEcho, and false elsewhere.
+```
+
+This is a concrete implementation surface that exists in the call stack rather than an abstract FSM-state reference.
+
+### 1.9 [Codex MINOR] §1.12 terminology audit — complete pass
+
+**Codex finding:** "Foreign master," "foreign slave," "master-master," "slow-slave" still in v7 prose.
+
+**v8 fix:** thorough audit and replace in prose. Mermaid state names (`MASTER_HEADER`, `SLAVE_LENGTH`, etc.) retain canonical spec-phase labels but are flagged as identifiers in a glossary at the top of the doc. Prose uses initiator/target throughout.
+
+(Note: the v7→v8 prose audit is done in v8; this v8 file uses the corrected terminology throughout.)
+
+### 1.10 [Opus MINOR] §3 mermaid annotation for PASSIVE_TRACKING composite
+
+**Opus finding:** A reader of §3 mermaid alone doesn't see that PASSIVE_TRACKING contains the full MASTER_RETX/SLAVE_RETX sub-FSM.
+
+**v8 fix:** add a textual note immediately under the §3 mermaid:
+
+```
+Note: PASSIVE_TRACKING is rendered as a single composite state in the
+diagram above. Internally it runs the SAME sub-FSM as the active mode
+(MASTER_HEADER through WAIT_TERMINATOR_SYN, including MASTER_RETX and
+SLAVE_RETX paths). The only behavioral difference vs active mode is
+staging-aware echo matching: PASSIVE_TRACKING has no staging buffer
+because the proxy did not originate the bytes.
+
+For the inner sub-FSM, see §3.1 mermaid below (identical to active-
+mode FSM modulo the SLAVE→FOREIGN-INITIATOR semantic rename).
+```
+
+Plus a second mermaid block in §3.1 showing the inner sub-FSM at full detail.
+
+### 1.11 [Opus MINOR + Codex MINOR] §4 invariants concurrency model
+
+**Opus + Codex both note:** I9/I10 don't specify whether forward/admin/transition happen on the same goroutine.
+
+**v8 fix:** add invariant **I11**:
+
+```
+I11 (concurrency model): All FSM transitions, byte classifications,
+byte forwards to observer queues, and admin event emissions for a
+single session execute on a single goroutine, sequentially. No
+concurrent observers see partial state mid-transition.
+```
+
+I9 and I10 are derivable from I11.
+
+### 1.12 [Codex MINOR] §1.9 alert deployment ownership
+
+**Codex finding:** alert rule presence should be validated in live-bus phase.
+
+**v8 fix:** explicit in §1.10 / §14:
+
+```
+Step C live validation MUST include:
+  - HelianthusRound9FiredUnderProxy alert rule present in Prometheus
+    config (verify via Prometheus API).
+  - Rule owner: operations team; deployed alongside proxy image.
+  - Pre-deploy gate: prometheus-rules.yaml audit verifies rule
+    presence before proxy rollout.
+```
+
+## 2. Items NOT changed from v7
+
+  - Structural design (FSM-driven AA filter, per-session pacer, admin-channel-only faults, round-9 legacy fallback, scoped deletions).
+  - Residuals §2.1 slow-target and §2.2 pacer per-session — both correctly framed in v7.
+  - The PROTOCOL_FAULT byte-forward + admin-event rule (v7 §1.1 / I10).
+  - The deploy order A→B→C→D (v7 §1.10).
+
+## 3. Updated invariants list
+
+  - I0 (clock): monotonic time.
+  - I1 (no synthetic events in byte stream; admin channel excluded).
+  - I2 (FSM-driven filter).
+  - I3 (pacer τ_wire_byte cap, robust under jitter).
+  - I4 **v8-revised**: escape decoder 8-AA OR 32-ms bound, whichever first.
+  - I5 (FSM autonomy, RESETTED as resync).
+  - I6 (retx cap: 1 per phase).
+  - I7 (gateway-side bus.go timeout alignment).
+  - I8 (round-9 backward compat with gated counter + Prometheus alert).
+  - I9 **v8-revised**: classify under current phase BEFORE transition; transition fires only after byte consumption completes phase boundary.
+  - I10 (PROTOCOL_FAULT visibility: forward byte + admin event).
+  - I11 **NEW**: per-session single-goroutine execution model.
+
+## 4. Mapping v7 findings → v8 resolutions
+
+| v7 finding | v8 resolution |
+|---|---|
+| Codex IRREDUCIBLE §1.3 byte ordering | §1.1 classify-then-transition; I9 revised. |
+| Codex BLOCKER + Opus BLOCKER §1.2 PASSIVE entry | §1.2 first-non-SYN primary, FAILED rare-validation. |
+| Codex MAJOR + Opus MAJOR §1.4 ESCAPE_PENDING duration | §1.3 hard 32-ms cap on ESCAPE_PENDING; I4 revised. |
+| Codex MAJOR §1.7 passive L_rtt poisoning | §1.4 abandon passive sampling; GRACE_BOOTSTRAP for first 3 echoes after long idle. |
+| Codex MAJOR §1.10 spec V1.3.1 citation | §1.5 acknowledged as engineering choice; explicit Step A acceptance criteria. |
+| Codex MAJOR §1.5 retx AA filter coverage | §1.6 explicit AA filter list across all active+passive non-IDLE phases. |
+| Codex MAJOR §1.6 tautological validation | §1.7 real initiator-class + target-class validation. |
+| Codex MAJOR §1.8 bus.go FSM contract | §1.8 concrete code location (`in_sendRawWithEcho_active_echo_wait`). |
+| Codex MINOR §1.12 terminology incomplete | §1.9 complete prose audit in v8. |
+| Opus MINOR §3 mermaid composite annotation | §1.10 explanatory note + §3.1 inner mermaid. |
+| Opus + Codex MINOR concurrency model | §1.11 invariant I11 (per-session single-goroutine). |
+| Codex MINOR alert deployment ownership | §1.12 explicit pre-deploy gate. |
+| Opus F-v7-2 L_rtt bootstrap recursion | Resolved by §1.4 (abandon passive sampling = no recursion). |
+| Opus F-v7-5 Step A acceptance | §1.5 explicit telemetry gate. |
+
+Every v7 finding from both reviewers has explicit v8 resolution.
+
+## 5. v8 status
+
+The five-round trajectory v3→v4→v5→v6→v7→v8 has surfaced and addressed:
+
+  - All structural blockers (telegram-atomic at byte-stream layer impossible for active arbitration; client metadata reception impossible via ENS).
+  - All algorithmic correctness bugs (byte ordering, pacer jitter, escape decoder window).
+  - All semantic violations (synthetic ENH events, sweeping deletions of cross-mode logic).
+  - All observability gaps (counter gating, alert rules, residual documentation).
+
+The design is now ready for **implementation review and live-bus validation**, not further architectural iteration. The next round of adversarial review on v8 is recommended; if it returns minor-fixes from both reviewers, v8 is the architectural spec to land.

--- a/architecture/adaptermux/frame-atomic-visibility-v8.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v8.md
@@ -45,7 +45,7 @@ Special case for IDLE→PASSIVE_TRACKING entry: the entering byte is the FIRST b
 
 **v7 prose:** "ENH adapters surface foreign-arbitration via FAILED(winner_addr) control events that arrive BEFORE the first data byte."
 
-**Both reviewers verified (independently) against ENH spec:** FAILED fires only as response to our own arbitration request, not for foreign-master arbitrations where we weren't competing. v7 inverted the architecture under a false premise.
+**Both reviewers verified (independently) against ENH spec:** FAILED fires only as response to our own arbitration request, not for foreign-initiator arbitrations where we weren't competing. v7 inverted the architecture under a false premise.
 
 **v8 fix:** Re-order primary/fallback in §1.2:
 
@@ -53,11 +53,11 @@ Special case for IDLE→PASSIVE_TRACKING entry: the entering byte is the FIRST b
 IDLE → PASSIVE_TRACKING entry rule (v8):
 
   Primary path: first non-SYN byte from adapter when no STARTED-for-us
-    is in flight. The byte IS the foreign master's QQ. Classify it
+    is in flight. The byte IS the foreign initiator's QQ. Classify it
     under PASSIVE_TRACKING/MASTER_HEADER byte_index=0.
 
   Contention edge case: if we happened to issue a START at the same
-    moment a foreign master won arbitration, ENH adapter emits
+    moment a foreign initiator won arbitration, ENH adapter emits
     FAILED(winner_addr). Use winner_addr as a validation hint for
     the subsequent QQ byte (validate QQ == winner_addr; on mismatch,
     PROTOCOL_FAULT).
@@ -80,12 +80,13 @@ This corrects the prose without changing implementation: §1.6's winner_addr val
 
   on byte b:
     if T_now - T_a9_seen > 32 ms:
-      # ESCAPE_PENDING timeout — drop both the 0xA9 and absorbed AAs.
+      # ESCAPE_PENDING timeout — drop the 0xA9 and absorbed AAs.
       # No emission to classifier; admin log only.
       admin.log("escape_pending_timeout", duration=T_now-T_a9_seen)
       state := NORMAL
-      drop b too (treat current byte as continuation of corruption);
-      OR re-process b in NORMAL state (if next-byte recovery preferred).
+      # Re-process current byte b in NORMAL state to preserve it
+      # for next-byte resync (chosen over drop-b for data preservation).
+      goto NORMAL with input b
 
     elif b == 0x01: emit (0xAA, was_escaped=true); state := NORMAL
     elif b == 0x00: emit (0xA9, was_escaped=true); state := NORMAL
@@ -106,7 +107,7 @@ Updated invariant **I4 (v8)**: "Escape decoder budget: absorb up to 8 AAs OR wai
 
 **v7 attempt:** Sample L_rtt during PASSIVE_TRACKING by computing `T_received - (previous_wire_byte_estimate + τ_wire_byte)`.
 
-**Codex correctly identifies:** This estimate includes foreign-master inter-byte gaps, target think time, OS/TCP jitter, adapter buffering. Cannot separate link latency from foreign-side cadence variability without adapter wire timestamps (which we don't have). Poisons the EMA.
+**Codex correctly identifies:** This estimate includes foreign-initiator inter-byte gaps, target think time, OS/TCP jitter, adapter buffering. Cannot separate link latency from foreign-side cadence variability without adapter wire timestamps (which we don't have). Poisons the EMA.
 
 **v8 fix:** Abandon passive sampling entirely. L_rtt is measured ONLY during active mode (echoes of our own writes). For long idle stretches:
 
@@ -153,7 +154,7 @@ Step A acceptance criteria:
   - Pass/fail gate: no NEW error classes appear; pre-existing error
     classes (echo_mismatch, collision, nack) maintain or reduce.
   - Specific tests: scan duration bound, no-ACK behavior, slow-ACK
-    (target responding at 100ms), NACK retry sequence, multi-master
+    (target responding at 100ms), NACK retry sequence, multi-initiator
     contention.
 ```
 

--- a/architecture/adaptermux/frame-atomic-visibility-v8.md
+++ b/architecture/adaptermux/frame-atomic-visibility-v8.md
@@ -3,6 +3,15 @@
 > Status: design sketch v8. Surgical fixes per round-7 split-verdict.
 > Branch: `frame-atomic-visibility` · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 Round 7 verdicts:
   - **Opus: minor-fixes** ("design has converged"); 1 BLOCKER (§1.2 prose) + 1 MAJOR (§1.4 ESCAPE_PENDING bound) + 4 minors.
   - **Codex: major-rethink** with 1 "irreducible blocker" (§1.3 byte ordering) + 7 majors + 4 minors.
@@ -118,7 +127,7 @@ v8 L_rtt regime:
   α = 0.3.
   Per-byte measurement during ACTIVE mode only: round-trip via echo.
   No measurement during PASSIVE_TRACKING.
-  
+
   On entry to ACTIVE mode after long IDLE (>30 s without active write):
     Use a GRACE_BOOTSTRAP period for the first 3 echoes of the new
     write. During grace, no hard timeout fires — only soft timeout
@@ -335,3 +344,5 @@ The five-round trajectory v3→v4→v5→v6→v7→v8 has surfaced and addressed
   - All observability gaps (counter gating, alert rules, residual documentation).
 
 The design is now ready for **implementation review and live-bus validation**, not further architectural iteration. The next round of adversarial review on v8 is recommended; if it returns minor-fixes from both reviewers, v8 is the architectural spec to land.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility.md
+++ b/architecture/adaptermux/frame-atomic-visibility.md
@@ -3,6 +3,15 @@
 > Status: design sketch · Branch: `frame-atomic-visibility` (multi-repo)
 > · Authors: Razvan + Claude · Date: 2026-05-18
 
+
+<!-- legacy-role-mapping:begin -->
+> **Legacy terminology note.** This historical design doc was written before
+> the canonical `initiator`/`target` rename completed across the docs corpus.
+> Wherever you encounter `m`+`aster` or `sl`+`ave` in this file, read it
+> as `initiator`/`target` respectively (per the legacy-role-mapping
+> convention used throughout `helianthus-docs-ebus`). Live source code and
+> new design docs use the canonical terms exclusively.
+
 A design note for a curious reader. This describes a redesign of how the
 Helianthus eBUS gateway/proxy exposes wire activity to its multiple
 clients (ebusd, vrc-explorer, the Helianthus gateway when it is acting as
@@ -501,3 +510,5 @@ so the work can land coherently.
 Status today: design only, no code changes. The companion-repo branches
 exist as markers to anchor future commits when this proposal exits
 sketch state.
+
+<!-- legacy-role-mapping:end -->

--- a/architecture/adaptermux/frame-atomic-visibility.md
+++ b/architecture/adaptermux/frame-atomic-visibility.md
@@ -12,6 +12,35 @@ atomic event.
 
 ---
 
+## 0. Headline invariant — proxy transparency
+
+The single overriding constraint is **proxy transparency**: no client of
+the proxy should be able to detect that a proxy exists between it and
+the physical bus. Every connected client must behave as if it had its
+own dedicated ENS-WiFi adapter wired directly to the raw eBUS, reached
+over TCP/ENS.
+
+Concrete consequences, each one cross-referenced in the sections below:
+
+  - The byte stream emitted to a client conforms exactly to the ENS/ENH
+    protocol an actual adapter would emit — same event types, same
+    framing, same escape rules. (§6)
+  - The perceived bus density (`symbol_rate`) per session matches what
+    a real ENS adapter would deliver to that specific client over its
+    own TCP link, including any per-link latency or congestion. (§3)
+  - Telegram bytes are paced across roughly the wire-time of the
+    telegram, not burst-flushed. (§4.5)
+  - Arbitration control events (`STARTED` / `FAILED` / `RESET`) carry
+    timing as close to direct-adapter timing as the model can preserve.
+  - The proxy never injects events the wire did not produce. No health
+    frames, no markers, no debug taps. Diagnostic telemetry lives
+    strictly on the proxy's own out-of-band admin channel, never in
+    the client byte stream.
+
+Every design choice below derives from this single rule.
+
+---
+
 ## 1. Problem
 
 eBUS is a 2400-baud half-duplex serial protocol where every transaction
@@ -60,9 +89,22 @@ may transition between modes from one telegram to the next.
 | `cross-proxy`    | telegram-atomic + synthetic SYNs  | symbol-rate based | every other client of the proxy            |
 
 In our topology nearly every observer is `cross-proxy`. There is exactly
-one `token-holder` at a time (the arbitration winner), and
-`passive-direct` is rare (it requires a separate physical tap on the
-bus, which we do not have).
+one `token-holder` at a time (the arbitration winner for the current
+telegram), and `passive-direct` is rare (it requires a separate
+physical tap on the bus, which we do not have).
+
+**The mode is per-telegram, not per-session.** A session's role is
+fixed at the moment a telegram begins — specifically at the
+`IDLE → ARBITRATING` FSM transition (§5). If this session was the
+arbitration winner it becomes `token-holder` for this telegram; every
+other session becomes `cross-proxy` observer for this telegram. The
+role is held until the telegram terminates (`DONE` or `ABORTED`), at
+which point the session drops back to "no role" and sees only the
+inter-telegram filler stream until the next `STARTED` event.
+
+A session therefore cannot be `token-holder` and `cross-proxy`
+*simultaneously*. It alternates between the two roles from one
+telegram to the next as arbitration outcomes determine.
 
 For `token-holder`, byte-level visibility is unavoidable — the client is
 driving the wire and must see its own echoes byte by byte to detect
@@ -71,8 +113,9 @@ requires mid-telegram visibility, and the current code path stays as-is
 for it.
 
 For `cross-proxy`, telegrams are buffered server-side until complete and
-then emitted as a coherent block, padded with synthetic SYNs to preserve
-correct wire-density timing.
+then emitted as a coherent block, paced across the wire-time of the
+telegram and padded with synthetic SYNs to preserve correct wire-density
+timing.
 
 ---
 
@@ -84,17 +127,35 @@ stream. The theoretical maximum on eBUS is 240 symbols/sec (2400 baud,
 typical healthy bus reports somewhere around 100–150 symbols/sec,
 reflecting actual telegram density plus AUTO-SYN keepalives.
 
-The Helianthus proxy maintains its own observed `symbol_rate`, computed
-as an exponential moving average over bytes-received-from-transport per
-unit time. This rate is then used everywhere the proxy needs to
-synthesize filler SYN bytes — never the theoretical 240/s rate, always
-the observed rate. The point is that a `cross-proxy` client should
-perceive the same bus density it would have perceived as a
-`passive-direct` consumer; both modes share the same observable
-`symbol_rate`.
+The Helianthus proxy maintains a `symbol_rate` EMA **per cross-proxy
+session** — not a single global per-transport value. The EMA tracks
+the rate at which bytes can actually be drained to that session's TCP
+egress (bytes-delivered ÷ wall-clock window), bounded above by the
+wire-side observed rate.
 
-This is the analogue of ebusd's `symbol_rate` indicator and gives us a
-single calibration knob for filler generation.
+Per-session scoping is dictated by the transparency invariant of §0:
+each client must perceive the bus density it would have observed if
+connected to its own dedicated ENS adapter over its own TCP link. A
+client with a slow or jittery link to the proxy will see a slightly
+lower `symbol_rate` than a client with a fast link, exactly mirroring
+what would happen with two independent ENS adapters delivering the
+same physical bus to two different observers with different link
+qualities. This is the architecturally correct behavior even though it
+means the proxy generates fewer filler SYNs for slow clients, lowering
+their effective view of bus density.
+
+**Bootstrap.** A session that has just connected has no per-session
+history. The proxy seeds the per-session EMA from a transport-level
+"wire-observed" reference rate (computed once on the adapter-facing
+side, common across sessions only as a bootstrap value), then lets the
+per-session EMA diverge as the session's own drain characteristics
+manifest. The transport-level reference is only ever used at session
+boot or after a session reset.
+
+This is the analogue of ebusd's `symbol_rate` indicator — but
+ebusd-as-process has only one bus view per process, so its
+`symbol_rate` is naturally per-process. We have N concurrent sessions
+on one proxy, so we need N independent rates.
 
 ---
 
@@ -171,6 +232,32 @@ it drops. The proxy emits at the EMA, not the instantaneous rate, which
 smooths the cross-proxy view. This is intentional — clients receive a
 locally-stable view of wire density and do not chase microsecond
 jitter.
+
+### 4.5 Intra-telegram pacing
+
+Telegram bytes are emitted to a `cross-proxy` observer **spread
+across roughly the wire-time `W_F` of the telegram, not burst-flushed.**
+Each byte is scheduled at approximately
+
+```
+T_byte_i = T_emit_start + i × tau_byte
+```
+
+where `tau_byte = 1 / per_session_symbol_rate`.
+
+This matches the natural pacing a real ENS adapter would produce —
+bytes arrive at the receiver spaced by the wire bit period plus
+inter-byte processing time (≈4–8 ms per byte at 2400 baud). A
+burst-flush would deliver the entire telegram in a single TCP write
+(<1 ms perceived by the client), which would violate the transparency
+invariant of §0: no real adapter delivers bytes that fast, and a
+client running its own framing-by-timing heuristics could detect the
+proxy by the unnatural intra-telegram density.
+
+The cost is straightforward emission-scheduling complexity in the
+proxy: each per-session emission queue is timer-driven rather than
+flush-on-arrival. The benefit is a wire-indistinguishable byte stream
+on the client side.
 
 ---
 
@@ -333,28 +420,43 @@ the existing escape-decoder + echo-comparator infrastructure unchanged.
 
 ---
 
-## 9. Open questions
+## 9. Decisions
 
-  1. Do we emit telegram bytes to a `cross-proxy` observer as a single
-     burst, or spread out across `W_F` to mimic wire pacing? Burst is
-     simpler and ENH parsers handle it; pacing is more "natural" but
-     adds emission complexity.
+The four design questions raised in the initial draft have been
+resolved. Numbering preserved for traceability.
 
-  2. How does the gateway behave when it is both the token holder (for
-     its own telegrams) and a cross-proxy observer (for ebusd-originated
-     telegrams)? Same TCP session, two visibility modes alternated per
-     transaction. The session-level state machine must track the role
-     transition.
+  1. **Intra-telegram pacing: natural (per-byte pacing).** Telegram
+     bytes are emitted across `W_F` matching wire pacing, not
+     burst-flushed. Driven directly by the transparency invariant of
+     §0 — a burst-flushed telegram is detectable by the client as
+     non-wire timing. Detailed in §4.5.
 
-  3. Should the symbol-rate EMA be per-session or global per-transport?
-     Global is simpler and matches ebusd; per-session captures observer
-     bandwidth limitations but probably not needed.
+  2. **`token-holder` vs `cross-proxy` is a per-telegram role, never
+     simultaneous.** A session cannot hold both roles at once. Its
+     role is determined at the `IDLE → ARBITRATING` FSM transition
+     (arbitration winner = token holder for that telegram; everyone
+     else = cross-proxy observer for that telegram) and remains fixed
+     until `DONE` or `ABORTED`. Between telegrams the session has no
+     role; it sees only the filler SYN stream. Detailed in §2.
 
-  4. What's the right backpressure policy if a cross-proxy observer is
-     slow? Dropping filler SYNs is safe (parsers tolerate "long idle").
-     Dropping telegrams is not. Proposal: bounded per-session telegram
-     queue, drop oldest on overflow with explicit `OVERFLOW` marker
-     event.
+  3. **Symbol-rate EMA is per-session, not per-transport.** Each
+     cross-proxy session has its own `symbol_rate` EMA driven by the
+     actual rate at which bytes drain to that session's TCP egress.
+     Slow clients perceive a slower bus by design — a consequence of
+     the transparency invariant. The transport-level wire-observed
+     rate is retained only as a bootstrap seed for newly connected
+     sessions. Detailed in §3.
+
+  4. **Backpressure: drop whole telegrams from the per-session queue.**
+     If the per-session emission queue overflows because the client
+     cannot drain fast enough, the proxy drops entire queued telegrams
+     oldest-first. Communication is at the telegram layer, so partial
+     drops are nonsensical. An `OVERFLOW` notice is recorded on the
+     proxy's admin channel — never injected into the client byte
+     stream (transparency invariant). From the client's perspective
+     this looks identical to a real ENS adapter whose buffer
+     overflowed: the client simply misses telegrams from its view of
+     the bus, with no in-stream indication that anything was dropped.
 
 ---
 

--- a/architecture/adaptermux/frame-atomic-visibility.md
+++ b/architecture/adaptermux/frame-atomic-visibility.md
@@ -181,58 +181,80 @@ telegram is now complete" so it can flush the buffered bytes. The
 machine runs once per active session, fed by `StreamEvent`s from the
 transport.
 
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> ARBITRATING : STARTED event
+
+    ARBITRATING --> IDLE : FAILED event
+    ARBITRATING --> MASTER_HEADER : grant resolved<br/>first byte = QQ
+
+    MASTER_HEADER --> MASTER_DATA : NN > 0
+    MASTER_HEADER --> MASTER_CRC : NN == 0
+
+    MASTER_DATA --> MASTER_CRC : NN bytes consumed
+
+    MASTER_CRC --> WAIT_TERMINATOR_SYN : ZZ == 0xFE<br/>(broadcast)
+    MASTER_CRC --> WAIT_MASTER_ACK : ZZ != 0xFE
+
+    WAIT_MASTER_ACK --> MASTER_HEADER : NACK<br/>(retransmit, retries remain)
+    WAIT_MASTER_ACK --> WAIT_TERMINATOR_SYN : ACK +<br/>master-master
+    WAIT_MASTER_ACK --> SLAVE_LENGTH : ACK +<br/>master-slave
+    WAIT_MASTER_ACK --> ABORTED : NACK exhausted
+
+    SLAVE_LENGTH --> SLAVE_DATA : NN' > 0
+    SLAVE_LENGTH --> SLAVE_CRC : NN' == 0
+
+    SLAVE_DATA --> SLAVE_CRC : NN' bytes consumed
+
+    SLAVE_CRC --> WAIT_SLAVE_ACK
+
+    WAIT_SLAVE_ACK --> SLAVE_LENGTH : NACK<br/>(retransmit, retries remain)
+    WAIT_SLAVE_ACK --> WAIT_TERMINATOR_SYN : ACK
+    WAIT_SLAVE_ACK --> ABORTED : NACK exhausted
+
+    WAIT_TERMINATOR_SYN --> DONE : SYN observed
+
+    DONE --> IDLE : emit telegram block<br/>to cross-proxy observers
+    ABORTED --> IDLE : emit failure marker
+
+    note right of IDLE
+        Every non-terminal state may transition
+        to ABORTED on:
+        - per-state read timeout exceeded
+        - transport reset / adapter disconnect
+        - arbitration-loss observed mid-telegram
+        - illegal symbol in current phase
+    end note
 ```
-IDLE
- │ (arbitration won — either by us or observed externally)
- ▼
-ARBITRATING
- │ (first non-SYN byte after grant)
- ▼
-MASTER_HEADER       (QQ ZZ PB SB NN consumed)
- │ (NN bytes consumed)
- ▼
-MASTER_DATA
- │ (CRC byte consumed)
- ▼
-MASTER_CRC
- │
- ▼
-WAIT_ACK            (ACK / NACK / SYN — or timeout)
- │ if NACK and retries remain → MASTER_HEADER (retransmit)
- │ if ACK and broadcast → DONE
- │ if ACK and master-master → WAIT_TERMINATOR_SYN
- │ if ACK and master-slave → SLAVE_LENGTH
- ▼
-SLAVE_LENGTH
- │
- ▼
-SLAVE_DATA
- │
- ▼
-SLAVE_CRC
- │
- ▼
-WAIT_SLAVE_ACK      (initiator's ACK / NACK back)
- │
- ▼
-WAIT_TERMINATOR_SYN
- │
- ▼
-DONE → emit telegram block to all cross-proxy observers, return to IDLE
 
-(any state) ── abort triggers ──▶ ABORTED → emit failure marker to observers
-```
+### 5.1 State legend
 
-Abort triggers are: transport read timeout exceeding the state-specific
-budget, transport reset, arbitration-loss detected mid-telegram,
-unexpected SYN in a phase where SYN is illegal.
+| State                 | Consumes / awaits                                       | Typical wall-clock budget |
+|-----------------------|---------------------------------------------------------|----------------------------|
+| `IDLE`                | filler SYN stream; STARTED arbitration event           | unbounded                  |
+| `ARBITRATING`         | grant resolution (won/lost), first post-grant byte     | ~50 ms                     |
+| `MASTER_HEADER`       | `QQ ZZ PB SB NN` (5 bytes)                              | ~25 ms                     |
+| `MASTER_DATA`         | NN data bytes (0–16)                                    | ~70 ms                     |
+| `MASTER_CRC`          | 1 CRC byte                                              | ~5 ms                      |
+| `WAIT_MASTER_ACK`     | ACK (0x00), NACK (0xFF), or SYN-timeout                 | ~25 ms                     |
+| `SLAVE_LENGTH`        | NN' (response data length)                              | ~25 ms                     |
+| `SLAVE_DATA`          | NN' data bytes (0–16)                                   | ~70 ms                     |
+| `SLAVE_CRC`           | 1 CRC byte                                              | ~5 ms                      |
+| `WAIT_SLAVE_ACK`      | initiator's ACK/NACK back to slave                      | ~25 ms                     |
+| `WAIT_TERMINATOR_SYN` | first SYN after the telegram ends                       | ~50 ms                     |
+| `DONE`                | terminal-success; emit block; reset                     | one tick                   |
+| `ABORTED`             | terminal-failure; emit failure marker; reset            | one tick                   |
 
-This is closely modelled on the existing passive reconstructor in
-`helianthus-ebusgo/protocol/passive_reconstructor.go`, which already
+### 5.2 Inheritance from `passive_reconstructor`
+
+This machine is closely modelled on the existing passive reconstructor
+in `helianthus-ebusgo/protocol/passive_reconstructor.go`, which already
 solves the bulk of the framing problem for `passive` scope. The
 proposal is to use the same machine for `active` cross-proxy emission,
 with the addition of per-telegram timing metadata (`T_wire_start`,
-`W_F`, `L_up`) needed by the SYN insertion logic.
+`W_F`, `L_up`) needed by the SYN insertion logic described in §4.
 
 ---
 

--- a/architecture/adaptermux/frame-atomic-visibility.md
+++ b/architecture/adaptermux/frame-atomic-visibility.md
@@ -1,0 +1,379 @@
+# Frame-Atomic Visibility — Helianthus Proxy Design Sketch
+
+> Status: design sketch · Branch: `frame-atomic-visibility` (multi-repo)
+> · Authors: Razvan + Claude · Date: 2026-05-18
+
+A design note for a curious reader. This describes a redesign of how the
+Helianthus eBUS gateway/proxy exposes wire activity to its multiple
+clients (ebusd, vrc-explorer, the Helianthus gateway when it is acting as
+observer on someone else's transaction, etc.). The current model leaks
+intra-frame artifacts; the proposed model treats each telegram as an
+atomic event.
+
+---
+
+## 1. Problem
+
+eBUS is a 2400-baud half-duplex serial protocol where every transaction
+is a multi-byte telegram (master telegram + optional slave response +
+CRC + ACK + terminator SYN). On an idle bus, an AUTO-SYN byte (0xAA) is
+emitted roughly every 35 ms to keep the bus alive.
+
+Our gateway speaks to a WiFi-connected eBUS adapter (eBUSD-WiFi) using
+the ENH/ENS framing protocol. The adapter buffers bytes for some amount
+of time before placing them on the physical wire, and conversely buffers
+received bytes before delivering them to us over WiFi. There is real
+latency and jitter in this hop (call it `L_up` for proxy→adapter and
+`L_dn` for adapter→proxy; both are on the order of 5–30 ms, occasionally
+spiking higher).
+
+The proxy currently mirrors raw byte events to every connected client in
+real time. Side effects observed in production:
+
+  - AUTO-SYNs emitted by the adapter mid-frame leak to clients as if
+    they were real wire bytes.
+  - When client A is mid-write but client B is also subscribed, B sees
+    A's bytes intermixed with AUTO-SYN noise that has no meaning at the
+    eBUS protocol layer.
+  - The gateway has accreted multiple suppression gates over time
+    (mid-write suppression, between-writes suppression, post-grant
+    pre-echo suppression, payload-0xAA + AUTO-SYN drain absorption) to
+    paper over this leak. Each gate fixes some cases and shifts others
+    into different failure modes (most recently: echo_mismatch errors
+    became timeout errors, with the same underlying transactions just
+    relabelled).
+
+The root cause is the visibility model itself: bytes are not the natural
+unit of eBUS observation. Telegrams are.
+
+---
+
+## 2. Three observer modes
+
+The proposal splits client visibility into three modes. Any one client
+may transition between modes from one telegram to the next.
+
+| Mode             | Stream                            | SYN source        | Used when                                  |
+|------------------|-----------------------------------|-------------------|--------------------------------------------|
+| `token-holder`   | byte-level real time              | wire-exact        | client owns arbitration for this telegram  |
+| `passive-direct` | byte-level real time              | wire-exact        | client is a hardware pass-through observer |
+| `cross-proxy`    | telegram-atomic + synthetic SYNs  | symbol-rate based | every other client of the proxy            |
+
+In our topology nearly every observer is `cross-proxy`. There is exactly
+one `token-holder` at a time (the arbitration winner), and
+`passive-direct` is rare (it requires a separate physical tap on the
+bus, which we do not have).
+
+For `token-holder`, byte-level visibility is unavoidable — the client is
+driving the wire and must see its own echoes byte by byte to detect
+arbitration outcome, NACKs, and so on. This is the only mode that
+requires mid-telegram visibility, and the current code path stays as-is
+for it.
+
+For `cross-proxy`, telegrams are buffered server-side until complete and
+then emitted as a coherent block, padded with synthetic SYNs to preserve
+correct wire-density timing.
+
+---
+
+## 3. Symbol-rate measurement (ebusd-style)
+
+ebusd exposes a `symbol_rate` statistic computed against the live byte
+stream. The theoretical maximum on eBUS is 240 symbols/sec (2400 baud,
+10-bit UART framing). The observed rate is always a submultiple — a
+typical healthy bus reports somewhere around 100–150 symbols/sec,
+reflecting actual telegram density plus AUTO-SYN keepalives.
+
+The Helianthus proxy maintains its own observed `symbol_rate`, computed
+as an exponential moving average over bytes-received-from-transport per
+unit time. This rate is then used everywhere the proxy needs to
+synthesize filler SYN bytes — never the theoretical 240/s rate, always
+the observed rate. The point is that a `cross-proxy` client should
+perceive the same bus density it would have perceived as a
+`passive-direct` consumer; both modes share the same observable
+`symbol_rate`.
+
+This is the analogue of ebusd's `symbol_rate` indicator and gives us a
+single calibration knob for filler generation.
+
+---
+
+## 4. SYN insertion model
+
+### 4.1 Continuous idle generator
+
+Between telegrams the proxy continuously emits filler SYN bytes to each
+`cross-proxy` observer at the observed `symbol_rate`. This holds the
+illusion of a quiet but live bus while no real telegram is in flight.
+
+### 4.2 Prefix and postfix when emitting a telegram
+
+When telegram `F` becomes complete (the terminator SYN has been observed
+on the adapter side), the proxy releases it to each `cross-proxy`
+observer with this shape:
+
+```
+[prefix_filler_SYNs] [byte_0 ... byte_N of F] [postfix continues idle]
+```
+
+The prefix and postfix asymmetry is intentional.
+
+  - `prefix_filler_count = round(L_up_estimate × observed_symbol_rate)`
+  - `postfix_filler_count` = whatever the continuous idle generator
+    naturally emits until the next telegram or external event.
+
+**Why asymmetric?** From the point of view of an originating client A:
+
+  - A submitted its frame to the proxy at wall clock T₀.
+  - The bytes actually started moving on the physical wire at T₀ + L_up.
+  - During the interval [T₀, T₀ + L_up] the WIRE was idle, and a
+    `passive-direct` observer would have counted ~`L_up * symbol_rate`
+    SYN bytes during that window.
+  - A `cross-proxy` observer (which may be A itself, observing its own
+    transaction reflected back) sees no events during this window — the
+    proxy is holding the frame. To make A's perceived view match what a
+    `passive-direct` consumer would have seen, the proxy must back-fill
+    the equivalent number of SYNs as a prefix immediately before
+    releasing F.
+
+After the telegram, the situation is different:
+
+  - The wire idle resumes at T₀ + L_up + W_F (where W_F is the
+    wire-time duration of the telegram itself).
+  - The proxy receives the terminator SYN of F at T₀ + L_up + W_F + L_dn.
+  - From this point onward, the continuous idle generator naturally
+    emits SYNs at the observed rate. There is no past gap to back-fill.
+
+Hence: prefix compensates for `L_up`; postfix needs no compensation.
+
+### 4.3 Estimating `L_up`
+
+`L_up` is measured per transaction by the proxy. For an outbound write
+issued at T_send, the first echo byte (if telegram is initiator-side) or
+the first received byte is observed at T_recv. With knowledge of the
+expected wire transmit time for a single byte (~4 ms at 2400 baud) and
+a running EMA of `L_dn`:
+
+```
+L_up_estimate(F) = T_recv_first - T_send_first - tau_wire_byte - L_dn_EMA
+```
+
+The estimator is allowed to be coarse — quantization to the SYN period
+(~35 ms or whatever the observed rate dictates) is fine, because the
+filler granularity is one SYN. A 5 ms vs 25 ms `L_up` difference is
+below the resolution of the model.
+
+### 4.4 Cross-effect with `symbol_rate` jitter
+
+`observed_symbol_rate` is an EMA, so it lags real conditions. During a
+transient bus burst the actual rate spikes high; during a quiet stretch
+it drops. The proxy emits at the EMA, not the instantaneous rate, which
+smooths the cross-proxy view. This is intentional — clients receive a
+locally-stable view of wire density and do not chase microsecond
+jitter.
+
+---
+
+## 5. Telegram state machine (sketch)
+
+The proxy needs a deterministic state machine that decides "this
+telegram is now complete" so it can flush the buffered bytes. The
+machine runs once per active session, fed by `StreamEvent`s from the
+transport.
+
+```
+IDLE
+ │ (arbitration won — either by us or observed externally)
+ ▼
+ARBITRATING
+ │ (first non-SYN byte after grant)
+ ▼
+MASTER_HEADER       (QQ ZZ PB SB NN consumed)
+ │ (NN bytes consumed)
+ ▼
+MASTER_DATA
+ │ (CRC byte consumed)
+ ▼
+MASTER_CRC
+ │
+ ▼
+WAIT_ACK            (ACK / NACK / SYN — or timeout)
+ │ if NACK and retries remain → MASTER_HEADER (retransmit)
+ │ if ACK and broadcast → DONE
+ │ if ACK and master-master → WAIT_TERMINATOR_SYN
+ │ if ACK and master-slave → SLAVE_LENGTH
+ ▼
+SLAVE_LENGTH
+ │
+ ▼
+SLAVE_DATA
+ │
+ ▼
+SLAVE_CRC
+ │
+ ▼
+WAIT_SLAVE_ACK      (initiator's ACK / NACK back)
+ │
+ ▼
+WAIT_TERMINATOR_SYN
+ │
+ ▼
+DONE → emit telegram block to all cross-proxy observers, return to IDLE
+
+(any state) ── abort triggers ──▶ ABORTED → emit failure marker to observers
+```
+
+Abort triggers are: transport read timeout exceeding the state-specific
+budget, transport reset, arbitration-loss detected mid-telegram,
+unexpected SYN in a phase where SYN is illegal.
+
+This is closely modelled on the existing passive reconstructor in
+`helianthus-ebusgo/protocol/passive_reconstructor.go`, which already
+solves the bulk of the framing problem for `passive` scope. The
+proposal is to use the same machine for `active` cross-proxy emission,
+with the addition of per-telegram timing metadata (`T_wire_start`,
+`W_F`, `L_up`) needed by the SYN insertion logic.
+
+---
+
+## 6. ENH/ENS protocol compatibility
+
+ENH is byte-event-oriented: each transport read returns a `(byte,
+was_escaped)` pair, plus occasional `STARTED` / `FAILED` arbitration
+markers. There is no native frame envelope on the wire — frame
+boundaries are implicit in the eBUS protocol semantics.
+
+A `cross-proxy` client does not need a new transport protocol. The
+proxy emits the same `ENH_EVT_RECEIVED` byte events it would have
+emitted under the byte-level model — but the timing and content of
+those events is controlled by the state machine above. From the
+client's perspective the byte stream looks exactly like a real wire:
+filler SYNs between telegrams, contiguous telegram bytes within
+telegrams. There are no intra-telegram AUTO-SYNs and no escape-layer
+leaks.
+
+Arbitration markers (`STARTED`, `FAILED`, `RESET`) remain real-time. A
+client that wants to compete for arbitration receives these as it does
+today; the change only affects byte-stream visibility, not control
+plane.
+
+---
+
+## 7. What the proposal removes
+
+Several suppression layers in the current code become unnecessary:
+
+  - The mid-write SYN suppression gate in the adapter mux.
+  - The between-writes suppression gate (round-7 patch).
+  - The post-grant pre-echo suppression window in the ENH transport
+    layer.
+  - The payload-0xAA + AUTO-SYN drain absorption logic in the protocol
+    layer (round-9 patch).
+
+These exist to hide bytes that should never have been exposed to
+clients in the first place. Under telegram-atomic visibility they are
+simply absent from the cross-proxy stream.
+
+The token-holder path keeps its byte-level model and continues to use
+the existing escape-decoder + echo-comparator infrastructure unchanged.
+
+---
+
+## 8. What the proposal costs
+
+  - **Latency.** Cross-proxy observers see each telegram only after it
+    has completed on the wire and traversed the proxy. Worst case
+    latency add is one telegram wire-time (~50–150 ms) plus L_dn.
+    Acceptable for polling-class clients (ebusd, vrc-explorer,
+    dashboards).
+
+  - **Buffer state.** Per session: roughly one max-size telegram (<100
+    bytes payload) plus state-machine metadata. Bounded and small.
+
+  - **Failure visibility latency.** A telegram that aborts mid-way is
+    not visible to cross-proxy observers until the abort is detected
+    and the failure marker is emitted. Worst case: state-specific
+    timeout budget elapses. The proxy needs explicit per-state timeout
+    values.
+
+  - **State machine completeness.** Edge cases (NACK retransmit,
+    broadcast with no response, master-master frames, mid-telegram
+    transport reset) must be modelled exhaustively. The risk is a
+    state transition we forgot, producing a stuck telegram. Mitigation:
+    model inherits from the existing passive reconstructor, which has
+    been validated against live traffic.
+
+  - **Telegram-ordering policy.** If two telegrams overlap due to
+    arbitration race resolution, which one is released first to
+    cross-proxy observers? Proposal: completion order (the order in
+    which `DONE` is reached). Start order is meaningless under
+    half-duplex arbitration.
+
+---
+
+## 9. Open questions
+
+  1. Do we emit telegram bytes to a `cross-proxy` observer as a single
+     burst, or spread out across `W_F` to mimic wire pacing? Burst is
+     simpler and ENH parsers handle it; pacing is more "natural" but
+     adds emission complexity.
+
+  2. How does the gateway behave when it is both the token holder (for
+     its own telegrams) and a cross-proxy observer (for ebusd-originated
+     telegrams)? Same TCP session, two visibility modes alternated per
+     transaction. The session-level state machine must track the role
+     transition.
+
+  3. Should the symbol-rate EMA be per-session or global per-transport?
+     Global is simpler and matches ebusd; per-session captures observer
+     bandwidth limitations but probably not needed.
+
+  4. What's the right backpressure policy if a cross-proxy observer is
+     slow? Dropping filler SYNs is safe (parsers tolerate "long idle").
+     Dropping telegrams is not. Proposal: bounded per-session telegram
+     queue, drop oldest on overflow with explicit `OVERFLOW` marker
+     event.
+
+---
+
+## 10. Why this is worth doing
+
+The Helianthus codebase has spent roughly nine investigation cycles
+patching byte-level visibility leaks under the existing model. Each
+round either fixes a subset of cases and shifts the rest to a new
+error class, or trades one masking layer for another. The structural
+cause is that we expose a unit (the byte) that is not meaningful at
+the protocol layer, and then we try to hide individual byte exposures
+via heuristics.
+
+Telegram-atomic visibility eliminates the unit mismatch. The proxy
+becomes a translator between two layers — physical wire bytes on one
+side, protocol-level telegrams plus calibrated idle on the other —
+and all the heuristics dissolve into a single clean contract: clients
+see the bus as a sequence of telegrams separated by SYN-rate-matched
+idle periods. No mid-telegram leaks, no AUTO-SYN intrusions, no
+escape-layer contamination, no race between competing clients during
+arbitration hand-off.
+
+It is the same simplification ebusd applied internally years ago when
+it adopted the `symbol_rate` framework: stop fighting the byte stream,
+treat the bus as the protocol abstraction it actually is.
+
+---
+
+## Companion repos
+
+This design will be implemented (when promoted past sketch status)
+across four repositories. Each carries its own branch of the same name
+so the work can land coherently.
+
+| Repo                              | Branch                      | Role                                                              |
+|-----------------------------------|-----------------------------|-------------------------------------------------------------------|
+| `helianthus-docs-ebus`            | `frame-atomic-visibility`   | this design doc + ongoing iterations                              |
+| `helianthus-ebusgo`               | `frame-atomic-visibility`   | telegram state machine + symbol-rate EMA at the protocol layer    |
+| `helianthus-ebusgateway`          | `frame-atomic-visibility`   | adapter-mux integration + cross-proxy emission scheduling         |
+| `helianthus-ebus-adapter-proxy`   | `frame-atomic-visibility`   | per-observer queue + SYN filler generator                         |
+
+Status today: design only, no code changes. The companion-repo branches
+exist as markers to anchor future commits when this proposal exits
+sketch state.

--- a/deployment/prometheus-alerts.md
+++ b/deployment/prometheus-alerts.md
@@ -1,0 +1,98 @@
+# Prometheus Alert Rules — Helianthus Gateway
+
+This document is the operations-side reference for Prometheus alert rules
+that the operator deployment manifest MUST include alongside the
+helianthus-ebusgateway image. The gateway itself only exposes counters;
+the *alerting decisions* — including any cross-counter or
+mode-conditioned predicates — live in the Prometheus rules file shipped
+with the deployment.
+
+## Index
+
+| Alert name | Source counter | Reference |
+|---|---|---|
+| `HelianthusRound9FiredUnderProxy` | `helianthus_round9_absorb_entered_total` | [frame-atomic-visibility-v8 §1.12 / I8](../architecture/adaptermux/frame-atomic-visibility-v8.md) |
+
+## HelianthusRound9FiredUnderProxy
+
+**Owner:** operations team. The rule MUST be present in the Prometheus
+config (`prometheus-rules.yaml`) before the adaptermux classifier is
+enabled in `enforce` mode. Step C live-bus validation (v8 §14) verifies
+rule presence via the Prometheus API before proxy rollout.
+
+**Counter source:** `helianthus_round9_absorb_entered_total`
+— exported by `helianthus-ebusgo`'s `protocol.Bus.Round9AbsorbEntered()`
+accessor. The counter is named neutrally on the Go side — it counts
+every round-9 AUTO-SYN absorb predicate fire inside `sendRawWithEcho`
+(`protocol/bus.go`), gated on the runtime phase predicate
+`inSendRawWithEchoActiveEchoWait()` (see [frame-atomic-visibility-v8 §1.8](../architecture/adaptermux/frame-atomic-visibility-v8.md)).
+The "fired under proxy" interpretation lives ENTIRELY in this alert
+rule's PromQL (which AND-s the counter with `classifier_mode == "enforce"`),
+not in the counter's code-side name. This keeps the Go protocol layer
+free of cross-repo coupling.
+
+**Why this alert exists:** under v8 I8, round-9 absorb code is RETAINED
+as a legacy fallback for direct-adapter mode (no proxy mediating wire
+AUTO-SYNs). When the adaptermux classifier is in `enforce` mode, the
+proxy is contractually obligated to filter wire AUTO-SYNs before they
+reach the gateway's echo position; any round-9 fire under that mode is
+a v8 invariant violation — the proxy is not filtering correctly.
+
+**Suggested rule:**
+
+```yaml
+groups:
+  - name: helianthus.round9
+    rules:
+      - alert: HelianthusRound9FiredUnderProxy
+        expr: |
+          rate(helianthus_round9_absorb_entered_total[5m]) > 0
+          and on(instance) helianthus_adaptermux_classifier_mode{mode="enforce"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          component: helianthus-gateway
+          invariant: frame-atomic-v8-I8
+        annotations:
+          summary: "Round-9 AUTO-SYN absorb fired while adaptermux classifier is in enforce mode"
+          description: |
+            The gateway's round-9 AUTO-SYN absorb predicate fired on instance
+            {{ $labels.instance }} while the adaptermux classifier is in
+            `enforce` mode. Per frame-atomic-visibility v8 §1.8 / I8, the
+            proxy MUST filter wire AUTO-SYNs before they reach the gateway's
+            echo position when classifier mode is `enforce` — round-9 firing
+            indicates the proxy is not correctly filtering. Investigate the
+            adaptermux classifier path and per-session pacer; this is the
+            v8 invariant violation that the round-9 fallback was kept to
+            measure, not to mask.
+          runbook_url: |
+            https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/adaptermux/frame-atomic-visibility-v8.md#18
+```
+
+**Gating model:**
+
+- The counter increments unconditionally on every round-9 fire, regardless
+  of classifier mode. The Go code does NOT consult the classifier mode
+  (no cross-repo coupling).
+- The alert rule does the gating via the `helianthus_adaptermux_classifier_mode`
+  gauge (exported by `helianthus-ebusgateway/internal/adaptermux` —
+  scheduled for Phase 3 of the frame-atomic-visibility rollout). Until
+  Phase 3 lands, deploy with the second clause commented out; the alert
+  will trip on ANY round-9 fire, which is conservative and
+  acceptable for the bootstrap phase.
+
+**Pre-deploy gate (Step C live-validation, v8 §14):**
+
+```bash
+# Check the rule is loaded.
+curl -s "${PROMETHEUS_URL}/api/v1/rules" \
+  | jq '.data.groups[].rules[] | select(.name == "HelianthusRound9FiredUnderProxy")'
+
+# Check the rule was loaded WITHOUT errors.
+curl -s "${PROMETHEUS_URL}/api/v1/rules" \
+  | jq '.data.groups[].rules[] | select(.name == "HelianthusRound9FiredUnderProxy") | .lastError // empty'
+# Empty output = OK; any output here is a load error.
+```
+
+If the rule is absent or fails to load, the proxy MUST NOT be promoted
+to `enforce` mode — the v8 invariant is unobservable without it.

--- a/deployment/prometheus-alerts.md
+++ b/deployment/prometheus-alerts.md
@@ -12,6 +12,7 @@ with the deployment.
 | Alert name | Source counter | Reference |
 |---|---|---|
 | `HelianthusRound9FiredUnderProxy` | `helianthus_round9_absorb_entered_total` | [frame-atomic-visibility-v8 §1.12 / I8](../architecture/adaptermux/frame-atomic-visibility-v8.md) |
+| `HelianthusV8ShadowWouldHaveDroppedGrowing` | `helianthus_v8_shadow_would_have_dropped_total` | [frame-atomic-visibility-v8 §4.7 — B3.7 shadow divergence](../architecture/adaptermux/frame-atomic-visibility-v8.md) |
 
 ## HelianthusRound9FiredUnderProxy
 
@@ -96,3 +97,87 @@ curl -s "${PROMETHEUS_URL}/api/v1/rules" \
 
 If the rule is absent or fails to load, the proxy MUST NOT be promoted
 to `enforce` mode — the v8 invariant is unobservable without it.
+
+## HelianthusV8ShadowWouldHaveDroppedGrowing
+
+**Owner:** operations team. The rule MUST be present in the Prometheus
+config before the adaptermux classifier is promoted from `shadow` to
+`enforce`. This is the **pre-enforce canary signal** for v8 classifier
+correctness.
+
+**Counter source:** `helianthus_v8_shadow_would_have_dropped_total`
+— exported by
+`helianthus-ebusgateway/internal/adaptermux/v8classifier.Classifier.ShadowWouldHaveDroppedTotal()`.
+The counter mirrors `fsmDropAaInjectionTotal` ONLY when the runtime
+mode is `shadow`; it stays at 0 in `off` and `enforce`. Each
+increment is a byte the v8 classifier would have filtered from
+session dispatch if it had been the canonical filter — i.e. a
+divergence vs the legacy pre-v8 path (which let the byte through).
+
+**Why this alert exists:** during the shadow canary window before
+promoting from `shadow` to `enforce`, operators need a clean
+no-divergence baseline. The counter staying at 0 (or growing only
+during known AA-injection events that operators expect to be
+filtered) is the green-light for `enforce` promotion. The counter
+growing under normal load means the classifier is flagging
+legitimate bytes — a false positive that would change the byte
+stream the cross-proxy client (ebusd) sees once enforce is on.
+Investigate before promoting.
+
+**Suggested rule:**
+
+```yaml
+groups:
+  - name: helianthus.v8
+    rules:
+      - alert: HelianthusV8ShadowWouldHaveDroppedGrowing
+        expr: |
+          rate(helianthus_v8_shadow_would_have_dropped_total[5m]) > 0
+          and on(instance) helianthus_adaptermux_classifier_mode{mode="shadow"} == 1
+        for: 5m
+        labels:
+          severity: info
+          component: helianthus-gateway
+          invariant: frame-atomic-v8-B3.7
+        annotations:
+          summary: "v8 classifier flagged bytes for drop during shadow canary"
+          description: |
+            On instance {{ $labels.instance }} the v8 classifier
+            is in `shadow` mode and the
+            `helianthus_v8_shadow_would_have_dropped_total` counter
+            is growing — the classifier is observing bytes it
+            would have filtered if promoted to `enforce`. Under
+            sustained, expected AA-injection load this is normal;
+            under unexpected growth (no known AA-injection events
+            in the bus capture) the classifier may be false-
+            positive flagging legitimate bytes. DO NOT promote to
+            `enforce` until the growth is explained.
+          runbook_url: |
+            https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/adaptermux/frame-atomic-visibility-v8.md#47
+```
+
+**Severity rationale (info, not warning):** non-zero growth in shadow
+mode is not itself a fault — it's the signal the operator is
+specifically looking for during canary validation. Promote to
+`warning` (or `critical`) by editing the rule once the operator's
+shadow validation runbook is complete and they want failure on
+any unexpected growth.
+
+**Pre-promotion gate (Step C live-validation, v8 §14):**
+
+```bash
+# 1. Check the rule is loaded.
+curl -s "${PROMETHEUS_URL}/api/v1/rules" \
+  | jq '.data.groups[].rules[] | select(.name == "HelianthusV8ShadowWouldHaveDroppedGrowing")'
+
+# 2. Check the rule was loaded WITHOUT errors.
+curl -s "${PROMETHEUS_URL}/api/v1/rules" \
+  | jq '.data.groups[].rules[] | select(.name == "HelianthusV8ShadowWouldHaveDroppedGrowing") | .lastError // empty'
+
+# 3. Query the actual counter value at the time of the
+#    promotion decision (must be 0 OR explainable by known
+#    AA-injection events).
+curl -s -G "${PROMETHEUS_URL}/api/v1/query" \
+  --data-urlencode 'query=helianthus_v8_shadow_would_have_dropped_total' \
+  | jq '.data.result[] | { instance: .metric.instance, value: .value[1] }'
+```


### PR DESCRIPTION
## Summary

Companion PR to [helianthus-ebusgateway B3.7 — shadow divergence accessor](https://github.com/Project-Helianthus/helianthus-ebusgateway/pulls). Adds the matching Prometheus alert rule + pre-promotion gate procedure.

## What's added

`deployment/prometheus-alerts.md`:

1. **Index entry** for `HelianthusV8ShadowWouldHaveDroppedGrowing`.
2. **Full rule definition** with PromQL gating on `helianthus_adaptermux_classifier_mode{mode="shadow"} == 1`.
3. **Severity rationale**: `info` (not warning). Non-zero growth in shadow IS the signal operators are looking for — it's a measurement, not a fault. Operators upgrade severity once their shadow validation runbook is complete.
4. **Pre-promotion gate procedure** (v8 §14 Step C live-validation): three `curl + jq` snippets that check rule presence, load errors, and the actual counter value before promoting the classifier to enforce.

## Counter source

`helianthus_v8_shadow_would_have_dropped_total` — exported by the new
`Classifier.ShadowWouldHaveDroppedTotal()` accessor in the gateway PR.

## Pair with HelianthusRound9FiredUnderProxy

The two alerts cover opposite ends of the rollout:

| Alert | Fires under | Means |
|---|---|---|
| `HelianthusRound9FiredUnderProxy` | `enforce` | Legacy round-9 absorb fired — the proxy is not filtering correctly. v8 invariant violation. |
| `HelianthusV8ShadowWouldHaveDroppedGrowing` | `shadow` | The classifier would drop bytes if promoted — operator must validate this is intentional before promoting. |

Together they form the full v8 rollout safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)