### PR TITLE
MSP-DOCS-CLEAN: activate external eeBUS ownership state

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -201,6 +201,6 @@ jobs:
       docs_ebus_repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       docs_ebus_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       docs_ebus_base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-      docs_eebus_ref: 62e4c2f2022c22f5129db923079268aafdc5617b
-      eebusreg_ref: 0e58327dfdb86ef243a19e18d590564813feaa00
-      enforce_through: MSP-DOCS-E2
+      docs_eebus_ref: 9fc4b2a86424ac00075cf3bd3510918c3f9cefaf
+      eebusreg_ref: 9fb73c5be17ceb28742c1428ef61a0c197cbc07d
+      enforce_through: MSP-DOCS-CLEAN

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ validate-schemas:
 
 validate-platform-contracts:
 	@python3 -m pytest -q tests/test_platform_contracts.py
-	@python3 scripts/validate_platform_contracts.py --mode repository --docs-ebus-root . --enforce-through MSP-DOCS-E2 --toolchain-mode "$(PLATFORM_TOOLCHAIN_MODE)"
+	@python3 scripts/validate_platform_contracts.py --mode repository --docs-ebus-root . --enforce-through MSP-DOCS-CLEAN --toolchain-mode "$(PLATFORM_TOOLCHAIN_MODE)"
 
 validate-platform-combined-ref:
 	@test -n "$(DOCS_EEBUS_ROOT)" && test -n "$(EEBUSREG_ROOT)"
@@ -35,7 +35,7 @@ validate-platform-combined-ref:
 validate-platform-expiry:
 	@test -n "$(EVALUATED_AT)" || (echo "EVALUATED_AT is required" >&2; exit 2)
 	@test -n "$(EVALUATION_SOURCE)" || (echo "EVALUATION_SOURCE is required" >&2; exit 2)
-	@python3 scripts/validate_platform_contracts.py --mode main-expiry --docs-ebus-root . --evaluated-at "$(EVALUATED_AT)" --evaluation-source "$(EVALUATION_SOURCE)" --enforce-through MSP-DOCS-E2 --toolchain-mode "$(PLATFORM_TOOLCHAIN_MODE)"
+	@python3 scripts/validate_platform_contracts.py --mode main-expiry --docs-ebus-root . --evaluated-at "$(EVALUATED_AT)" --evaluation-source "$(EVALUATION_SOURCE)" --enforce-through MSP-DOCS-CLEAN --toolchain-mode "$(PLATFORM_TOOLCHAIN_MODE)"
 
 ci-local:
 	@bash scripts/ci_local.sh

--- a/docs/platform/manifests/eebus-doc-ownership.yaml
+++ b/docs/platform/manifests/eebus-doc-ownership.yaml
@@ -275,7 +275,7 @@ entries:
       repository: helianthus-eebusreg
       path: docs
     canonical: false
-    state: planned
+    state: withdrawn
     kind: absence_constraint
     forbidden_states:
       - candidate
@@ -283,14 +283,14 @@ entries:
       - canonical
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
-      expires_at: "2026-07-25T00:00:00Z"
-      source_issue: Project-Helianthus/helianthus-execution-plans#58
-      source_pr: null
-      source_ref: null
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#349
+      source_pr: Project-Helianthus/helianthus-docs-ebus#350
+      source_ref: 9fb73c5be17ceb28742c1428ef61a0c197cbc07d
       content_sha256: null
       approved_at: null
       frozen_at: null
-      cleanup_required: false
+      cleanup_required: true
     enforcement:
       milestone: MSP-DOCS-CLEAN
       required_state: withdrawn
@@ -304,18 +304,18 @@ entries:
       repository: helianthus-docs-eebus
       path: README.md
     canonical: false
-    state: planned
+    state: active
     kind: summary_pointer
     target: eebus-architecture
     lifecycle:
       created_at: "2026-07-11T00:00:00Z"
-      expires_at: "2026-07-25T00:00:00Z"
-      source_issue: Project-Helianthus/helianthus-execution-plans#58
-      source_pr: null
-      source_ref: null
-      content_sha256: null
-      approved_at: null
-      frozen_at: null
+      expires_at: null
+      source_issue: Project-Helianthus/helianthus-docs-ebus#349
+      source_pr: Project-Helianthus/helianthus-docs-ebus#350
+      source_ref: 9fc4b2a86424ac00075cf3bd3510918c3f9cefaf
+      content_sha256: 2cbdf09619d7bdee2c6cc9c11495da15a04a1888309ea5df487c70c1a5c1eeba
+      approved_at: "2026-07-13T21:59:00Z"
+      frozen_at: "2026-07-13T21:59:00Z"
       cleanup_required: false
     enforcement:
       milestone: MSP-DOCS-CLEAN

