### PR TITLE
Document B524 II=0x09 DHW pseudo-circuit discovery

### DIFF
--- a/architecture/b524-structural-decisions.md
+++ b/architecture/b524-structural-decisions.md
@@ -181,16 +181,16 @@ Current implementation note: the gateway still uses `findDeviceAddressByPrefix("
 | Field | Value |
 | --- | --- |
 | Semantic effect | Determines which heating circuit instances exist and whether they are active or inactive |
-| Source registers | `GG=0x02 RR=0x0002` (`circuit_type`) |
+| Source registers | `GG=0x02 RR=0x0002` (`circuit_type`), with `II=0x09` DHW pseudo-circuit corroboration from `RR=0x0008` (`current_circuit_flow_temperature`) or `RR=0x0020` (`calculated_flow_temperature`) |
 | Reference | [`ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance`](../protocols/vaillant/ebus-vaillant-B524-register-map.md#gg0x02--heating-circuits-multi-instance), [`ebus-vaillant-B524-register-map.md#mctype--circuit-type`](../protocols/vaillant/ebus-vaillant-B524-register-map.md#mctype--circuit-type) |
 | Source document title | `Vaillant sensoCOMFORT (VRC 720) -- Training Document`; `Vaillant multiMATIC VRC 700/4f, VRC 700/5 - Control por compensacion climatica` |
 | Source section | `6.2.2 Settings in the Installation Wizard`; `Distribucion de zonas y circuitos de calefaccion` |
 | Supporting statement | In `6.2.2 Settings in the Installation Wizard`, the VRC 720 training documents "Enter the number of heating circuits" as `0-3` with VR 71 and up to `0-9` with VR 71 plus VR 70 expansion. In `Distribucion de zonas y circuitos de calefaccion`, the multiMATIC training states "Hasta 9 circuitos de calefaccion de mezcla y 9 zonas". This constrains expected circuit cardinality, while the gateway still relies on direct `circuit_type` probes for actual publication. |
 | Constraint strength | `CONSTRAINING` |
 | Scope of validity | `PROTOCOL` |
-| Evaluation rule | `refreshCircuits()` probes instances `0x00..0x0A`; readable `0x0000`, `0x00FF`, and `0xFFFF` are treated as inactive, any other value creates/keeps an active circuit snapshot |
-| Fallback / unknown behavior | No synthetic circuit count is invented if type reads never succeed. Helianthus intentionally does **not** derive primary circuit inventory from functional-module topology or hydraulic-scheme inference, because B524 is treated as the authoritative aggregation surface for this structure. The inactive markers `0x00FF` and `0xFFFF` align with common invalid/uninitialized conventions, while `0x0000` is treated as inactive based on current lab observation rather than protocol specification. |
-| Published effect | `circuits[]` contains only active discovered instances |
+| Evaluation rule | `refreshCircuits()` probes instances `0x00..0x0A`; readable `0x00FF` and `0xFFFF` are treated as inactive, any non-zero/non-invalid value creates/keeps an active circuit snapshot. Readable `0x0000` is inactive except for `II=0x09`, which is promoted to active DHW (`mctype=3`) only when plausible live temperature evidence exists at `RR=0x0008` or `RR=0x0020`. |
+| Fallback / unknown behavior | No synthetic circuit count is invented if type reads never succeed. Helianthus intentionally does **not** derive primary circuit inventory from functional-module topology or hydraulic-scheme inference, because B524 is treated as the authoritative aggregation surface for this structure. The inactive markers `0x00FF` and `0xFFFF` align with common invalid/uninitialized conventions, while ordinary `0x0000` circuit instances are treated as inactive based on current lab observation rather than protocol specification. The `II=0x09` exception is evidence-gated so empty inactive slots are not published. |
+| Published effect | `circuits[]` contains active discovered instances, including the `II=0x09` DHW pseudo-circuit when live evidence exists |
 | Evidence status | `PROVEN` |
 | Code anchors | `refreshCircuits()`, `mergeCircuitSnapshotNonDestructive()`, `publishCircuits()` |
 

