### PR TITLE
docs(proxy): clarify FIFO proxy arbitration fairness

### DIFF
--- a/architecture/decisions.md
+++ b/architecture/decisions.md
@@ -100,6 +100,11 @@ contention. FIFO ordering applies after that protocol ordering.
 
 **Consequences:** Concurrent callers are serialized according to bus arbitration rules without each caller knowing about priorities.
 
+**Proxy note:** This ADR describes physical eBUS arbitration rank. A proxy that
+emulates bus access among northbound clients MUST NOT use lower initiator
+addresses as client-session priority. It grants proxy turns by FIFO/fair queue;
+the selected client's frame then participates in physical bus arbitration.
+
 ## ADR-009: Sentinel errors with classification helpers
 
 **Status:** Accepted

--- a/architecture/enh-ens-conformance-tests.md
+++ b/architecture/enh-ens-conformance-tests.md
@@ -102,9 +102,16 @@ XR rows below reference these symbols explicitly. Implementations MAY expose the
 
 ### XR_Arbitration_Fairness_NoStarvation
 
-**Invariant:** Under contention (multiple pending bus requests), no single request is starved indefinitely. A fairness mechanism (e.g., priority queue, round-robin, or bounded retry) ensures all requests eventually get bus access.
+**Invariant:** Under proxy-mediated contention (multiple pending northbound bus
+requests), no single request is starved indefinitely. Proxy arbitration is fair
+across sessions and transports, including clients that use different initiator
+addresses; lower initiator address is physical bus priority, not proxy-session
+priority.
 
-**Falsifiable:** Queue 10 requests with equal priority. Mock adapter grants STARTED to each in turn. All 10 must complete within `10 x single_request_timeout`.
+**Falsifiable:** Queue requests from at least two sessions with different
+initiator addresses and from both TCP and UDP northbound paths. Mock adapter
+grants `STARTED` to each in proxy FIFO order. All requests must complete without
+a lower-address client bypassing an older higher-address contender.
 
 ## UDP-PLAIN
 

--- a/development/smoke-matrix.md
+++ b/development/smoke-matrix.md
@@ -199,9 +199,9 @@ merges, a required adjunct proof subset is evaluated in addition to `T01..T88`:
 - `PX02`: stale `STARTED` absorb expiry with bounded fail path
 - `PX03`: `SYN` while waiting for command `ACK` reopens arbitration immediately
 - `PX04`: `SYN` while waiting for target response reopens arbitration immediately
-- `PX05`: lower initiator wins same-boundary competition
-- `PX06`: lower initiator arriving before next round closes beats queued higher
-- `PX07`: requeue-after-timeout by former owner still wins over higher
+- `PX05`: same-boundary competition is resolved by FIFO registration order, not initiator priority
+- `PX06`: queued higher initiator keeps its FIFO turn when a lower initiator arrives before the next round closes
+- `PX07`: requeue-after-timeout receives a new FIFO position and cannot steal priority from an older contender
 - `PX08`: equal-initiator FIFO ordering is preserved
 - `PX09`: local target sees request only from echoed `RECEIVED`, never `SEND`
 - `PX10`: local emulated target response inside responder window remains coherent


### PR DESCRIPTION
## What
Clarifies that proxy-mediated arbitration is FIFO/fair across northbound clients and transports, even when clients use different eBUS initiator addresses.

## Why
The physical bus still has eBUS initiator priority, but the proxy must not use lower initiator address as client-session priority. This aligns the docs gate with the current proxy fairness direction.

## Changes
- Add a proxy note to ADR-008 distinguishing physical eBUS arbitration from proxy session scheduling.
- Strengthen XR_Arbitration_Fairness_NoStarvation to cover different initiator addresses and TCP/UDP northbound paths.
- Update PX05..PX07 wording from lower-initiator priority to FIFO/fair queue semantics.

## Validation
- `PATH="$(go env GOPATH)/bin:$PATH" ./scripts/ci_local.sh`