### PR TITLE
feat(platform): activate publication contract v2

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -196,7 +196,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       contents: read
-    uses: Project-Helianthus/helianthus-docs-ebus/.github/workflows/platform-contracts-combined-ref.yml@153191f72b5b9ecacbadcf2f3d7e480c6fef89a4
+    uses: Project-Helianthus/helianthus-docs-ebus/.github/workflows/platform-contracts-combined-ref.yml@41a04eabdeefa2fdfe34ea36dfdcc80d8624b849
     with:
       docs_ebus_repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       docs_ebus_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -196,7 +196,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       contents: read
-    uses: Project-Helianthus/helianthus-docs-ebus/.github/workflows/platform-contracts-combined-ref.yml@41a04eabdeefa2fdfe34ea36dfdcc80d8624b849
+    uses: Project-Helianthus/helianthus-docs-ebus/.github/workflows/platform-contracts-combined-ref.yml@b245469c30752f06a49bb567b9a4680431774d0d
     with:
       docs_ebus_repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       docs_ebus_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -24,6 +24,12 @@ Current platform contracts:
 - [`eebus-ha-network-proof.md`](./eebus-ha-network-proof.md)
 - [`eebus-interop-smoke.md`](./eebus-interop-smoke.md)
 
+The publication-contract v2 canonical collection is the exact foundational
+inventory of `cross-runtime-envelope.md`, `hash-auth-binding.md`,
+`shared-registry-boundary.md`, `promotion-and-consumer-contract.md`, and
+`ownership-validation.md`. The remaining pages are milestone-specific
+operational contracts and are not silently added to that collection.
+
 The authoritative eeBUS ownership state is the versioned
 [`manifests/eebus-doc-ownership.yaml`](./manifests/eebus-doc-ownership.yaml)
 manifest.

--- a/docs/platform/manifests/eebus-doc-ownership.yaml
+++ b/docs/platform/manifests/eebus-doc-ownership.yaml
@@ -1,5 +1,39 @@
 schema: helianthus.platform.doc-ownership
-version: 1
+version: 2
+channel_registry:
+  canonical:
+    visibility: stable
+    owner: canonical_documentation_owner
+eligible_channels:
+  cross-runtime-platform-contracts:
+    - canonical
+  eebus-api-v1:
+    - canonical
+  eebus-architecture:
+    - canonical
+  eebus-protocol:
+    - canonical
+  platform-cross-runtime-envelope:
+    - canonical
+  platform-hash-auth-binding:
+    - canonical
+  platform-ownership-validation:
+    - canonical
+  platform-promotion-consumer-contract:
+    - canonical
+  platform-shared-registry-boundary:
+    - canonical
+exact_memberships:
+  canonical:
+    - cross-runtime-platform-contracts
+    - eebus-api-v1
+    - eebus-architecture
+    - eebus-protocol
+    - platform-cross-runtime-envelope
+    - platform-hash-auth-binding
+    - platform-ownership-validation
+    - platform-promotion-consumer-contract
+    - platform-shared-registry-boundary
 entries:
   - id: eebus-protocol
     surface: protocol
@@ -11,13 +45,7 @@ entries:
       path: protocols/ship-spine-overview.md
     canonical: true
     state: active
-    outputs:
-      candidate: false
-      stable_navigation: true
-      search: true
-      sitemap: true
-      versioned_bundle: true
-      release_bundle: true
+    kind: canonical_document
     lifecycle:
       created_at: "2026-07-10T00:00:00Z"
       expires_at: null
@@ -42,13 +70,7 @@ entries:
       path: architecture/README.md
     canonical: true
     state: active
-    outputs:
-      candidate: false
-      stable_navigation: true
-      search: true
-      sitemap: true
-      versioned_bundle: true
-      release_bundle: true
+    kind: canonical_document
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
       expires_at: null
@@ -73,13 +95,7 @@ entries:
       path: api/api-surface-v1.md
     canonical: true
     state: active
-    outputs:
-      candidate: false
-      stable_navigation: true
-      search: true
-      sitemap: true
-      versioned_bundle: true
-      release_bundle: true
+    kind: canonical_document
     lifecycle:
       created_at: "2026-07-10T00:00:00Z"
       expires_at: null
@@ -94,7 +110,7 @@ entries:
       milestone: MSP-DOCS-API-SCHEMA
       required_state: active
 
-  - id: cross-runtime-platform-contracts
+  - id: platform-cross-runtime-envelope
     surface: platform
     owner:
       repository: helianthus-docs-ebus
@@ -104,13 +120,138 @@ entries:
       path: docs/platform/cross-runtime-envelope.md
     canonical: true
     state: active
-    outputs:
-      candidate: false
-      stable_navigation: true
-      search: true
-      sitemap: true
-      versioned_bundle: true
-      release_bundle: true
+    kind: canonical_document
+    lifecycle:
+      created_at: "2026-07-11T00:00:00Z"
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#341
+      source_pr: Project-Helianthus/helianthus-docs-ebus#342
+      source_ref: null
+      content_sha256: null
+      approved_at: "2026-07-11T00:00:00Z"
+      frozen_at: "2026-07-11T00:00:00Z"
+      cleanup_required: false
+    enforcement:
+      milestone: MSP-DOCS-PLATFORM
+      required_state: active
+
+  - id: platform-hash-auth-binding
+    surface: platform
+    owner:
+      repository: helianthus-docs-ebus
+      path: docs/platform/hash-auth-binding.md
+    source:
+      repository: helianthus-docs-ebus
+      path: docs/platform/hash-auth-binding.md
+    canonical: true
+    state: active
+    kind: canonical_document
+    lifecycle:
+      created_at: "2026-07-11T00:00:00Z"
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#341
+      source_pr: Project-Helianthus/helianthus-docs-ebus#342
+      source_ref: null
+      content_sha256: null
+      approved_at: "2026-07-11T00:00:00Z"
+      frozen_at: "2026-07-11T00:00:00Z"
+      cleanup_required: false
+    enforcement:
+      milestone: MSP-DOCS-PLATFORM
+      required_state: active
+
+  - id: platform-shared-registry-boundary
+    surface: platform
+    owner:
+      repository: helianthus-docs-ebus
+      path: docs/platform/shared-registry-boundary.md
+    source:
+      repository: helianthus-docs-ebus
+      path: docs/platform/shared-registry-boundary.md
+    canonical: true
+    state: active
+    kind: canonical_document
+    lifecycle:
+      created_at: "2026-07-11T00:00:00Z"
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#341
+      source_pr: Project-Helianthus/helianthus-docs-ebus#342
+      source_ref: null
+      content_sha256: null
+      approved_at: "2026-07-11T00:00:00Z"
+      frozen_at: "2026-07-11T00:00:00Z"
+      cleanup_required: false
+    enforcement:
+      milestone: MSP-DOCS-PLATFORM
+      required_state: active
+
+  - id: platform-promotion-consumer-contract
+    surface: platform
+    owner:
+      repository: helianthus-docs-ebus
+      path: docs/platform/promotion-and-consumer-contract.md
+    source:
+      repository: helianthus-docs-ebus
+      path: docs/platform/promotion-and-consumer-contract.md
+    canonical: true
+    state: active
+    kind: canonical_document
+    lifecycle:
+      created_at: "2026-07-11T00:00:00Z"
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#341
+      source_pr: Project-Helianthus/helianthus-docs-ebus#342
+      source_ref: null
+      content_sha256: null
+      approved_at: "2026-07-11T00:00:00Z"
+      frozen_at: "2026-07-11T00:00:00Z"
+      cleanup_required: false
+    enforcement:
+      milestone: MSP-DOCS-PLATFORM
+      required_state: active
+
+  - id: platform-ownership-validation
+    surface: platform
+    owner:
+      repository: helianthus-docs-ebus
+      path: docs/platform/ownership-validation.md
+    source:
+      repository: helianthus-docs-ebus
+      path: docs/platform/ownership-validation.md
+    canonical: true
+    state: active
+    kind: canonical_document
+    lifecycle:
+      created_at: "2026-07-11T00:00:00Z"
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#341
+      source_pr: Project-Helianthus/helianthus-docs-ebus#342
+      source_ref: null
+      content_sha256: null
+      approved_at: "2026-07-11T00:00:00Z"
+      frozen_at: "2026-07-11T00:00:00Z"
+      cleanup_required: false
+    enforcement:
+      milestone: MSP-DOCS-PLATFORM
+      required_state: active
+
+  - id: cross-runtime-platform-contracts
+    surface: platform
+    owner:
+      repository: helianthus-docs-ebus
+      path: docs/platform/README.md
+    source:
+      repository: helianthus-docs-ebus
+      path: docs/platform/README.md
+    canonical: true
+    state: active
+    kind: canonical_collection
+    members:
+      - platform-cross-runtime-envelope
+      - platform-hash-auth-binding
+      - platform-ownership-validation
+      - platform-promotion-consumer-contract
+      - platform-shared-registry-boundary
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
       expires_at: null