--- a/protocols/vaillant/ebus-vaillant-B524-register-map.md
+++ b/protocols/vaillant/ebus-vaillant-B524-register-map.md
@@ -389,7 +389,24 @@ Current canon status:
 
 ## GG=0x02 — Heating Circuits (multi-instance)
 
-All registers use opcode `0x02`. Instances 0x00-0x0A; active circuits discovered by probing `heating_circuit_type` (RR=0x0002) — value `0` (`mctype=inactive`) indicates unused circuit slot. Absent instances (beyond the highest configured slot) return empty/null response (no valid payload from bus). Verified via scan: II=0,1 return mctype=1 (heating), II=2-9 return mctype=0 (inactive), II=10 returns null (absent).
+All registers use opcode `0x02`. Instances 0x00-0x0A; active heating
+circuits are normally discovered by probing `heating_circuit_type`
+(RR=0x0002). Value `0` (`mctype=inactive`) indicates an unused circuit slot
+for ordinary heating-circuit instances, while absent instances beyond the
+highest configured slot return empty/null response (no valid payload from bus).
+
+Observed exception: instance `II=0x09` can represent a DHW/additional-cylinder
+pseudo-circuit even when `heating_circuit_type` reports `0`. Treat this slot as
+active DHW (`mctype=3`) only when it has plausible live temperature evidence
+from `current_circuit_flow_temperature` (RR=0x0008) or
+`calculated_flow_temperature` (RR=0x0020). This preserves inactive handling for
+all other `mctype=0` circuit slots. Community evidence:
+[`helianthus-vrc-explorer#53`](https://github.com/Project-Helianthus/helianthus-vrc-explorer/discussions/53).
+
+Older scan baseline: II=0,1 return mctype=1 (heating), II=2-9 return mctype=0
+(inactive), II=10 returns null (absent). That baseline does not disprove the
+`II=0x09` pseudo-circuit because its discriminator is temperature evidence, not
+the type selector alone.
 
 | RR | Name | Cat | Wire | Decode | ebusd | Constraint | Values | Gates | Notes |
 |----|------|-----|------|--------|-------|------------|--------|-------|-------|
@@ -874,7 +891,7 @@ Used by: GG=0x02 RR=0x0002
 | 0 | inactive | inactive | Inactive | Circuit unused |
 | 1 | mixer | heating | Heating | Weather-compensated heating. Mixing or direct depending on basic system diagram. |
 | 2 | fixed | fixed_value | Fixed value | Circuit held at a fixed target flow temperature. Applications: swimming pool heating, door air curtain heating. |
-| 3 | hwc | dhw | DHW | Heating circuit used as DHW circuit for an additional cylinder. |
+| 3 | hwc | dhw | DHW | Heating circuit used as DHW circuit for an additional cylinder. Instance `II=0x09` may need to be inferred as this role from live temperature evidence when RR=0x0002 reports inactive. |
 | 4 | returnincr | return_increase | Increase in return | Return temperature raise circuit. Target return temperature at RR=0x0004 (factory setting 30°C). |
 
 **Naming note:** ebusd templates label value 1 as "mixer" — this is a community naming convention; the Vaillant VRC720 operating & installation manual calls it "Heating" (Heizen). The mixing valve is an implementation detail of the hydraulic system, not the circuit type itself.


### PR DESCRIPTION
## What
Documents the B524 `GG=0x02 II=0x09` DHW/additional-cylinder pseudo-circuit exception and updates the structural decision rule.

## Why
Community VRC Explorer evidence shows `II=0x09` can carry live DHW circuit temperatures even when `RR=0x0002` reports inactive. The docs now describe the evidence-gated promotion rule and preserve ordinary inactive-slot handling.

## Verification
- `git diff --check`

Closes #330.
