### PR TITLE
Document radio sensor zone-state fallback

### DIFF
--- a/architecture/b524-structural-decisions.md
+++ b/architecture/b524-structural-decisions.md
@@ -135,7 +135,7 @@ Current implementation note: the gateway still uses `findDeviceAddressByPrefix("
 | Constraint strength | `CORROBORATING` |
 | Scope of validity | `PROTOCOL` |
 | Evaluation rule | `refreshState()` reads the raw value; `publishZones()` exposes the decoded integer via `decodeRoomTemperatureZoneMapping()` |
-| Fallback / unknown behavior | Missing or undecodable values are published as absent rather than synthesized |
+| Fallback / unknown behavior | Missing or undecodable mapping values are published as absent rather than synthesized. When the mapping is known and direct zone room-state values are absent, the gateway may project room temperature/humidity from the already refreshed radio-device snapshot: `1 -> GG=0x09 regulator sensor`, `>=2 -> GG=0x0A thermostat instance mapping - 1`. Direct zone-state register values remain authoritative. |
 | Published effect | Consumers receive explicit zone-to-room-sensor mapping data instead of guessing |
 | Evidence status | `PROVEN` |
 | Code anchors | `refreshState()`, `decodeRoomTemperatureZoneMapping()`, `publishZones()` |

--- a/architecture/semantic-configuration-gates.md
+++ b/architecture/semantic-configuration-gates.md
@@ -79,6 +79,14 @@ This page does not restate the root-discovery or identity-enrichment rationale. 
 - Primary evidence: `GG=0x03 RR=0x0013`
 - Structural effect: publishes `roomTemperatureZoneMapping`
 - Cross-check path: remote-side `zone_assignment` from `GG=0x09/0x0A RR=0x0025`
+- Projection fallback: when direct zone room-state registers are absent, the
+  gateway may fill `zones[].state.currentTempC` and
+  `zones[].state.currentHumidityPct` from the mapped radio-device snapshot:
+  mapping `1` uses the regulator sensor (`GG=0x09`), while mapping values
+  `>=2` use thermostat instance `mapping - 1` (`GG=0x0A`). Direct zone-state
+  register values remain authoritative when present.
+- Traffic rule: this fallback consumes already refreshed radio-device semantic
+  data; it must not introduce extra active B524 polling from zone publication.
 
 ### Zone-to-circuit derivation gate
 


### PR DESCRIPTION
## Summary
- Document the zone room-state projection fallback from mapped radio-device snapshots.
- State direct zone room-state registers remain authoritative.
- State the mapping rule: 1 -> regulator sensor; >=2 -> thermostat instance mapping-1.
- State this fallback consumes existing semantic data and must not add active B524 polling.

## Validation
- env PATH=/tmp/helianthus-docs-bin:$PATH make ci-local
- git diff --check

Fixes #328
Companion: Project-Helianthus/helianthus-ebusgateway#683