### PR TITLE
Record startup L1 direct probe contract

### DIFF
--- a/api/mcp.md
+++ b/api/mcp.md
@@ -357,6 +357,9 @@ Note: This inventory reflects the current known tool surface. The gateway may ex
   - `ebus.v1.semantic.system.get`
   - `ebus.v1.semantic.circuits.get`
   - `ebus.v1.semantic.radio_devices.get`
+    - `data: []` means the startup radio inventory probe completed without
+      publishable radio slots. `data: null` means the plane has not been
+      published yet.
   - `ebus.v1.semantic.fm5_mode.get`
   - `ebus.v1.semantic.solar.get`
   - `ebus.v1.semantic.cylinders.get`

--- a/architecture/semantic-read-circuit-breaker.md
+++ b/architecture/semantic-read-circuit-breaker.md
@@ -10,6 +10,9 @@ Goal: suppress repeated failing reads per semantic register target while still a
 - Circuit scope is per selector key: `b524:<group>:<instance>:<addr>` (hex formatted as `%02x:%02x:%04x`).
 - A breaker decision suppresses only that key; other semantic keys continue polling.
 - The B524 fetch path still performs bounded internal retries (up to 3 attempts, `75ms` backoff) before returning one success/failure outcome to the breaker.
+- Startup L1 priming is intentionally outside this breaker path. Its bounded
+  first-minute probes use direct live reads so a short breaker cooldown from an
+  early miss cannot by itself keep required MCP semantic planes `null`.
 
 ## State Machine
 


### PR DESCRIPTION
## What
Document two follow-up semantics from gateway PR Project-Helianthus/helianthus-ebusgateway#663:

- Startup L1 priming uses bounded direct live reads rather than the semantic read circuit-breaker path.
- `ebus.v1.semantic.radio_devices.get` returns `[]` after a completed empty startup inventory probe; `null` remains not-yet-published.

## Why
The final live fix proved that short breaker cooldowns can consume the first-minute startup proof window, and MCP consumers need nil-vs-empty radio semantics to interpret O1 artifacts correctly.

## Validation
- `git diff --check`
- `./scripts/ci_local.sh` passes markdown, terminology, private-IP, source-address, and taxonomy checks; local run stops at runtime-state schema because `jv` is not installed on this machine.