@@ -135,13 +276,11 @@ entries:
       path: docs
     canonical: false
     state: planned
-    outputs:
-      candidate: false
-      stable_navigation: false
-      search: false
-      sitemap: false
-      versioned_bundle: false
-      release_bundle: false
+    kind: absence_constraint
+    forbidden_states:
+      - candidate
+    channels:
+      - canonical
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
       expires_at: "2026-07-25T00:00:00Z"
@@ -166,13 +305,8 @@ entries:
       path: README.md
     canonical: false
     state: planned
-    outputs:
-      candidate: false
-      stable_navigation: false
-      search: false
-      sitemap: false
-      versioned_bundle: false
-      release_bundle: false
+    kind: summary_pointer
+    target: eebus-architecture
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
       expires_at: "2026-07-25T00:00:00Z"

--- a/docs/platform/ownership-validation.md
+++ b/docs/platform/ownership-validation.md
@@ -227,7 +227,8 @@ The canonical JSON token binds `producer_id`, `consumer_id`, `repository`, `pr`,
 `prior_token_digest`, and `observation_source`. Its evidence core also records
 manifest blob identities, registered channels, eligibility, exact memberships,
 collection members, candidate inventory, and local publisher blob identities.
-Re-running the command with the same immutable objects produces identical bytes.
+Re-running the command with the same immutable objects and the same explicit
+evaluation instant and observation source produces identical bytes.
 
 ## Main Expiry Validation
 

--- a/docs/platform/ownership-validation.md
+++ b/docs/platform/ownership-validation.md
@@ -5,12 +5,15 @@ Canonical source: this page.
 ## Manifest
 
 `manifests/eebus-doc-ownership.yaml` is the authoritative versioned ownership
-manifest. Its schema is closed. Each of the six surfaces has exactly one entry,
-every owner/source pair is globally unique, and a canonical owner path may occur
-only once. All repository paths are portable relative paths with no traversal,
-private path, private identifier, credential, or network data. Every path
-segment also excludes Windows-reserved characters, trailing dots or spaces, and
-reserved device names (including reserved names followed by an extension).
+manifest. Version 2 is the current publication contract; version 1 remains a
+trusted-prior input during migration. The schema is closed. All six surfaces
+must be represented, while the platform surface may contain multiple canonical
+documents plus explicit canonical collections. Every owner/source pair is
+globally unique, and a canonical owner path may occur only once. All repository
+paths are portable relative paths with no traversal, private path, private
+identifier, credential, or network data. Every path segment also excludes
+Windows-reserved characters, trailing dots or spaces, and reserved device names
+(including reserved names followed by an extension).
 
 The loader retains YAML mapping pairs until duplicate-key validation is
 complete. It rejects duplicate keys at any depth, cyclic aliases, more than 16
@@ -37,6 +40,16 @@ code-repository, and summary-only entries are noncanonical. In particular,
 protocol ownership cannot be reassigned to the code README or marked
 noncanonical while active.
 
+Version 2 separates eligibility from publication. `channel_registry` is the
+closed inventory of controlled publication channels, `eligible_channels`
+declares where an entry may appear, and `exact_memberships` records the complete
+current membership of every registered channel. An active canonical document
+or collection must be present in each declared membership. Candidate entries
+cannot appear in a stable membership. Collections contain only active canonical
+documents; summary pointers target an active canonical document or collection
+without acquiring canonical membership themselves. An absence constraint
+covers all and only the registered channels.
+
 Platform governance prose may require an artifact to record or report evidence,
 including whether protocol activity was observed. That exemption is local to
 the reporting predicate and its single bounded observation complement. The
@@ -49,12 +62,12 @@ coordinated protocol, architecture, or API behavior cannot inherit an exemption.
 
 ## State Contract
 
-| State | Expiry | Output | Required artifact rule |
+| State | Expiry | Publication | Required artifact rule |
 | --- | --- | --- | --- |
-| `planned` | Exactly 14 days after `created_at` | No candidate or stable output; noncanonical and nonlinkable | Owner/source may be absent or may be pre-existing material that has no publication authority |
-| `candidate` | Exactly 30 days after `created_at` | Candidate output only from a hidden `_candidate` area | Regular owner and source files plus the direct commit object at the pinned source checkout HEAD and exact content hash |
-| `active` | No expiry | All stable outputs after approval and freeze | Regular owner and source files |
-| `withdrawn` | No expiry | No output and never consumer-visible | Owner and every distinct source artifact absent immediately; cleanup mandatory |
+| `planned` | Exactly 14 days after `created_at` | No eligibility or membership; noncanonical and nonlinkable | Owner/source may be absent or may be pre-existing material that has no publication authority |
+| `candidate` | Exactly 30 days after `created_at` | Candidate-channel eligibility only from a hidden `_candidate` area; never in a stable membership | Regular owner and source files plus the direct commit object at the pinned source checkout HEAD and exact content hash |
+| `active` | No expiry | Exact registered-channel membership after approval and freeze | Regular owner and source files |
+| `withdrawn` | No expiry | No eligibility or membership and never consumer-visible | Owner and every distinct source artifact absent immediately; cleanup mandatory |
 
 Every present lifecycle timestamp (`created_at`, `expires_at`, `approved_at`, or
 `frozen_at`) uses the same strict RFC 3339 UTC extended form described below.
@@ -85,7 +98,7 @@ manifest exists, pass it as `--prior-manifest PATH`. Every prior `withdrawn`
 entry remains indexed by both `surface` and `id`, remains the sole entry for that
 surface, and remains `withdrawn`. For the same surface and ID, the complete
 normalized manifest entry is an immutable tombstone: lifecycle and provenance,
-enforcement, owner/source metadata, output flags, and any additional fields must
+enforcement, owner/source metadata, publication fields, and any additional fields must
 all remain byte-for-value equivalent after YAML normalization. A new ID cannot
 resurrect that surface as `planned`, `candidate`, or `active`, and a duplicate
 replacement cannot coexist with the tombstone. Artifact absence remains a
@@ -98,8 +111,9 @@ case.
 The current E2 enforcement state is:
 
 - existing protocol ownership and the API representation schema are `active`;
-- the platform contracts are `active` from `MSP-DOCS-PLATFORM` onward;
-- the architecture ownership landing is `active`, with its stable output
+- the five foundational platform documents and their canonical collection are
+  `active` from `MSP-DOCS-PLATFORM` onward;
+- the architecture ownership landing is `active`, with its canonical membership
   supported at `MSP-DOCS-E2`;
 - current `helianthus-eebusreg/docs` and its README remain `planned` and are not
   failures during E2;
@@ -123,8 +137,8 @@ An E2 or CLEAN check cannot reuse PLATFORM enforcement: each successor invokes
 the same combined-ref validator with its own required stage. Planned entries
 also expire after 14 days, so main expiry CI fails inclusively if a required
 successor transition is not completed. Candidate entries transition only to
-their declared required state or to `withdrawn` cleanup, while candidate output
-remains excluded from every stable channel.
+their declared required state or to `withdrawn` cleanup, while candidate
+membership remains excluded from every stable channel.
 
 ## Combined-Ref Pull Request Validation
 
