### PR TITLE
docs: document semantic poll task coalescing

### DIFF
--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -101,6 +101,26 @@ non-null during startup before the heavier schedule read cycle fills detailed
 entries, and FM5-related planes may publish a bounded startup interpretation
 before later system/radio/solar/cylinder reads refine or downgrade the model.
 
+## Steady-State Poll Scheduling
+
+The Vaillant semantic poller uses a single serialized task scheduler for active
+semantic reads. Each recurring task family has a stable scheduler key:
+discovery, config, state, circuits, system, radio devices, energy, schedules,
+and the three boiler-status tiers.
+
+The scheduler MUST coalesce duplicate queued or running tasks with the same key.
+If a new tick arrives while the same task family is pending, the queued task is
+kept once and its priority may be raised. If the same task family is already
+running, the duplicate tick is dropped. This is a load-shaping rule: it prevents
+bus contention or slow responders from creating a backlog of identical B524/B509
+sweeps that later drain as gateway-originated bursts.
+
+Coalescing does not change any eBUS wire format, `bus.Send` behavior,
+adaptermux arbitration, retry classification, or semantic merge semantics. The
+next successful execution of a task family remains authoritative for live values;
+partial results are still merged according to the incremental freshness rules
+below.
+
 ## Incremental Merge and Freshness Semantics
 
 Zone and DHW updates are merged incrementally, not replaced wholesale.

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -105,8 +105,8 @@ before later system/radio/solar/cylinder reads refine or downgrade the model.
 
 The Vaillant semantic poller uses a single serialized task scheduler for active
 semantic reads. Each recurring task family has a stable scheduler key:
-discovery, config, state, circuits, system, radio devices, energy, schedules,
-and the three boiler-status tiers.
+regulator capability, discovery, config, state, circuits, system, radio
+devices, energy, schedules, and the three boiler-status tiers.
 
 The scheduler MUST coalesce duplicate queued or running tasks with the same key.
 If a new tick arrives while the same task family is pending, the queued task is

--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -111,9 +111,10 @@ devices, energy, schedules, and the three boiler-status tiers.
 The scheduler MUST coalesce duplicate queued or running tasks with the same key.
 If a new tick arrives while the same task family is pending, the queued task is
 kept once and its priority may be raised. If the same task family is already
-running, the duplicate tick is dropped. This is a load-shaping rule: it prevents
-bus contention or slow responders from creating a backlog of identical B524/B509
-sweeps that later drain as gateway-originated bursts.
+running, at most one deferred rerun is kept for the next available task slot and
+additional same-key signals merge into that rerun. This is a load-shaping rule:
+it prevents bus contention or slow responders from creating an unbounded backlog
+of identical B524/B509 sweeps while preserving edge-triggered refresh signals.
 
 Coalescing does not change any eBUS wire format, `bus.Send` behavior,
 adaptermux arbitration, retry classification, or semantic merge semantics. The


### PR DESCRIPTION
## Summary
- document steady-state semantic poll task keys and duplicate coalescing
- clarify running same-key signals preserve one deferred rerun instead of unbounded backlog
- clarify this is load shaping only and does not alter bus.Send, adaptermux arbitration, wire format, retry classification, or semantic merge semantics

## Validation
- PATH="/Users/razvan/go/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Library/Apple/bin:/Applications/GPAC.app/Contents/MacOS/:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/usr/local/MacGPG2/bin:/Applications/Wireshark.app/Contents/MacOS:/Applications/VMware Fusion.app/Contents/Public:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/razvan/.codex/tmp/arg0/codex-arg0rN81M0:/Users/razvan/.local/bin:/Users/razvan/.rvm/bin:/Users/razvan/.lmstudio/bin" ./scripts/ci_local.sh

Gateway companion: Project-Helianthus/helianthus-ebusgateway#666
Closes #317