### PR TITLE
Correct circuit type watch classification docs

### DIFF
--- a/architecture/startup-semantic-fsm.md
+++ b/architecture/startup-semantic-fsm.md
@@ -162,11 +162,11 @@ fresh cached/shadow value instead of issuing a new active `B5 24` request.
   reception/paired state, and remote room telemetry.
 - `config`: user or system configuration such as zone/DHW target temperature,
   operating mode, manual fallback temperature, holiday windows, quick-veto
-  configuration, and room-temperature-zone mapping. Passive direct apply for
-  this class remains `config_opt_in`.
+  configuration, room-temperature-zone mapping, and associated circuit type.
+  Passive direct apply for this class remains `config_opt_in`.
 - `discovery`: structural or identity selectors such as zone names, zone index,
-  associated circuit type, remote device-slot identity, and device-slot
-  topology. These selectors are not `state_default` direct-apply eligible.
+  remote device-slot identity, and device-slot topology. These selectors are
+  not `state_default` direct-apply eligible.
 
 Disconnected functional-module inventory slots are identity-only during
 steady-state detail refresh. If `device_connected=false` but class/firmware or


### PR DESCRIPTION
## What
Correct the B524 watch cadence docs so associated circuit type / circuit_type is listed under config, not discovery.

## Why
Gateway PR #679 review correctly classified circuit_type as configuration because it feeds zone mode/HVAC derivation.

## Validation
- `git diff --check`
- `PATH="$PATH:$(go env GOPATH)/bin" ./scripts/ci_local.sh`

## Links
- Closes #324
- Companion correction for Project-Helianthus/helianthus-ebusgateway#679