### PR TITLE
Document B524 semantic execution cadence split

### DIFF
--- a/api/watch-summary.md
+++ b/api/watch-summary.md
@@ -133,6 +133,24 @@ v1 default profile TTLs:
 Runtime scheduler semantics use descriptor policy, not legacy hard-coded
 `500ms` windows.
 
+Execution loops must also respect the freshness profile. A selector classified
+as `state_slow`, `config`, or `discovery` must not be invoked from the
+one-minute state loop just because the scheduler can cache it; the caller
+cadence is part of the bus traffic contract. For B524-backed semantic reads,
+the steady-state split is:
+
+| Profile | Execution owner |
+| --- | --- |
+| `state_fast` | One-minute semantic state loop, limited to fast-changing live values such as current temperatures, special functions, valve state, and other actuator/runtime state. |
+| `state_slow` | Slower semantic refresh path; never promoted to the one-minute state loop only for convenience. |
+| `config` | Config refresh path. Target temperatures, operation modes, zone mappings, circuit type, holiday/quick-veto configuration, and DHW target/op-mode selectors live here. |
+| `discovery` | Discovery/identity refresh path. Names, structural indexes, and topology evidence live here. |
+
+This rule was made explicit after gateway issue
+Project-Helianthus/helianthus-ebusgateway#680: descriptor classification alone
+was insufficient when the execution loop still called slower selectors at
+state cadence.
+
 Effective shadow-hit limit is:
 
 `min(caller maxAge, descriptor EffectiveFreshnessTTL())`

--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -223,9 +223,18 @@ contention. FIFO ordering applies after that protocol ordering.
 - coalesces “same tick” requests into one bus request,
 - publishes the resulting value to all waiting callers/subscribers, and
 - enforces default polling cadences by semantic class:
-  - `state`: 1 minute
+  - `state_fast`: 1 minute
+  - `state_slow`: slower semantic refresh path, not the 1-minute loop
   - `config`: 5 minutes
   - `discovery`: 10 minutes
+
+Descriptor classification and execution cadence are both normative. A B524
+selector classified as `config`, `discovery`, or `state_slow` must not be
+called from the 1-minute state loop simply because scheduler caching exists.
+Gateway issue Project-Helianthus/helianthus-ebusgateway#680 closed the
+regression where zone/DHW target, operation-mode, humidity, mapping, and
+holiday/quick-veto selectors were classified correctly but still invoked at
+state cadence.
 
 For write confirmation (when a write API exists), perform targeted confirm reads:
 - start at 5 seconds after the write,
@@ -294,7 +303,7 @@ without pretending there is a protocol join handshake.
 
 **Consequences:** Collision state becomes deterministic and observable, upper layers can immediately stop unsafe writes, and initiator source transitions remain stable under delayed bus echoes.
 
-## ADR-020: Read scheduler coalescing with state/config refresh windows
+## ADR-020: Read scheduler coalescing with freshness-profile refresh windows
 
 **Status:** Accepted
 
@@ -304,10 +313,16 @@ without pretending there is a protocol join handshake.
 
 - Coalesce read-only invocations by deterministic key: `(plane, method, params)`.
 - If the same key is already in-flight, subsequent callers wait for the same result instead of issuing another bus read.
-- Cache successful responses per key and apply policy windows:
-  - **state** refresh window defaults to `1m`,
-  - **config** refresh window defaults to `5m`.
-- Policy is tunable in router options (`state`/`config` intervals), and invocation class can be overridden per call via params (`cache_class` / `refresh_class`).
+- Cache successful responses per key and apply freshness-profile policy
+  windows:
+  - **state_fast** refresh window defaults to `1m`,
+  - **state_slow** refresh window is longer than the one-minute state loop,
+  - **config** refresh window defaults to `5m`,
+  - **discovery** refresh window is for topology/identity evidence.
+- Policy is tunable in router options by freshness profile
+  (`state_fast`/`state_slow`/`config`/`discovery` intervals), and invocation
+  class can be overridden per call via params (`cache_class` /
+  `refresh_class`).
 - Write methods (`ReadOnly=false`) bypass cache/coalescing and always go to bus.
 - Cached representation stores raw decoded response frame copy, and each caller re-decodes from that frame to avoid shared mutable decoded state.
 


### PR DESCRIPTION
## Summary
- Document that B524 descriptor freshness and execution cadence are both normative.
- State that config/discovery/state_slow selectors must not be invoked from the one-minute state loop.
- Tie the docs gate to gateway issue Project-Helianthus/helianthus-ebusgateway#680.

## Validation
- env PATH=/tmp/helianthus-docs-bin:$PATH make ci-local
- git diff --check

Fixes #326
Companion: Project-Helianthus/helianthus-ebusgateway#681