--- a/docs/platform/ownership-validation.md
+++ b/docs/platform/ownership-validation.md
@@ -118,7 +118,7 @@ The current E2 enforcement state is:
 - `helianthus-eebusreg/docs` is `withdrawn` at `MSP-DOCS-CLEAN`;
 - the code-repository README is `active` only as the exact minimal
   summary-and-build pointer;
-- both CLEAN states are terminal inputs to successors and are validated against
+- both CLEAN states are required inputs to successors and are validated against
   the immutable eebusreg cleanup head.
 
 At CLEAN, the validator also scans documentation-like files throughout the

--- a/docs/platform/ownership-validation.md
+++ b/docs/platform/ownership-validation.md
@@ -115,11 +115,11 @@ The current E2 enforcement state is:
   `active` from `MSP-DOCS-PLATFORM` onward;
 - the architecture ownership landing is `active`, with its canonical membership
   supported at `MSP-DOCS-E2`;
-- current `helianthus-eebusreg/docs` and its README remain `planned` and are not
-  failures during E2;
-- at `MSP-DOCS-CLEAN`, code-repository docs must transition
-  `planned -> withdrawn`, while the README must transition
-  `planned -> active` as a minimal summary-only pointer.
+- `helianthus-eebusreg/docs` is `withdrawn` at `MSP-DOCS-CLEAN`;
+- the code-repository README is `active` only as the exact minimal
+  summary-and-build pointer;
+- both CLEAN states are terminal inputs to successors and are validated against
+  the immutable eebusreg cleanup head.
 
 At CLEAN, the validator also scans documentation-like files throughout the
 eebusreg checkout, including root architecture files and alternate nested
@@ -146,14 +146,15 @@ membership remains excluded from every stable channel.
 checks out the current PR head SHA for docs-ebus and these merged dependency
 commits:
 
-- docs-eebus: `62e4c2f2022c22f5129db923079268aafdc5617b`;
-- eebusreg: `0e58327dfdb86ef243a19e18d590564813feaa00`.
+- docs-eebus: `9fc4b2a86424ac00075cf3bd3510918c3f9cefaf`;
+- eebusreg: `9fb73c5be17ceb28742c1428ef61a0c197cbc07d`.
 
 All three values are explicit immutable 40-hex commits. Each repository is
 checked out into a separate clean root and validated without sibling discovery
 or ambient checkout state. A missing, symbolic, moving, mismatched, dirty, or
-incorrect repository root is terminal. Dependency pins change only in the PR
-that owns the corresponding successor transition.
+incorrect repository root is terminal. This caller enforces
+`MSP-DOCS-CLEAN`; dependency pins change only in the PR that owns the
+corresponding successor transition.
 
 For pull requests, both Docs Checks and Combined Ref independently check out the
 trusted base at `github.event.pull_request.base.sha` into a sibling of the

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -146,7 +146,7 @@ echo "==> check eBUS source-address table"
 python3 scripts/check_source_address_table_against_official_specs.py --run-canary
 python3 -m pytest -q tests/test_source_address_table_checker.py
 
-echo "==> check cross-runtime platform contracts (MSP-DOCS-E2)"
+echo "==> check cross-runtime platform contracts (MSP-DOCS-CLEAN)"
 python3 -m pytest -q tests/test_platform_contracts.py -k trusted_prior_workflow
 python3 -m pytest -q tests/test_platform_contracts.py -k 'not trusted_prior_workflow'
 set --
@@ -157,7 +157,7 @@ python3 scripts/validate_platform_contracts.py \
   --mode repository \
   --docs-ebus-root . \
   --docs-ebus-repository "${platform_docs_ebus_repository}" \
-  --enforce-through MSP-DOCS-E2 \
+  --enforce-through MSP-DOCS-CLEAN \
   --toolchain-mode "${platform_toolchain_mode}" \
   "$@"
 
@@ -192,7 +192,7 @@ if [ "${combined_ref_requested}" = true ]; then
     --docs-eebus-ref "${PLATFORM_DOCS_EEBUS_REF}" \
     --eebusreg-ref "${PLATFORM_EEBUSREG_REF}" \
     --prior-manifest "${PLATFORM_PRIOR_MANIFEST}" \