@@ -190,6 +204,30 @@ GitHub always uses `exact` mode.
 Workflow validation is gated by actionlint `v1.7.7`; runtime-state schema
 validation is gated by `jv v0.7.0`. Both binaries are installed at pinned Go
 module versions and their reported versions are verified before use.
+
+## Post-Merge Completion Token
+
+`scripts/platform_publication_token.py` mints the PLATFORM-B completion token
+only from a clean, nonsymlinked checkout whose `HEAD` is the supplied squash
+merge. The supplied base, PR head, and merge values must be distinct lowercase
+40-hex commit objects. The merge must have the supplied base as its only parent,
+the base must be an ancestor of the PR head, and the merge and PR head trees must
+match exactly. Repository identity is bound to the expected GitHub origin.
+
+The generator reads the prior and current manifests plus every local publisher
+artifact with `git ls-tree` and `git cat-file`. The base manifest must be valid
+version 1 and the merged manifest must be valid version 2. Planned or candidate
+expiry at the supplied strict UTC evaluation instant blocks token creation. The
+evaluation instant cannot precede the immutable merge committer time and carries
+an explicit observation source. No network request or moving ref participates
+in the proof.
+
+The canonical JSON token binds `producer_id`, `consumer_id`, `repository`, `pr`,
+`base_oid`, `head_oid`, `merge_oid`, `tree_oid`, `evidence_core_sha256`,
+`prior_token_digest`, and `observation_source`. Its evidence core also records
+manifest blob identities, registered channels, eligibility, exact memberships,
+collection members, candidate inventory, and local publisher blob identities.
+Re-running the command with the same immutable objects produces identical bytes.
 
 ## Main Expiry Validation
 

--- a/scripts/platform_publication_token.py
+++ b/scripts/platform_publication_token.py
@@ -12,15 +12,15 @@ import re
 import stat
 import subprocess
 import sys
+import urllib.parse
 from datetime import datetime, timezone
 from typing import Any
-
-import yaml
 
 
 EXPECTED_REPOSITORY = "Project-Helianthus/helianthus-docs-ebus"
 PRODUCER_ID = "MSP-DOCS-E2R-PLATFORM"
 CONSUMER_ID = "MSP-DOCS-E2R-PUBLISH"
+ENFORCE_THROUGH = "MSP-DOCS-E2"
 MANIFEST_PATH = "docs/platform/manifests/eebus-doc-ownership.yaml"
 VALIDATOR_PATH = pathlib.Path(__file__).with_name("validate_platform_contracts.py")
 OID = re.compile(r"[0-9a-f]{40}\Z")
@@ -89,7 +89,10 @@ def _load_validator() -> Any:
     if spec is None or spec.loader is None:
         raise TokenError("publication-token.validator")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        raise TokenError("publication-token.validator") from None
     return module
 
 
