### PR TITLE
Define empty FM5 plane semantics

### DIFF
--- a/architecture/b524-semantic-mapping.md
+++ b/architecture/b524-semantic-mapping.md
@@ -156,7 +156,11 @@ Semantics:
 
 ## `ebus.v1.semantic.solar.get`
 
-Not implemented. Gated by `fm5_config<=2`. Source registers would come from GG=0x04 (solar circuit).
+Gated by `fm5_config<=2`. Source registers come from GG=0x04 (solar circuit).
+When FM5 evidence exists but the runtime cannot safely interpret FM5-backed
+solar semantics, the MCP plane remains non-null and returns an empty typed
+object. Consumers must treat that as known absent/non-interpreted, not as a
+zero-valued solar measurement.
 
 ## `ebus.v1.semantic.cylinders.get`
 
@@ -166,6 +170,9 @@ Publication gate:
 - Entire family is gated by `fm5_config<=2`.
 - Individual instances are published only when `GG=0x05 RR=0x0004` (`cylinder_temperature`) is live and decodable for that instance.
 - Config-only responses from `GG=0x05 RR=0x0001..0x0003` do not imply a real cylinder and must not create `cylinders[]` entries.
+- When FM5 is absent or GPIO-only, the MCP plane remains non-null and returns
+  `[]`. Consumers must treat this as known absent/non-interpreted rather than
+  unknown data.
 
 | Semantic Path | B524 | Type |
 |---------------|------|------|

--- a/architecture/semantic-structure-fsm-map.md
+++ b/architecture/semantic-structure-fsm-map.md
@@ -91,8 +91,8 @@ These suppress or delay evidence collection without being structural decisions b
 | `circuits` | `GG=0x02 RR=0x0002` | Circuit discovery + managing-device evaluation | Startup semantic FSM | Yes | Omitted when no active circuit evidence exists |
 | `radioDevices` | `GG=0x09/0x0A/0x0C` slot evidence | Radio inventory evaluation | Startup semantic FSM | Yes | Omitted when slot evidence is absent or withheld |
 | `fm5SemanticMode` | System + radio + solar/cylinder evidence | FM5 semantic evaluation | Startup semantic FSM | Yes | Downgraded/cleared when evidence falls below gate |
-| `solar` | FM5 + `GG=0x04` | Solar family gate | Startup semantic FSM | Yes | Cleared when FM5 is not interpreted |
-| `cylinders` | FM5 + `GG=0x05` + per-instance temperature evidence | Cylinder family gate + individual cylinder gate | Startup semantic FSM | Yes | Family cleared when FM5 not interpreted; instance omitted without live evidence |
+| `solar` | FM5 + `GG=0x04` | Solar family gate | Startup semantic FSM | Yes | Published as an empty non-null object when FM5 is absent or GPIO-only; interpreted fields remain null until live evidence exists |
+| `cylinders` | FM5 + `GG=0x05` + per-instance temperature evidence | Cylinder family gate + individual cylinder gate | Startup semantic FSM | Yes | Published as an empty non-null list when FM5 is absent or GPIO-only; individual instances are omitted without live evidence |
 | `dhw` | B524 reads / fallback hydration | No structural FSM in Phase 1 | Startup semantic FSM + DHW freshness FSM | Yes | Can expire after TTL without changing topology |
 | `energyTotals` | Energy broadcast ingestion | No structural FSM in Phase 1 | Published independently of startup readiness | No direct B524 breaker path | Can remain absent or stale independently of structure |
 


### PR DESCRIPTION
## What
Document that non-interpreted FM5 states publish non-null empty solar/cylinders planes: an empty typed solar object or empty `cylinders` list means known absent/GPIO-only, while interpreted fields and cylinder instances still require live evidence.

## Why
Gateway PR Project-Helianthus/helianthus-ebusgateway#663 fixes the M4 startup O1 failure by preserving empty-vs-unknown semantics through MCP. The public docs need to match that contract.

## Validation
- `git diff --check`
- `./scripts/ci_local.sh` progressed through markdown, terminology, private-IP, source-address, and taxonomy checks; local run stops at runtime-state schema because `jv` is not installed on this machine.