### PR TITLE
Document B524 backfill pacing (#319)

### DIFF
--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -122,6 +122,17 @@ next successful execution of a task family remains authoritative for live values
 partial results are still merged according to the incremental freshness rules
 below.
 
+Broad B524 backfill tasks must also avoid repeating full topology sweeps when a
+stable live inventory already exists. Circuit refresh is the reference pattern:
+startup and periodic rediscovery may scan the full documented circuit instance
+range, but normal steady-state refreshes operate on the known active circuit
+instances until the rediscovery interval expires. This preserves detection of
+new or removed circuits without making every config refresh pay the full
+`GG=0x02` scan cost. The long rediscovery interval starts only after the full
+documented range has produced definitive active/inactive answers; partial scans
+retry on the regular configuration cadence. Critical state and boiler fast-tier
+reads are not delayed by this backfill pacing rule.
+
 ## Incremental Merge and Freshness Semantics
 
 Zone and DHW updates are merged incrementally, not replaced wholesale.


### PR DESCRIPTION
## Summary
- document steady-state B524 backfill pacing for broad circuit scans
- clarify startup/rediscovery full scans vs known-active normal refreshes
- document that partial full scans retry on regular config cadence until all slots answer
- state that this does not alter transport, bus.Send, or arbitration behavior

## Validation
- PATH="$(go env GOPATH)/bin:$PATH" ./scripts/ci_local.sh
- git diff --check

Fixes #319