### PR TITLE
fix(platform): allow v2 multi-document surfaces

### DIFF
--- a/scripts/validate_platform_contracts.py
+++ b/scripts/validate_platform_contracts.py
@@ -962,10 +962,15 @@ def _manifest_categories(manifest: dict[str, Any]) -> set[str]:
     manifest_surfaces = [entry["surface"] for entry in manifest["entries"]]
     if set(manifest_surfaces) != SURFACES:
         categories.add("ownership.surface-missing")
-    if (
-        set(manifest) == TOP_FIELDS_V1
-        and len(manifest_surfaces) != len(set(manifest_surfaces))
-    ):
+    duplicate_surfaces = {
+        surface
+        for surface in manifest_surfaces
+        if manifest_surfaces.count(surface) > 1
+    }
+    allowed_duplicate_surfaces = (
+        {"platform"} if set(manifest) == TOP_FIELDS_V2 else set()
+    )
+    if duplicate_surfaces - allowed_duplicate_surfaces:
         categories.add("ownership.surface-duplicate")
 
     pairs: set[tuple[str, str, str, str]] = set()

--- a/scripts/validate_platform_contracts.py
+++ b/scripts/validate_platform_contracts.py
@@ -962,7 +962,10 @@ def _manifest_categories(manifest: dict[str, Any]) -> set[str]:
     manifest_surfaces = [entry["surface"] for entry in manifest["entries"]]
     if set(manifest_surfaces) != SURFACES:
         categories.add("ownership.surface-missing")
-    if len(manifest_surfaces) != len(set(manifest_surfaces)):
+    if (
+        set(manifest) == TOP_FIELDS_V1
+        and len(manifest_surfaces) != len(set(manifest_surfaces))
+    ):
         categories.add("ownership.surface-duplicate")
 
     pairs: set[tuple[str, str, str, str]] = set()

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -953,6 +953,37 @@ def test_publication_v2_allows_multiple_documents_on_one_surface() -> None:
     assert validator._manifest_categories(manifest) == set()
 
 
+def test_publication_v2_rejects_multiple_documents_outside_platform() -> None:
+    validator = load_validator()
+    manifest = publication_v2_manifest()
+    by_surface = {item["surface"]: item for item in manifest["entries"]}
+    duplicate = copy.deepcopy(by_surface["protocol"])
+    duplicate.update(
+        {
+            "id": "duplicate-protocol-document",
+            "owner": {
+                "repository": "helianthus-docs-eebus",
+                "path": "protocols/duplicate.md",
+            },
+            "source": {
+                "repository": "helianthus-docs-eebus",
+                "path": "protocols/duplicate.md",
+            },
+        }
+    )
+    manifest["entries"].append(duplicate)
+    manifest["eligible_channels"][duplicate["id"]] = [PUBLICATION_CHANNEL]
+    manifest["exact_memberships"][PUBLICATION_CHANNEL] = sorted(
+        manifest["exact_memberships"][PUBLICATION_CHANNEL] + [duplicate["id"]]
+    )
+    by_surface["platform"]["members"] = sorted(
+        by_surface["platform"]["members"] + [duplicate["id"]]
+    )
+
+    assert validator._schema_valid(manifest) is True
+    assert "ownership.surface-duplicate" in validator._manifest_categories(manifest)
+
+
 @pytest.mark.parametrize("surface", ("api", "summary_only", "code_repo"))
 def test_publication_v2_collection_rejects_noncanonical_members(
     surface: str,

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -921,6 +921,38 @@ def test_publication_v2_state_validation_is_end_to_end() -> None:
     assert validator._state_categories(manifest, {}) == set()
 
 
+def test_publication_v2_allows_multiple_documents_on_one_surface() -> None:
+    validator = load_validator()
+    manifest = publication_v2_manifest()
+    entries = {item["surface"]: item for item in manifest["entries"]}
+    document = copy.deepcopy(entries["protocol"])
+    document.update(
+        {
+            "id": "platform-hash-auth-binding",
+            "surface": "platform",
+            "owner": {
+                "repository": "helianthus-docs-ebus",
+                "path": "docs/platform/hash-auth-binding.md",
+            },
+            "source": {
+                "repository": "helianthus-docs-ebus",
+                "path": "docs/platform/hash-auth-binding.md",
+            },
+        }
+    )
+    manifest["entries"].append(document)
+    manifest["eligible_channels"][document["id"]] = [PUBLICATION_CHANNEL]
+    manifest["exact_memberships"][PUBLICATION_CHANNEL] = sorted(
+        manifest["exact_memberships"][PUBLICATION_CHANNEL] + [document["id"]]
+    )
+    entries["platform"]["members"] = sorted(
+        entries["platform"]["members"] + [document["id"]]
+    )
+
+    assert validator._schema_valid(manifest) is True
+    assert validator._manifest_categories(manifest) == set()
+
+
 @pytest.mark.parametrize("surface", ("api", "summary_only", "code_repo"))
 def test_publication_v2_collection_rejects_noncanonical_members(
     surface: str,


### PR DESCRIPTION
## What
Close the trusted-validator bootstrap gap that blocks a real v2 canonical collection with multiple documents on the platform surface.

## Why
PR #347 proved the merged PLATFORM-A validator still emits `ownership.surface-duplicate` for the real v2 manifest. The v1 uniqueness invariant must remain unchanged.

## Acceptance Criteria
- [ ] Tests-only RED is observed by GitHub CI
- [ ] v2 permits multiple documents on one surface
- [ ] v1 continues rejecting duplicate surfaces
- [ ] Full local and GitHub CI are green

## Dependencies
- Based on #346 / `41a04eabdeefa2fdfe34ea36dfdcc80d8624b849`
- Unblocks the preserved PLATFORM-B branch in #347
- Tracks #345

Current head `45b0180` is intentionally tests-only RED.