@@ -118,20 +121,17 @@ def _manifest_at(
     root: pathlib.Path, commit: str, expected_version: int, validator: Any
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     mode, blob_oid, raw = _blob_at(root, commit, MANIFEST_PATH)
-    if len(raw) > validator.MAX_MANIFEST_BYTES:
-        raise TokenError("publication-token.manifest")
-    try:
-        text = raw.decode("utf-8")
-        validator._scan_yaml_resources(text)
-        manifest = yaml.safe_load(text)
-    except (UnicodeError, yaml.YAMLError, RecursionError, MemoryError):
-        raise TokenError("publication-token.manifest") from None
+    manifest = validator._parse_manifest_bytes(raw)
     if (
         not isinstance(manifest, dict)
         or manifest.get("version") != expected_version
         or not validator._schema_valid(manifest)
         or validator._manifest_categories(manifest)
         or validator._state_categories(manifest, {})
+        or (
+            expected_version == 2
+            and validator._enforcement_categories(manifest, ENFORCE_THROUGH)
+        )
     ):
         raise TokenError("publication-token.manifest")
     return manifest, {
@@ -183,14 +183,51 @@ def _publisher_blobs(
     return dict(sorted(blobs.items()))
 
 
+def _github_repository(remote: str) -> str | None:
+    scp = re.fullmatch(r"(?:git@)?github\.com:(?P<path>[^?#]+)", remote, re.I)
+    if scp is not None:
+        path = scp.group("path")
+    else:
+        try:
+            parsed = urllib.parse.urlsplit(remote)
+            port = parsed.port
+        except ValueError:
+            return None
+        scheme = parsed.scheme.casefold()
+        if (
+            scheme not in {"https", "ssh", "git"}
+            or (parsed.hostname or "").casefold() != "github.com"
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        if scheme == "https" and (parsed.username is not None or port is not None):
+            return None
+        if scheme == "ssh" and (
+            (parsed.username or "git").casefold() != "git" or port not in {None, 22}
+        ):
+            return None
+        if scheme == "git" and (
+            parsed.username is not None or port not in {None, 9418}
+        ):
+            return None
+        path = parsed.path
+
+    normalized = path.strip("/")
+    if normalized.casefold().endswith(".git"):
+        normalized = normalized[:-4]
+    parts = normalized.split("/")
+    if len(parts) != 2 or any(not part for part in parts):
+        return None
+    if any(re.fullmatch(r"[A-Za-z0-9_.-]+", part) is None for part in parts):
+        return None
+    return "/".join(parts).casefold()
+
+
 def _repository_matches(root: pathlib.Path, repository: str) -> bool:
     remote = _git(root, "remote", "get-url", "origin")
-    accepted = {
-        f"https://github.com/{repository}.git",
-        f"git@github.com:{repository}.git",
-        f"ssh://git@github.com/{repository}.git",
-    }
-    return remote in accepted
+    return _github_repository(remote) == repository.casefold()
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -320,6 +357,6 @@ if __name__ == "__main__":
     except TokenError as exc:
         print(exc.category, file=sys.stderr)
         raise SystemExit(1) from None
-    except (OSError, UnicodeError, ValueError, yaml.YAMLError):
+    except (OSError, UnicodeError, ValueError, RecursionError, MemoryError):
         print("publication-token.input", file=sys.stderr)
         raise SystemExit(1) from None

--- a/scripts/platform_publication_token.py
+++ b/scripts/platform_publication_token.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Emit the reproducible PLATFORM-B post-merge completion token."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import pathlib
+import re
+import stat
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import yaml
+
+
+EXPECTED_REPOSITORY = "Project-Helianthus/helianthus-docs-ebus"
+PRODUCER_ID = "MSP-DOCS-E2R-PLATFORM"
+CONSUMER_ID = "MSP-DOCS-E2R-PUBLISH"
+MANIFEST_PATH = "docs/platform/manifests/eebus-doc-ownership.yaml"
+VALIDATOR_PATH = pathlib.Path(__file__).with_name("validate_platform_contracts.py")
+OID = re.compile(r"[0-9a-f]{40}\Z")
+OBSERVATION_SOURCE = re.compile(r"[a-z0-9][a-z0-9._+-]*\Z")
+
+
+class TokenError(Exception):
+    """A fail-closed token diagnostic without input disclosure."""
+
+    def __init__(self, category: str) -> None:
+        super().__init__(category)
+        self.category = category
+
+
+def _git(root: pathlib.Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise TokenError("publication-token.git-object")
+    return result.stdout.strip()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _directory_without_symlinks(path: pathlib.Path) -> bool:
+    absolute = path.absolute()
+    if not absolute.anchor:
+        return False
+    current = pathlib.Path(absolute.anchor)
+    try:
+        root_stat = current.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+        return False
+    for part in absolute.parts[1:]:
+        current = current / part
+        try:
+            item_stat = current.lstat()
+        except OSError:
+            return False
+        if stat.S_ISLNK(item_stat.st_mode) or not stat.S_ISDIR(item_stat.st_mode):
+            return False
+    return True
+
+
+def _load_validator() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "platform_contract_validator_for_token", VALIDATOR_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise TokenError("publication-token.validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _blob_at(root: pathlib.Path, commit: str, path: str) -> tuple[str, str, bytes]:
+    listing = _git(root, "ls-tree", commit, "--", path)
+    if "\n" in listing or "\t" not in listing:
+        raise TokenError("publication-token.git-object")
+    metadata, listed_path = listing.split("\t", 1)
+    fields = metadata.split()
+    if listed_path != path or len(fields) != 3:
+        raise TokenError("publication-token.git-object")
+    mode, object_type, blob_oid = fields
+    if mode not in {"100644", "100755"} or object_type != "blob":
+        raise TokenError("publication-token.git-object")
+    raw = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "blob", blob_oid],
+        check=False,
+        capture_output=True,
+    )
+    if raw.returncode != 0:
+        raise TokenError("publication-token.git-object")
+    return mode, blob_oid, raw.stdout
+
+
+def _manifest_at(
+    root: pathlib.Path, commit: str, expected_version: int, validator: Any
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    mode, blob_oid, raw = _blob_at(root, commit, MANIFEST_PATH)
+    if len(raw) > validator.MAX_MANIFEST_BYTES:
+        raise TokenError("publication-token.manifest")
+    try:
+        text = raw.decode("utf-8")
+        validator._scan_yaml_resources(text)
+        manifest = yaml.safe_load(text)
+    except (UnicodeError, yaml.YAMLError, RecursionError, MemoryError):
+        raise TokenError("publication-token.manifest") from None
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("version") != expected_version
+        or not validator._schema_valid(manifest)
+        or validator._manifest_categories(manifest)
+        or validator._state_categories(manifest, {})
+    ):
+        raise TokenError("publication-token.manifest")
+    return manifest, {
+        "mode": mode,
+        "oid": blob_oid,
+        "sha256": _sha256(raw),
+        "version": expected_version,
+    }
+
+
+def _commit_time(root: pathlib.Path, merge_oid: str) -> datetime:
+    raw = _git(root, "show", "-s", "--format=%cI", merge_oid)
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        raise TokenError("publication-token.commit-time") from None
+    if parsed.tzinfo is None:
+        raise TokenError("publication-token.commit-time")
+    utc = parsed.astimezone(timezone.utc).replace(microsecond=0)
+    return utc
+
+
+def _validate_expiry(manifest: dict[str, Any], evaluated_at: datetime) -> None:
+    for entry in manifest["entries"]:
+        if entry["state"] not in {"planned", "candidate"}:
+            continue
+        expires = datetime.fromisoformat(
+            entry["lifecycle"]["expires_at"].removesuffix("Z") + "+00:00"
+        )
+        if evaluated_at >= expires:
+            raise TokenError(f"publication-token.{entry['state']}-expired")
+
+
+def _publisher_blobs(
+    root: pathlib.Path, merge_oid: str, manifest: dict[str, Any]
+) -> dict[str, dict[str, str]]:
+    blobs: dict[str, dict[str, str]] = {}
+    for entry in manifest["entries"]:
+        owner = entry["owner"]
+        if owner["repository"] != "helianthus-docs-ebus" or entry["state"] != "active":
+            continue
+        mode, blob_oid, raw = _blob_at(root, merge_oid, owner["path"])
+        blobs[entry["id"]] = {
+            "mode": mode,
+            "oid": blob_oid,
+            "path": owner["path"],
+            "sha256": _sha256(raw),
+        }
+    return dict(sorted(blobs.items()))
+
+
+def _repository_matches(root: pathlib.Path, repository: str) -> bool:
+    remote = _git(root, "remote", "get-url", "origin")
+    accepted = {
+        f"https://github.com/{repository}.git",
+        f"git@github.com:{repository}.git",
+        f"ssh://git@github.com/{repository}.git",
+    }
+    return remote in accepted
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=pathlib.Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--base-oid", required=True)
+    parser.add_argument("--head-oid", required=True)
+    parser.add_argument("--merge-oid", required=True)
+    parser.add_argument("--evaluated-at", required=True)
+    parser.add_argument("--observation-source", required=True)
+    return parser
+
+
+def build_token(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root
+    repository = args.repository
+    oids = (args.base_oid, args.head_oid, args.merge_oid)
+    if (
+        repository != EXPECTED_REPOSITORY
+        or args.pr <= 0
+        or len(set(oids)) != 3
+        or any(OID.fullmatch(value) is None for value in oids)
+        or OBSERVATION_SOURCE.fullmatch(args.observation_source) is None
+        or not _directory_without_symlinks(root)
+        or not _repository_matches(root, repository)
+        or _git(root, "status", "--porcelain=v1", "--untracked-files=all")
+        or _git(root, "rev-parse", "HEAD") != args.merge_oid
+    ):
+        raise TokenError("publication-token.identity")
+
+    for oid in oids:
+        if _git(root, "cat-file", "-t", oid) != "commit":
+            raise TokenError("publication-token.git-object")
+    ancestry = _git(root, "rev-list", "--parents", "-n", "1", args.merge_oid).split()
+    if ancestry != [args.merge_oid, args.base_oid]:
+        raise TokenError("publication-token.base-drift")
+    ancestor = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "--is-ancestor", args.base_oid, args.head_oid],
+        check=False,
+        capture_output=True,
+    )
+    if ancestor.returncode != 0:
+        raise TokenError("publication-token.base-drift")
+
+    tree_oid = _git(root, "rev-parse", f"{args.merge_oid}^{{tree}}")
+    head_tree = _git(root, "rev-parse", f"{args.head_oid}^{{tree}}")
+    if tree_oid != head_tree or OID.fullmatch(tree_oid) is None:
+        raise TokenError("publication-token.tree-drift")
+
+    validator = _load_validator()
+    prior_manifest, prior_identity = _manifest_at(root, args.base_oid, 1, validator)
+    manifest, manifest_identity = _manifest_at(root, args.merge_oid, 2, validator)
+    evaluated_at = validator._parse_instant(args.evaluated_at)
+    if evaluated_at is None or evaluated_at < _commit_time(root, args.merge_oid):
+        raise TokenError("publication-token.evaluation-time")
+    _validate_expiry(manifest, evaluated_at)
+
+    base_tree = _git(root, "rev-parse", f"{args.base_oid}^{{tree}}")
+    prior_completion = {
+        "producer_id": "MSP-DOCS-E2R-PLATFORM-A",
+        "consumer_id": "MSP-DOCS-E2R-PLATFORM-B",
+        "merge_oid": args.base_oid,
+        "tree_oid": base_tree,
+    }
+    prior_token_digest = _sha256(_canonical_json(prior_completion))
+    observation_source = args.observation_source
+    collection_members = {
+        entry["id"]: entry["members"]
+        for entry in manifest["entries"]
+        if entry["kind"] == "canonical_collection"
+    }
+    evidence_core = {
+        "base_oid": args.base_oid,
+        "candidate_inventory": sorted(
+            entry["id"] for entry in manifest["entries"] if entry["state"] == "candidate"
+        ),
+        "channel_registry": manifest["channel_registry"],
+        "collection_members": collection_members,
+        "consumer_id": CONSUMER_ID,
+        "eligible_channels": manifest["eligible_channels"],
+        "evaluated_at": args.evaluated_at,
+        "exact_memberships": manifest["exact_memberships"],
+        "head_oid": args.head_oid,
+        "manifest": manifest_identity,
+        "merge_oid": args.merge_oid,
+        "observation_source": observation_source,
+        "prior_manifest": prior_identity,
+        "prior_manifest_entry_count": len(prior_manifest["entries"]),
+        "prior_token_digest": prior_token_digest,
+        "pr": args.pr,
+        "producer_id": PRODUCER_ID,
+        "publisher_blobs": _publisher_blobs(root, args.merge_oid, manifest),
+        "repository": repository,
+        "result": "pass",
+        "tree_oid": tree_oid,
+    }
+    evidence_core_sha256 = _sha256(_canonical_json(evidence_core))
+    return {
+        "base_oid": args.base_oid,
+        "consumer_id": CONSUMER_ID,
+        "evidence_core": evidence_core,
+        "evidence_core_sha256": evidence_core_sha256,
+        "head_oid": args.head_oid,
+        "merge_oid": args.merge_oid,
+        "observation_source": observation_source,
+        "pr": args.pr,
+        "prior_token_digest": prior_token_digest,
+        "producer_id": PRODUCER_ID,
+        "repository": repository,
+        "schema_version": 2,
+        "tree_oid": tree_oid,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    token = build_token(args)
+    sys.stdout.buffer.write(_canonical_json(token) + b"\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except TokenError as exc:
+        print(exc.category, file=sys.stderr)
+        raise SystemExit(1) from None
+    except (OSError, UnicodeError, ValueError, yaml.YAMLError):
+        print("publication-token.input", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/scripts/validate_platform_contracts.py
+++ b/scripts/validate_platform_contracts.py
@@ -621,12 +621,9 @@ def _inspect_yaml_node(root: yaml.nodes.Node | None) -> None:
     visit(root, 1)
 
 
-def _parse_manifest_path(path: pathlib.Path) -> dict[str, Any] | None:
+def _parse_manifest_bytes(raw: bytes) -> dict[str, Any] | None:
     loader: yaml.SafeLoader | None = None
     try:
-        if not _regular_path_without_symlinks(path):
-            raise _ManifestSchemaError
-        raw = path.read_bytes()
         if len(raw) > MAX_MANIFEST_BYTES:
             raise _ManifestSchemaError
         text = raw.decode("utf-8")
@@ -652,6 +649,15 @@ def _parse_manifest_path(path: pathlib.Path) -> dict[str, Any] | None:
     if not isinstance(loaded, dict):
         return None
     return loaded
+
+
+def _parse_manifest_path(path: pathlib.Path) -> dict[str, Any] | None:
+    try:
+        if not _regular_path_without_symlinks(path):
+            raise _ManifestSchemaError
+        return _parse_manifest_bytes(path.read_bytes())
+    except (OSError, _ManifestSchemaError):
+        return None
 
 
 def _load_manifest(root: pathlib.Path) -> tuple[dict[str, Any] | None, str | None]:
@@ -819,6 +825,9 @@ def _schema_valid_v2(manifest: Mapping[str, Any]) -> bool:
             if (
                 channel not in eligible.get(entry_id, [])
                 or entries_by_id[entry_id]["state"] != "active"
+                or entries_by_id[entry_id]["kind"]
+                not in {"canonical_document", "canonical_collection"}
+                or not entries_by_id[entry_id]["canonical"]
             ):
                 return False
 
@@ -839,6 +848,8 @@ def _schema_valid_v2(manifest: Mapping[str, Any]) -> bool:
             target = entries_by_id.get(entry["target"])
             if (
                 entry["canonical"]
+                or eligible.get(entry_id, [])
+                or any(entry_id in members for members in memberships.values())
                 or target is None
                 or target["kind"]
                 not in {"canonical_document", "canonical_collection"}
@@ -849,6 +860,8 @@ def _schema_valid_v2(manifest: Mapping[str, Any]) -> bool:
         elif kind == "absence_constraint":
             if (
                 entry["canonical"]
+                or eligible.get(entry_id, [])
+                or any(entry_id in members for members in memberships.values())
                 or entry["forbidden_states"] != ["candidate"]
                 or entry["channels"] != sorted(channels)
             ):
@@ -1948,14 +1961,21 @@ def _toolchain_categories(mode: str) -> set[str]:
     return categories
 
 
-def _validated_manifest(root: pathlib.Path) -> tuple[dict[str, Any] | None, set[str]]:
+def _validated_manifest(
+    root: pathlib.Path, *, current_manifest_version: int = 2
+) -> tuple[dict[str, Any] | None, set[str]]:
     manifest, error = _load_manifest(root)
     if error is not None:
         return None, {error}
     assert manifest is not None
     if not _schema_valid(manifest):
         return None, {"manifest.schema"}
-    return manifest, _manifest_categories(manifest)
+    manifest_categories = _manifest_categories(manifest)
+    if manifest_categories:
+        return manifest, manifest_categories
+    if manifest["version"] < current_manifest_version:
+        return None, {"manifest.version-floor"}
+    return manifest, set()
 
 
 def _history_categories(
@@ -2011,6 +2031,7 @@ def validate_repository(
     prior_manifest: pathlib.Path | None = None,
     evaluated_at: str | None = None,
     evaluation_source: str | None = None,
+    _current_manifest_version: int = 2,
 ) -> list[str]:
     root = pathlib.Path(docs_ebus_root)
     categories = _toolchain_categories(toolchain_mode)
@@ -2022,7 +2043,9 @@ def validate_repository(
     )
     if not root_valid:
         categories.add("input.repository-root")
-    manifest, manifest_categories = _validated_manifest(root)
+    manifest, manifest_categories = _validated_manifest(
+        root, current_manifest_version=_current_manifest_version
+    )
     categories.update(manifest_categories)
     if manifest is None:
         return _result(categories)
@@ -2053,6 +2076,7 @@ def validate_workspace(
     enforce_through: str,
     toolchain_mode: str,
     prior_manifest: pathlib.Path | None = None,
+    _current_manifest_version: int = 2,
 ) -> list[str]:
     roots = {
         "helianthus-docs-ebus": pathlib.Path(docs_ebus_root),
@@ -2099,7 +2123,10 @@ def validate_workspace(
         resolved.add(resolved_root)
         valid_roots[repository] = root
 
-    manifest, manifest_categories = _validated_manifest(roots["helianthus-docs-ebus"])
+    manifest, manifest_categories = _validated_manifest(
+        roots["helianthus-docs-ebus"],
+        current_manifest_version=_current_manifest_version,
+    )
     categories.update(manifest_categories)
     if manifest is None:
         return _result(categories)

--- a/scripts/validate_platform_contracts.py
+++ b/scripts/validate_platform_contracts.py
@@ -962,7 +962,10 @@ def _manifest_categories(manifest: dict[str, Any]) -> set[str]:
     manifest_surfaces = [entry["surface"] for entry in manifest["entries"]]
     if set(manifest_surfaces) != SURFACES:
         categories.add("ownership.surface-missing")
-    if len(manifest_surfaces) != len(set(manifest_surfaces)):
+    if (
+        set(manifest) == TOP_FIELDS_V1
+        and len(manifest_surfaces) != len(set(manifest_surfaces))
+    ):
         categories.add("ownership.surface-duplicate")
 
     pairs: set[tuple[str, str, str, str]] = set()

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import importlib.util
+import json
 import os
 import pathlib
 import re
@@ -367,11 +368,18 @@ def combined_ref_inputs() -> dict[str, Any]:
     return inputs
 
 
-def assert_stable_outputs(item: dict[str, Any]) -> None:
-    assert item["outputs"] == {
-        "candidate": False,
-        **{name: True for name in E2_STABLE_OUTPUTS},
-    }
+def assert_stable_publication(
+    manifest: dict[str, Any], item: dict[str, Any]
+) -> None:
+    if manifest["version"] == 1:
+        assert item["outputs"] == {
+            "candidate": False,
+            **{name: True for name in E2_STABLE_OUTPUTS},
+        }
+        return
+    assert item["kind"] in {"canonical_document", "canonical_collection"}
+    assert manifest["eligible_channels"][item["id"]] == ["canonical"]
+    assert item["id"] in manifest["exact_memberships"]["canonical"]
 
 
 def assert_e2_manifest_contract(manifest: dict[str, Any]) -> None:
@@ -382,7 +390,7 @@ def assert_e2_manifest_contract(manifest: dict[str, Any]) -> None:
     )
     assert architecture["state"] == "active"
     assert architecture["canonical"] is True
-    assert_stable_outputs(architecture)
+    assert_stable_publication(manifest, architecture)
     assert {
         key: architecture["lifecycle"][key]
         for key in ("source_issue", "source_pr", "approved_at", "frozen_at")
@@ -395,7 +403,7 @@ def assert_e2_manifest_contract(manifest: dict[str, Any]) -> None:
 
     api = repository_entry(manifest, "eebus-api-v1")
     assert api["state"] == "active"
-    assert_stable_outputs(api)
+    assert_stable_publication(manifest, api)
 
     for entry_id in E2_CLEAN_ENTRY_IDS:
         item = repository_entry(manifest, entry_id)
@@ -449,10 +457,17 @@ def desired_e2_manifest() -> dict[str, Any]:
     architecture = repository_entry(manifest, "eebus-architecture")
     architecture["state"] = "active"
     architecture["canonical"] = True
-    architecture["outputs"] = {
-        "candidate": False,
-        **{name: True for name in E2_STABLE_OUTPUTS},
-    }
+    if manifest["version"] == 1:
+        architecture["outputs"] = {
+            "candidate": False,
+            **{name: True for name in E2_STABLE_OUTPUTS},
+        }
+    else:
+        architecture["kind"] = "canonical_document"
+        manifest["eligible_channels"][architecture["id"]] = ["canonical"]
+        manifest["exact_memberships"]["canonical"] = sorted(
+            set(manifest["exact_memberships"]["canonical"]) | {architecture["id"]}
+        )
     architecture["lifecycle"].update(
         {
             "expires_at": None,
@@ -1116,6 +1131,190 @@ def test_platform_b_token_generator_requires_immutable_inputs() -> None:
     assert "the following arguments are required" in result.stderr
 
 
+def build_publication_token_fixture(
+    tmp_path: pathlib.Path,
+) -> tuple[pathlib.Path, str, str, str]:
+    root = tmp_path / "helianthus-docs-ebus"
+    root.mkdir()
+    prior = base_manifest()
+    for entry_item in prior["entries"]:
+        if entry_item["lifecycle"]["source_ref"] == "__SOURCE_REF__":
+            entry_item["lifecycle"]["source_ref"] = "0" * 40
+    write_files(
+        root,
+        {
+            MANIFEST_PATH.as_posix(): yaml.safe_dump(prior, sort_keys=False),
+        },
+    )
+    base_oid = commit_fixture(root, "helianthus-docs-ebus")
+
+    current_files: dict[str, str | bytes] = {
+        MANIFEST_PATH.as_posix(): yaml.safe_dump(
+            repository_manifest(), sort_keys=False
+        ),
+        "docs/platform/README.md": (
+            REPO_ROOT / "docs/platform/README.md"
+        ).read_bytes(),
+    }
+    for page in CONTRACT_PAGES:
+        current_files[page.as_posix()] = (REPO_ROOT / page).read_bytes()
+    write_files(root, current_files)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_DATE": "2026-07-13T15:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-07-13T15:00:00Z",
+        }
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Contract Fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit",
+            "-qm",
+            "platform b head",
+        ],
+        cwd=root,
+        check=True,
+        env=env,
+    )
+    head_oid = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    tree_oid = subprocess.check_output(
+        ["git", "rev-parse", "HEAD^{tree}"], cwd=root, text=True
+    ).strip()
+    merge_oid = subprocess.check_output(
+        [
+            "git",
+            "-c",
+            "user.name=Contract Fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit-tree",
+            tree_oid,
+            "-p",
+            base_oid,
+            "-m",
+            "platform b squash merge",
+        ],
+        cwd=root,
+        text=True,
+        env=env,
+    ).strip()
+    subprocess.run(
+        ["git", "reset", "--hard", "-q", merge_oid], cwd=root, check=True
+    )
+    return root, base_oid, head_oid, merge_oid
+
+
+def publication_token_command(
+    root: pathlib.Path, base_oid: str, head_oid: str, merge_oid: str
+) -> list[str]:
+    return [
+        "python3",
+        str(PUBLICATION_TOKEN_PATH),
+        "--root",
+        str(root),
+        "--repository",
+        "Project-Helianthus/helianthus-docs-ebus",
+        "--pr",
+        "347",
+        "--base-oid",
+        base_oid,
+        "--head-oid",
+        head_oid,
+        "--merge-oid",
+        merge_oid,
+        "--evaluated-at",
+        "2026-07-13T15:00:01Z",
+        "--observation-source",
+        "test.fixture-clock",
+    ]
+
+
+def test_platform_b_token_is_reproducible_from_raw_git_objects(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
+    command = publication_token_command(root, base_oid, head_oid, merge_oid)
+    first = subprocess.run(command, check=False, capture_output=True, text=True)
+    second = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout == second.stdout
+
+    token = json.loads(first.stdout)
+    assert token["schema_version"] == 2
+    assert token["producer_id"] == "MSP-DOCS-E2R-PLATFORM"
+    assert token["consumer_id"] == "MSP-DOCS-E2R-PUBLISH"
+    assert token["repository"] == "Project-Helianthus/helianthus-docs-ebus"
+    assert token["pr"] == 347
+    assert token["base_oid"] == base_oid
+    assert token["head_oid"] == head_oid
+    assert token["merge_oid"] == merge_oid
+    assert token["observation_source"] == "test.fixture-clock"
+    assert token["evidence_core"]["prior_manifest"]["version"] == 1
+    assert token["evidence_core"]["manifest"]["version"] == 2
+    assert token["evidence_core"]["candidate_inventory"] == []
+    core = json.dumps(
+        token["evidence_core"],
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert token["evidence_core_sha256"] == hashlib.sha256(core).hexdigest()
+    assert re.fullmatch(r"[0-9a-f]{64}", token["prior_token_digest"])
+    assert set(token["evidence_core"]["publisher_blobs"]) == {
+        "cross-runtime-platform-contracts",
+        "platform-cross-runtime-envelope",
+        "platform-hash-auth-binding",
+        "platform-ownership-validation",
+        "platform-promotion-consumer-contract",
+        "platform-shared-registry-boundary",
+    }
+
+
+def test_platform_b_token_rejects_identity_drift(tmp_path: pathlib.Path) -> None:
+    root, _, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
+    result = subprocess.run(
+        publication_token_command(root, head_oid, head_oid, merge_oid),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert result.stderr == "publication-token.identity\n"
+
+
+def test_platform_b_token_rejects_dirty_root(tmp_path: pathlib.Path) -> None:
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
+    (root / "untracked.txt").write_text("drift\n", encoding="utf-8")
+    result = subprocess.run(
+        publication_token_command(root, base_oid, head_oid, merge_oid),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert result.stderr == "publication-token.identity\n"
+
+
+def test_platform_b_token_rejects_backdated_evaluation(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
+    command = publication_token_command(root, base_oid, head_oid, merge_oid)
+    command[command.index("--evaluated-at") + 1] = "2026-07-13T14:59:59Z"
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert result.returncode == 1
+    assert result.stderr == "publication-token.evaluation-time\n"
+
+
 def mark_manifest_entry_withdrawn(
     manifest: dict[str, Any], entry_id: str
 ) -> None:
@@ -1703,9 +1902,10 @@ def test_e2_architecture_entry_is_activated_in_place() -> None:
     assert architecture["canonical"] is True
 
 
-def test_e2_architecture_enables_all_stable_outputs() -> None:
-    assert_stable_outputs(
-        repository_entry(repository_manifest(), "eebus-architecture")
+def test_e2_architecture_is_canonically_published() -> None:
+    manifest = repository_manifest()
+    assert_stable_publication(
+        manifest, repository_entry(manifest, "eebus-architecture")
     )
 
 
@@ -1725,11 +1925,12 @@ def test_e2_architecture_lifecycle_is_bound_to_merged_docs_pr() -> None:
     }
 
 
-def test_e2_api_v1_remains_active_with_all_stable_outputs() -> None:
-    api = repository_entry(repository_manifest(), "eebus-api-v1")
+def test_e2_api_v1_remains_active_and_canonically_published() -> None:
+    manifest = repository_manifest()
+    api = repository_entry(manifest, "eebus-api-v1")
 
     assert api["state"] == "active"
-    assert_stable_outputs(api)
+    assert_stable_publication(manifest, api)
 
 
 def test_e2_combined_ref_uses_exact_merged_docs_pin() -> None:
@@ -1847,12 +2048,15 @@ def test_e2_contract_rejects_incorrect_lifecycle_metadata(
 
 
 @pytest.mark.parametrize("entry_id", ("eebus-architecture", "eebus-api-v1"))
-@pytest.mark.parametrize("output", E2_STABLE_OUTPUTS)
-def test_e2_contract_rejects_disabled_stable_output(
-    entry_id: str, output: str
+@pytest.mark.parametrize("surface", ("eligibility", "membership"))
+def test_e2_contract_rejects_missing_canonical_publication(
+    entry_id: str, surface: str
 ) -> None:
     manifest = desired_e2_manifest()
-    repository_entry(manifest, entry_id)["outputs"][output] = False
+    if surface == "eligibility":
+        manifest["eligible_channels"][entry_id] = []
+    else:
+        manifest["exact_memberships"]["canonical"].remove(entry_id)
 
     with pytest.raises(AssertionError):
         assert_e2_manifest_contract(manifest)
@@ -2070,7 +2274,7 @@ def test_combined_ref_caller_pins_trusted_reusable_workflow() -> None:
     trusted_call = (
         "uses: Project-Helianthus/helianthus-docs-ebus/"
         ".github/workflows/platform-contracts-combined-ref.yml@"
-        "153191f72b5b9ecacbadcf2f3d7e480c6fef89a4"
+        + PLATFORM_A_MERGE
     )
     assert trusted_call in caller
     assert "uses: ./.github/workflows/platform-contracts-combined-ref.yml" not in caller

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -27,7 +27,7 @@ REQUIREMENTS_CI_PATH = REPO_ROOT / "requirements-ci.txt"
 MAKEFILE_PATH = REPO_ROOT / "Makefile"
 COMBINED_REF_CLI_PATH = REPO_ROOT / "scripts/validate_platform_combined_ref.py"
 PUBLICATION_TOKEN_PATH = REPO_ROOT / "scripts/platform_publication_token.py"
-PLATFORM_A_MERGE = "41a04eabdeefa2fdfe34ea36dfdcc80d8624b849"
+PLATFORM_A_MERGE = "b245469c30752f06a49bb567b9a4680431774d0d"
 TRUSTED_PRIOR_STEP = "Materialize trusted prior manifest"
 PLATFORM_STAGE = "MSP-DOCS-PLATFORM"
 E2_STAGE = "MSP-DOCS-E2"
@@ -803,6 +803,7 @@ def validate(
         enforce_through=workspace.enforce_through,
         toolchain_mode=workspace.toolchain_mode,
         prior_manifest=prior_manifest,
+        _current_manifest_version=1,
     )
     assert diagnostics == sorted(set(diagnostics))
     assert all(
@@ -831,6 +832,7 @@ def repository_validate(
         prior_manifest=prior_manifest,
         evaluated_at=evaluated_at,
         evaluation_source=evaluation_source,
+        _current_manifest_version=1,
     )
 
 
@@ -865,15 +867,6 @@ def publication_v2_manifest() -> dict[str, Any]:
             "owner": "canonical_documentation_owner",
         }
     }
-    manifest["eligible_channels"] = {
-        item["id"]: [PUBLICATION_CHANNEL]
-        for item in manifest["entries"]
-        if item["state"] == "active"
-    }
-    manifest["exact_memberships"] = {
-        PUBLICATION_CHANNEL: sorted(manifest["eligible_channels"])
-    }
-
     by_surface = {item["surface"]: item for item in manifest["entries"]}
     for item in manifest["entries"]:
         item.pop("outputs")
@@ -900,11 +893,33 @@ def publication_v2_manifest() -> dict[str, Any]:
     code_repo["canonical"] = False
     code_repo["forbidden_states"] = ["candidate"]
     code_repo["channels"] = sorted(manifest["channel_registry"])
+    manifest["eligible_channels"] = {
+        item["id"]: [PUBLICATION_CHANNEL]
+        for item in manifest["entries"]
+        if item["state"] == "active"
+        and item["kind"] in {"canonical_document", "canonical_collection"}
+    }
+    manifest["exact_memberships"] = {
+        PUBLICATION_CHANNEL: sorted(manifest["eligible_channels"])
+    }
     return manifest
 
 
-def test_publication_v1_manifest_remains_accepted_unchanged() -> None:
+def test_publication_v1_manifest_remains_accepted_as_history_schema() -> None:
     assert load_validator()._schema_valid(base_manifest()) is True
+
+
+def test_publication_v1_manifest_is_rejected_as_current_after_migration(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "docs-ebus"
+    write_files(
+        root,
+        {MANIFEST_PATH.as_posix(): yaml.safe_dump(base_manifest(), sort_keys=False)},
+    )
+    manifest, categories = load_validator()._validated_manifest(root)
+    assert manifest is None
+    assert categories == {"manifest.version-floor"}
 
 
 def test_publication_v2_accepts_closed_contract() -> None:
@@ -928,6 +943,21 @@ def test_publication_v2_rejects_unregistered_eligible_channel() -> None:
 def test_publication_v2_rejects_exact_membership_drift() -> None:
     manifest = publication_v2_manifest()
     manifest["exact_memberships"][PUBLICATION_CHANNEL].pop()
+    assert load_validator()._schema_valid(manifest) is False
+
+
+@pytest.mark.parametrize("surface", ("summary_only", "code_repo"))
+def test_publication_v2_rejects_noncanonical_channel_membership(
+    surface: str,
+) -> None:
+    manifest = publication_v2_manifest()
+    entry_id = next(
+        item["id"] for item in manifest["entries"] if item["surface"] == surface
+    )
+    manifest["eligible_channels"][entry_id] = [PUBLICATION_CHANNEL]
+    manifest["exact_memberships"][PUBLICATION_CHANNEL] = sorted(
+        manifest["exact_memberships"][PUBLICATION_CHANNEL] + [entry_id]
+    )
     assert load_validator()._schema_valid(manifest) is False
 
 
@@ -1196,6 +1226,8 @@ def test_platform_b_token_generator_requires_immutable_inputs() -> None:
 
 def build_publication_token_fixture(
     tmp_path: pathlib.Path,
+    *,
+    current_manifest: str | bytes | None = None,
 ) -> tuple[pathlib.Path, str, str, str]:
     root = tmp_path / "helianthus-docs-ebus"
     root.mkdir()
@@ -1212,9 +1244,9 @@ def build_publication_token_fixture(
     base_oid = commit_fixture(root, "helianthus-docs-ebus")
 
     current_files: dict[str, str | bytes] = {
-        MANIFEST_PATH.as_posix(): yaml.safe_dump(
-            repository_manifest(), sort_keys=False
-        ),
+        MANIFEST_PATH.as_posix(): current_manifest
+        if current_manifest is not None
+        else yaml.safe_dump(repository_manifest(), sort_keys=False),
         "docs/platform/README.md": (
             REPO_ROOT / "docs/platform/README.md"
         ).read_bytes(),
@@ -1300,7 +1332,7 @@ def publication_token_command(
     ]
 
 
-def test_platform_b_token_is_reproducible_from_raw_git_objects(
+def test_platform_b_token_is_reproducible_from_objects_and_attestation_inputs(
     tmp_path: pathlib.Path,
 ) -> None:
     root, base_oid, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
@@ -1340,6 +1372,73 @@ def test_platform_b_token_is_reproducible_from_raw_git_objects(
         "platform-promotion-consumer-contract",
         "platform-shared-registry-boundary",
     }
+
+
+def test_platform_b_token_rejects_duplicate_manifest_keys(
+    tmp_path: pathlib.Path,
+) -> None:
+    duplicate_key_manifest = (
+        yaml.safe_dump(repository_manifest(), sort_keys=False) + "version: 2\n"
+    )
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(
+        tmp_path, current_manifest=duplicate_key_manifest
+    )
+    result = subprocess.run(
+        publication_token_command(root, base_oid, head_oid, merge_oid),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert result.stderr == "publication-token.manifest\n"
+
+
+def test_platform_b_token_rejects_unmet_stage_enforcement(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = repository_manifest()
+    entry = repository_entry(manifest, "platform-hash-auth-binding")
+    entry["enforcement"] = {
+        "milestone": E2_STAGE,
+        "required_state": "candidate",
+    }
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(
+        tmp_path,
+        current_manifest=yaml.safe_dump(manifest, sort_keys=False),
+    )
+    result = subprocess.run(
+        publication_token_command(root, base_oid, head_oid, merge_oid),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert result.stderr == "publication-token.manifest\n"
+
+
+@pytest.mark.parametrize(
+    "remote",
+    (
+        "https://github.com/Project-Helianthus/helianthus-docs-ebus",
+        "git@github.com:project-helianthus/HELIANTHUS-DOCS-EBUS.git",
+        "ssh://git@github.com:22/Project-Helianthus/helianthus-docs-ebus.git",
+        "git://github.com/Project-Helianthus/helianthus-docs-ebus.git",
+    ),
+)
+def test_platform_b_token_accepts_normalized_github_origins(
+    tmp_path: pathlib.Path, remote: str
+) -> None:
+    root, base_oid, head_oid, merge_oid = build_publication_token_fixture(tmp_path)
+    subprocess.run(
+        ["git", "remote", "set-url", "origin", remote], cwd=root, check=True
+    )
+    result = subprocess.run(
+        publication_token_command(root, base_oid, head_oid, merge_oid),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_platform_b_token_rejects_identity_drift(tmp_path: pathlib.Path) -> None:
@@ -4049,6 +4148,9 @@ def test_removed_caller_pin_arguments_are_category_only(tmp_path: pathlib.Path) 
 
 def test_main_expiry_cli_is_terminal_and_category_only(tmp_path: pathlib.Path) -> None:
     workspace = build_workspace(tmp_path)
+    write_manifest_text(
+        workspace, yaml.safe_dump(publication_v2_manifest(), sort_keys=False)
+    )
     result = subprocess.run(
         [
             "python3",

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -25,6 +25,8 @@ WORKFLOW_PATHS = (
 REQUIREMENTS_CI_PATH = REPO_ROOT / "requirements-ci.txt"
 MAKEFILE_PATH = REPO_ROOT / "Makefile"
 COMBINED_REF_CLI_PATH = REPO_ROOT / "scripts/validate_platform_combined_ref.py"
+PUBLICATION_TOKEN_PATH = REPO_ROOT / "scripts/platform_publication_token.py"
+PLATFORM_A_MERGE = "41a04eabdeefa2fdfe34ea36dfdcc80d8624b849"
 TRUSTED_PRIOR_STEP = "Materialize trusted prior manifest"
 PLATFORM_STAGE = "MSP-DOCS-PLATFORM"
 E2_STAGE = "MSP-DOCS-E2"
@@ -1013,6 +1015,105 @@ def test_publication_combined_ref_cli_has_one_invocation_surface() -> None:
     assert "scripts/validate_platform_combined_ref.py" in makefile
     assert "scripts/validate_platform_combined_ref.py" in workflow
     assert '--docs-eebus-ref "${PLATFORM_DOCS_EEBUS_REF}"' in local_ci
+
+
+def test_platform_b_repository_manifest_is_v2() -> None:
+    validator = load_validator()
+    manifest = repository_manifest()
+    assert manifest["version"] == 2
+    assert validator._schema_valid(manifest) is True
+    assert all("outputs" not in item for item in manifest["entries"])
+    assert manifest["channel_registry"] == {
+        "canonical": {
+            "visibility": "stable",
+            "owner": "canonical_documentation_owner",
+        }
+    }
+
+
+def test_platform_b_collection_has_exact_platform_inventory() -> None:
+    manifest = repository_manifest()
+    entries = {item["id"]: item for item in manifest["entries"]}
+    expected = {
+        "platform-cross-runtime-envelope": "docs/platform/cross-runtime-envelope.md",
+        "platform-hash-auth-binding": "docs/platform/hash-auth-binding.md",
+        "platform-shared-registry-boundary": "docs/platform/shared-registry-boundary.md",
+        "platform-promotion-consumer-contract": "docs/platform/promotion-and-consumer-contract.md",
+        "platform-ownership-validation": "docs/platform/ownership-validation.md",
+    }
+    collection = entries["cross-runtime-platform-contracts"]
+    assert collection["kind"] == "canonical_collection"
+    assert collection["owner"]["path"] == "docs/platform/README.md"
+    assert collection["members"] == sorted(expected)
+    for entry_id, path in expected.items():
+        assert entries[entry_id]["kind"] == "canonical_document"
+        assert entries[entry_id]["owner"] == {
+            "repository": "helianthus-docs-ebus",
+            "path": path,
+        }
+
+
+def test_platform_b_membership_and_noncanonical_constraints_are_exact() -> None:
+    manifest = repository_manifest()
+    entries = {item["id"]: item for item in manifest["entries"]}
+    expected_members = sorted(
+        entry_id
+        for entry_id, item in entries.items()
+        if item["state"] == "active"
+        and item["kind"] in {"canonical_document", "canonical_collection"}
+    )
+    assert manifest["eligible_channels"] == {
+        entry_id: ["canonical"] for entry_id in expected_members
+    }
+    assert manifest["exact_memberships"] == {"canonical": expected_members}
+    assert entries["eebusreg-substantive-docs"]["kind"] == "absence_constraint"
+    assert entries["eebusreg-substantive-docs"]["channels"] == ["canonical"]
+    assert entries["eebusreg-substantive-docs"]["forbidden_states"] == [
+        "candidate"
+    ]
+    assert entries["eebusreg-readme-summary"]["kind"] == "summary_pointer"
+    assert entries["eebusreg-readme-summary"]["target"] == "eebus-architecture"
+
+
+def test_platform_b_combined_ref_uses_platform_a_validator() -> None:
+    caller = (REPO_ROOT / ".github/workflows/docs-ci.yml").read_text(encoding="utf-8")
+    assert (
+        "Project-Helianthus/helianthus-docs-ebus/"
+        ".github/workflows/platform-contracts-combined-ref.yml@"
+        f"{PLATFORM_A_MERGE}"
+    ) in caller
+
+
+def test_platform_b_token_generator_has_closed_identity_contract() -> None:
+    assert PUBLICATION_TOKEN_PATH.is_file()
+    assert not PUBLICATION_TOKEN_PATH.is_symlink()
+    text = PUBLICATION_TOKEN_PATH.read_text(encoding="utf-8")
+    for field in (
+        "producer_id",
+        "consumer_id",
+        "repository",
+        "pr",
+        "base_oid",
+        "head_oid",
+        "merge_oid",
+        "tree_oid",
+        "evidence_core_sha256",
+        "prior_token_digest",
+        "observation_source",
+    ):
+        assert field in text
+
+
+def test_platform_b_token_generator_requires_immutable_inputs() -> None:
+    result = subprocess.run(
+        ["python3", str(PUBLICATION_TOKEN_PATH)],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "the following arguments are required" in result.stderr
 
 
 def mark_manifest_entry_withdrawn(


### PR DESCRIPTION
## What
Migrate the canonical platform manifest to publication-contract v2 and add reproducible post-merge token generation.

## Why
This is PLATFORM-B of the MSP-DOCS-E2 remediation, following the merged v2 bootstrap and trusted-validator patch.

## Acceptance Criteria
- [x] Tests-only RED was observed by GitHub CI at `e314828`
- [x] Real manifest is migrated to v2 with exact canonical membership
- [x] Combined-ref caller pins the PLATFORM-A2 merge
- [x] Reproducible immutable post-merge token generator is included
- [x] Full local CI is green at `7b8d14b`
- [x] One bounded exact-head architecture/code-structure review is closed and all accepted findings are fixed

## Dependencies
- Depends on #346 and #348 (merged as `b245469c30752f06a49bb567b9a4680431774d0d`)
- Tracks #345

No further audit cycle is required; merge follows exact-head GitHub CI.