-    --enforce-through MSP-DOCS-E2 \
+    --enforce-through MSP-DOCS-CLEAN \
     --toolchain-mode "${platform_toolchain_mode}"
 fi
 

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -33,6 +33,8 @@ PLATFORM_STAGE = "MSP-DOCS-PLATFORM"
 E2_STAGE = "MSP-DOCS-E2"
 CLEAN_STAGE = "MSP-DOCS-CLEAN"
 E2_DOCS_EEBUS_REF = "62e4c2f2022c22f5129db923079268aafdc5617b"
+CLEAN_DOCS_EEBUS_REF = "9fc4b2a86424ac00075cf3bd3510918c3f9cefaf"
+CLEAN_EEBUSREG_REF = "9fb73c5be17ceb28742c1428ef61a0c197cbc07d"
 E2_SOURCE_ISSUE = "Project-Helianthus/helianthus-docs-eebus#8"
 E2_SOURCE_PR = "Project-Helianthus/helianthus-docs-eebus#9"
 E2_MERGED_AT = "2026-07-12T19:42:19Z"
@@ -2095,22 +2097,30 @@ def test_e2_api_v1_remains_active_and_canonically_published() -> None:
     assert_stable_publication(manifest, api)
 
 
-def test_e2_combined_ref_uses_exact_merged_docs_pin() -> None:
-    assert combined_ref_inputs()["docs_eebus_ref"] == E2_DOCS_EEBUS_REF
+def test_clean_combined_ref_uses_exact_merged_dependency_pins() -> None:
+    inputs = combined_ref_inputs()
+    assert inputs["docs_eebus_ref"] == CLEAN_DOCS_EEBUS_REF
+    assert inputs["eebusreg_ref"] == CLEAN_EEBUSREG_REF
 
 
-def test_e2_combined_ref_enforces_exact_stage() -> None:
-    assert combined_ref_inputs()["enforce_through"] == E2_STAGE
+def test_clean_combined_ref_enforces_exact_stage() -> None:
+    assert combined_ref_inputs()["enforce_through"] == CLEAN_STAGE
 
 
 @pytest.mark.parametrize(
     "target", ("validate-platform-contracts", "validate-platform-expiry")
 )
-def test_platform_make_target_enforces_e2_stage(target: str) -> None:
-    assert cli_option(make_validator_args(target), "--enforce-through") == E2_STAGE
+def test_platform_make_target_enforces_clean_stage(target: str) -> None:
+    assert cli_option(make_validator_args(target), "--enforce-through") == CLEAN_STAGE
 
 
-def test_ownership_validation_guide_tracks_supported_e2_contract() -> None:
+def test_local_ci_enforces_clean_stage() -> None:
+    local_ci = (REPO_ROOT / "scripts/ci_local.sh").read_text(encoding="utf-8")
+    assert "cross-runtime platform contracts (MSP-DOCS-CLEAN)" in local_ci
+    assert local_ci.count("--enforce-through MSP-DOCS-CLEAN") == 2
+
+
+def test_ownership_validation_guide_tracks_supported_clean_contract() -> None:
     guide = (
         REPO_ROOT / "docs/platform/ownership-validation.md"
     ).read_text(encoding="utf-8")
@@ -2156,7 +2166,7 @@ def test_ownership_validation_guide_tracks_supported_e2_contract() -> None:
     }
     assert canonical == {
         "architecture_state": "active",
-        "docs_eebus_ref": E2_DOCS_EEBUS_REF,
+        "docs_eebus_ref": CLEAN_DOCS_EEBUS_REF,
     }
     assert {
         "architecture_state": state_match.group("state"),
@@ -2164,13 +2174,26 @@ def test_ownership_validation_guide_tracks_supported_e2_contract() -> None:
     } == canonical
 
 
-def test_e2_does_not_transition_clean_entries() -> None:
+def test_clean_transitions_code_repository_ownership_entries() -> None:
     manifest = repository_manifest()
+    docs = repository_entry(manifest, "eebusreg-substantive-docs")
+    readme = repository_entry(manifest, "eebusreg-readme-summary")
 
-    for entry_id in E2_CLEAN_ENTRY_IDS:
-        item = repository_entry(manifest, entry_id)
-        assert item["enforcement"]["milestone"] == CLEAN_STAGE
-        assert item["state"] == "planned"
+    assert docs["enforcement"] == {
+        "milestone": CLEAN_STAGE,
+        "required_state": "withdrawn",
+    }
+    assert docs["state"] == "withdrawn"
+    assert docs["lifecycle"]["cleanup_required"] is True
+    assert docs["lifecycle"]["expires_at"] is None
+
+    assert readme["enforcement"] == {
+        "milestone": CLEAN_STAGE,
+        "required_state": "active",
+    }
+    assert readme["state"] == "active"
+    assert readme["lifecycle"]["cleanup_required"] is False
+    assert readme["lifecycle"]["expires_at"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_platform_contracts.py
+++ b/tests/test_platform_contracts.py
@@ -479,6 +479,22 @@ def desired_e2_manifest() -> dict[str, Any]:
             "frozen_at": E2_MERGED_AT,
         }
     )
+    for entry_id in E2_CLEAN_ENTRY_IDS:
+        item = repository_entry(manifest, entry_id)
+        item["state"] = "planned"
+        item["canonical"] = False
+        item["lifecycle"].update(
+            {
+                "expires_at": "2026-07-25T00:00:00Z",
+                "source_issue": "Project-Helianthus/helianthus-execution-plans#58",
+                "source_pr": None,
+                "source_ref": None,
+                "content_sha256": None,
+                "approved_at": None,
+                "frozen_at": None,
+                "cleanup_required": False,
+            }
+        )
     return manifest
 
 
@@ -1248,7 +1264,7 @@ def build_publication_token_fixture(
     current_files: dict[str, str | bytes] = {
         MANIFEST_PATH.as_posix(): current_manifest
         if current_manifest is not None
-        else yaml.safe_dump(repository_manifest(), sort_keys=False),
+        else yaml.safe_dump(desired_e2_manifest(), sort_keys=False),
         "docs/platform/README.md": (
             REPO_ROOT / "docs/platform/README.md"
         ).read_bytes(),
@@ -1380,7 +1396,7 @@ def test_platform_b_token_rejects_duplicate_manifest_keys(
     tmp_path: pathlib.Path,
 ) -> None:
     duplicate_key_manifest = (
-        yaml.safe_dump(repository_manifest(), sort_keys=False) + "version: 2\n"
+        yaml.safe_dump(desired_e2_manifest(), sort_keys=False) + "version: 2\n"
     )
     root, base_oid, head_oid, merge_oid = build_publication_token_fixture(
         tmp_path, current_manifest=duplicate_key_manifest
@@ -1398,7 +1414,7 @@ def test_platform_b_token_rejects_duplicate_manifest_keys(
 def test_platform_b_token_rejects_unmet_stage_enforcement(
     tmp_path: pathlib.Path,
 ) -> None:
-    manifest = repository_manifest()
+    manifest = desired_e2_manifest()
     entry = repository_entry(manifest, "platform-hash-auth-binding")
     entry["enforcement"] = {
         "milestone": E2_STAGE,
@@ -2278,7 +2294,7 @@ def test_e2_contract_rejects_premature_clean_transition(
 
 def test_canonical_repository_validation_passes() -> None:
     assert repository_validate(
-        load_validator(), REPO_ROOT, enforce_through=E2_STAGE
+        load_validator(), REPO_ROOT, enforce_through=CLEAN_STAGE
     ) == []
 
 


### PR DESCRIPTION
## What
Activate the MSP-DOCS-CLEAN ownership transition and pin combined validation to the exact cleaned runtime head.

## TDD Evidence
- Tests-only RED: `bbc880a`
- GitHub RED run: `29288220435`
- RED result: 7 intended failures, 377 existing passes
- GREEN: `b49ed55`

## Changes
- `eebusreg-substantive-docs`: `planned -> withdrawn`
- `eebusreg-readme-summary`: `planned -> active`
- docs-eebus pin: `9fc4b2a86424ac00075cf3bd3510918c3f9cefaf`
- eebusreg pin: `9fb73c5be17ceb28742c1428ef61a0c197cbc07d`
- local, Makefile, and GitHub enforcement: `MSP-DOCS-CLEAN`

## Verification
- [x] 394 platform-contract tests pass
- [x] Full local docs CI passes
- [x] Exact local combined-ref CLEAN validation passes
- [ ] GitHub Docs Checks green
- [ ] GitHub Combined Ref green

Tracks #349. Companion to Project-Helianthus/helianthus-eebusreg#16.
