### PR TITLE
MSP-07: close sampled comparator outcome matrix

### DIFF
--- a/docs/platform/draft-candidate-fact-graph-v1.md
+++ b/docs/platform/draft-candidate-fact-graph-v1.md
@@ -141,11 +141,36 @@ combination is valid:
 | --- | --- | --- | --- |
 | `RAW_ONLY` / null | At least one reviewable native or root ref; any selected artifact contributes all of its refs | no samples; `NOT_EVALUATED` | null |
 | `CANDIDATE` / null | complete eBUS identity and complete eeBUS service/entity/feature path, with both native artifacts and refs | non-empty, directly bound cross-runtime samples; recomputed `MATCH` | recomputed final rounded eeBUS value and target unit |
-| `CONFLICTED` / null | same complete direct eBUS and eeBUS provenance as `CANDIDATE` | non-empty samples; recomputed `CONFLICT` | null |
+| `CONFLICTED` / null | same complete direct eBUS and eeBUS provenance as `CANDIDATE` | non-empty samples; recomputed `MISMATCH` or `CONFLICT` | null |
 | `WITHHELD` / `CLOUD_ONLY` | a verified cloud artifact and its refs, and no native substitute | no samples; `NOT_EVALUATED` | null |
 | `WITHHELD` / `NO_SIGNAL` | at least one selected native artifact and all its refs | no samples; `NOT_EVALUATED` | null |
-| `WITHHELD` / `NOT_TESTED` | bundle provenance only, or incomplete native provenance | no samples; `NOT_EVALUATED` | null |
+| `WITHHELD` / `NOT_TESTED` | bundle provenance only or incomplete native provenance for `NOT_EVALUATED`; complete direct eBUS and eeBUS provenance for `INDETERMINATE` | empty samples and `NOT_EVALUATED`, or non-empty directly bound samples and `INDETERMINATE` | null |
 | `WITHHELD` / `CONFLICT` | complete direct eBUS and eeBUS provenance | non-empty samples; recomputed `CONFLICT` | null |
+
+The outcome mapping is deterministic and exhaustive. "Fact" means the
+in-progress candidate fact; "terminal bundle" means a terminal result for this
+immutable evidence bundle:
+
+| Outcome | Scope | Status | Terminal state | Samples | Draft |
+| --- | --- | --- | --- | --- | --- |
+| `MATCH` | fact | `CANDIDATE` | null | non-empty | value and unit set |
+| `MISMATCH` | fact | `CONFLICTED` | null | non-empty | null |
+| `CONFLICT` | fact | `CONFLICTED` | null | non-empty | null |
+| `CONFLICT` | terminal bundle | `WITHHELD` | `CONFLICT` | non-empty | null |
+| `INDETERMINATE` | terminal bundle | `WITHHELD` | `NOT_TESTED` | non-empty | null |
+| `NOT_EVALUATED` | terminal bundle | `WITHHELD` | `NOT_TESTED` | empty | null |
+
+The existing `RAW_ONLY`/`NOT_EVALUATED`, `WITHHELD/NO_SIGNAL`, and
+`WITHHELD/CLOUD_ONLY` rows above remain closed. MISMATCH maps to no terminal state.
+It is never collapsed into terminal `CONFLICT`. `WITHHELD/CONFLICT` requires
+recomputed `CONFLICT`. `INDETERMINATE` and `NOT_EVALUATED` share
+`WITHHELD/NOT_TESTED` only because their explicit outcomes and non-empty versus
+empty sample lists distinguish them. `NO_SIGNAL` and `CLOUD_ONLY` are never synthesized
+from a comparator outcome.
+
+Only the `CANDIDATE`/`MATCH` row can be considered for later semantic
+eligibility. It is still M7 candidate raw/debug material and gains no stable
+consumer exposure or promotion authority.
 
 Cloud-only evidence cannot escape `WITHHELD/CLOUD_ONLY`. Cloud evidence ids
 are exactly `public-evidence:sha256:<64 lowercase hex>` and the digest must be
@@ -225,10 +250,10 @@ The deterministic evaluator performs these steps in order:
 7. count a conflict when `delta >= conflict_threshold.absolute_decimal` for
    the declared number of consecutive `PRESENT` samples; an unavailable or
    below-threshold sample resets the run; and
-8. return `CONFLICT` first, otherwise `INDETERMINATE` when an availability or
-   minimum-sample bound fails, otherwise `MISMATCH` when any present delta is
-   over tolerance, otherwise `MATCH`. An empty list alone returns
-   `NOT_EVALUATED`.
+8. return `INDETERMINATE` first when an availability or minimum-sample bound
+   fails, otherwise `CONFLICT` when the consecutive threshold was reached,
+   otherwise `MISMATCH` when any present delta is over tolerance, otherwise
+   `MATCH`. An empty list alone returns `NOT_EVALUATED`.
 
 All arithmetic is exact decimal arithmetic with sufficient fixed precision for
 the bounded 64-character inputs. Sample offsets are captured monotonic offsets
@@ -236,6 +261,14 @@ from the evidence bundle. The evaluator does not read a clock or acquire more
 samples. `MATCH`, `MISMATCH`, `CONFLICT`, `INDETERMINATE`, and `NOT_EVALUATED`
 are draft outcomes only. The stored outcome must equal the recomputed outcome;
 it is never caller-controlled.
+
+Every non-empty evaluation list must contain valid, directly bound eBUS and
+eeBUS sides. A schema-invalid, unbound, or forged side is rejected rather than
+classified. For bound inputs, a missing or stale native observation, or too few
+available samples, produces `INDETERMINATE`; it cannot produce `MISMATCH` or
+`CONFLICT`. Consequently `MISMATCH` and `CONFLICT` always prove non-empty,
+available cross-runtime numeric inputs, while sampled `INDETERMINATE` preserves
+the bound unavailable or insufficient observations that caused it.
 
 ## Deterministic Ordering And Hashes
 

--- a/scripts/validate_candidate_fact_graph.py
+++ b/scripts/validate_candidate_fact_graph.py
@@ -744,9 +744,11 @@ def check_provenance(
             if any(canonical(ref) not in seen for ref in artifact["evidence_refs"]):
                 fail("provenance.binding")
         _check_sample_provenance(fact, artifacts)
-        if fact["status"] in {"CANDIDATE", "CONFLICTED"} or fact[
-            "terminal_negative_state"
-        ] == "CONFLICT":
+        if (
+            fact["comparator"]["samples"]
+            or fact["status"] in {"CANDIDATE", "CONFLICTED"}
+            or fact["terminal_negative_state"] == "CONFLICT"
+        ):
             if (
                 provenance["ebus"] is None
                 or provenance["eebus"] is None
@@ -1012,6 +1014,7 @@ def check_states(graph: dict[str, Any], registry: dict[str, Any]) -> None:
                 terminal is not None
                 or fact["draft_value"] is None
                 or fact["draft_unit"] is None
+                or not samples
                 or outcome != "MATCH"
                 or native_kinds != {"EBUS", "EEBUS"}
             ):
@@ -1021,20 +1024,30 @@ def check_states(graph: dict[str, Any], registry: dict[str, Any]) -> None:
                 terminal is not None
                 or fact["draft_value"] is not None
                 or fact["draft_unit"] is not None
-                or outcome != "CONFLICT"
+                or not samples
+                or outcome not in {"MISMATCH", "CONFLICT"}
                 or native_kinds != {"EBUS", "EEBUS"}
             ):
                 fail("state.terminal")
         elif status == "WITHHELD":
             if terminal is None or fact["draft_value"] is not None or fact["draft_unit"] is not None:
                 fail("state.terminal")
-            if terminal in {"CLOUD_ONLY", "NO_SIGNAL", "NOT_TESTED"} and (
+            if terminal in {"CLOUD_ONLY", "NO_SIGNAL"} and (
                 samples or outcome != "NOT_EVALUATED"
             ):
                 fail("state.terminal")
             if terminal == "CLOUD_ONLY" and not cloud_only:
                 fail("state.terminal")
             if terminal == "NO_SIGNAL" and not native_kinds:
+                fail("state.terminal")
+            if terminal == "NOT_TESTED" and not (
+                (not samples and outcome == "NOT_EVALUATED")
+                or (
+                    samples
+                    and outcome == "INDETERMINATE"
+                    and native_kinds == {"EBUS", "EEBUS"}
+                )
+            ):
                 fail("state.terminal")
             if terminal == "CONFLICT" and (
                 outcome != "CONFLICT" or native_kinds != {"EBUS", "EEBUS"} or not samples
@@ -1233,13 +1246,13 @@ def _evaluate_numeric_window_details(
                     conflict = True
             else:
                 conflict_run = 0
-    if conflict:
-        return "CONFLICT", last_right
     if (
         unavailable > parameters["maximum_missing_samples"]
         or present < parameters["minimum_samples"]
     ):
         return "INDETERMINATE", last_right
+    if conflict:
+        return "CONFLICT", last_right
     return ("MISMATCH" if mismatch else "MATCH"), last_right
 
 
@@ -1279,12 +1292,19 @@ def check_comparators(
             fail("comparator.invalid")
         status = fact["status"]
         expected = {
-            "RAW_ONLY": {"NOT_EVALUATED"},
-            "CANDIDATE": {"MATCH"},
-            "CONFLICTED": {"CONFLICT"},
-            "WITHHELD": {"NOT_EVALUATED", "CONFLICT", "INDETERMINATE"},
+            ("RAW_ONLY", None): {"NOT_EVALUATED"},
+            ("CANDIDATE", None): {"MATCH"},
+            ("CONFLICTED", None): {"MISMATCH", "CONFLICT"},
+            ("WITHHELD", "CONFLICT"): {"CONFLICT"},
+            ("WITHHELD", "NOT_TESTED"): {
+                "NOT_EVALUATED",
+                "INDETERMINATE",
+            },
+            ("WITHHELD", "NO_SIGNAL"): {"NOT_EVALUATED"},
+            ("WITHHELD", "CLOUD_ONLY"): {"NOT_EVALUATED"},
         }
-        if computed not in expected[status]:
+        terminal = fact["terminal_negative_state"]
+        if computed not in expected.get((status, terminal), set()):
             fail("comparator.invalid")
         if status == "CANDIDATE":
             if (
@@ -1294,10 +1314,9 @@ def check_comparators(
                 != _format_decimal(last_right, parameters["rounding"])
             ):
                 fail("comparator.invalid")
-        terminal = fact["terminal_negative_state"]
         if terminal == "CONFLICT" and computed != "CONFLICT":
             fail("comparator.invalid")
-        if terminal in {"NO_SIGNAL", "CLOUD_ONLY", "NOT_TESTED"} and computed != "NOT_EVALUATED":
+        if terminal in {"NO_SIGNAL", "CLOUD_ONLY"} and computed != "NOT_EVALUATED":
             fail("comparator.invalid")
 
 

--- a/tests/test_candidate_fact_graph_contract.py
+++ b/tests/test_candidate_fact_graph_contract.py
@@ -91,6 +91,22 @@ def test_contract_closes_status_identity_comparator_and_retest_fields() -> None:
         assert token in page
 
 
+def test_contract_defines_exact_sampled_outcome_state_matrix() -> None:
+    page = read(PAGE)
+    required_rows = (
+        "`MATCH` | fact | `CANDIDATE` | null | non-empty | value and unit set",
+        "`MISMATCH` | fact | `CONFLICTED` | null | non-empty | null",
+        "`CONFLICT` | fact | `CONFLICTED` | null | non-empty | null",
+        "`CONFLICT` | terminal bundle | `WITHHELD` | `CONFLICT` | non-empty | null",
+        "`INDETERMINATE` | terminal bundle | `WITHHELD` | `NOT_TESTED` | non-empty | null",
+        "`NOT_EVALUATED` | terminal bundle | `WITHHELD` | `NOT_TESTED` | empty | null",
+    )
+    for row in required_rows:
+        assert row in page
+    assert "MISMATCH maps to no terminal state" in page
+    assert "NO_SIGNAL` and `CLOUD_ONLY` are never synthesized" in page
+
+
 def test_machine_schema_and_registry_are_closed() -> None:
     schema = json.loads(read(SCHEMA))
     replay_schema = json.loads(read(REPLAY_SCHEMA))

--- a/tests/test_candidate_fact_graph_executable_contract.py
+++ b/tests/test_candidate_fact_graph_executable_contract.py
@@ -482,9 +482,29 @@ def _comparison_vector(
     draft_unit: str | None = None,
 ) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
     graph = deepcopy(load_json(POSITIVE))
-    left = _artifact("EBUS", "a", "1", left_value, "degC" if left_value else None)
-    right = _artifact("EEBUS", "b", "2", right_value, "degC" if right_value else None)
-    target = graph["facts"][0]
+    left = _artifact("EBUS", "a", "8", left_value, "degC" if left_value else None)
+    right = _artifact("EEBUS", "b", "9", right_value, "degC" if right_value else None)
+    target = next(
+        fact
+        for fact in graph["facts"]
+        if fact["provenance"]["ebus"]
+        and fact["provenance"]["ebus"]["family"] == "B524"
+    )
+    eebus_path = {
+        "service": "service-" + "a" * 32,
+        "entity": "entity-" + "b" * 32,
+        "feature": "feature-" + "c" * 32,
+        "feature_path": [
+            {"kind": "SERVICE", "selector": "service-" + "a" * 32},
+            {"kind": "ENTITY", "selector": "entity-" + "b" * 32},
+            {"kind": "FEATURE", "selector": "feature-" + "c" * 32},
+        ],
+    }
+    left["ebus_identity"] = deepcopy(target["provenance"]["ebus"])
+    right["normalized_evidence"]["data"] = {
+        "services": [{"id": {"digest": eebus_path["service"]}}],
+        "feature_paths": [deepcopy(eebus_path)],
+    }
     target["status"] = status
     target["terminal_negative_state"] = terminal
     target["draft_value"] = draft_value
@@ -497,6 +517,8 @@ def _comparison_vector(
     target["provenance"]["ebus_artifact_id"] = left["artifact_id"]
     target["provenance"]["eebus_source_id"] = right["source_id"]
     target["provenance"]["eebus_artifact_id"] = right["artifact_id"]
+    target["provenance"]["eebus_service"] = eebus_path["service"]
+    target["provenance"]["eebus"] = eebus_path
     target["comparator"] = {
         "draft_id": "NUMERIC_WINDOW_V1_DRAFT",
         "samples": [
@@ -510,7 +532,26 @@ def _comparison_vector(
         ],
         "outcome": outcome,
     }
-    source = {"artifacts": [left, right]}
+    source = deepcopy(load_json(SOURCE_BUNDLE))
+    source["sources"].extend(
+        [
+            {
+                "source_id": left["source_id"],
+                "source_kind": "EBUS",
+                "artifact_ids": [left["artifact_id"]],
+            },
+            {
+                "source_id": right["source_id"],
+                "source_kind": "EEBUS",
+                "artifact_ids": [right["artifact_id"]],
+            },
+        ]
+    )
+    source["artifacts"].extend([left, right])
+    source["evidence_refs"].extend(
+        [deepcopy(left["evidence_refs"][0]), deepcopy(right["evidence_refs"][0])]
+    )
+    graph["source_bundle"]["evidence_refs"] = deepcopy(source["evidence_refs"])
     return graph, target, source
 
 
@@ -518,11 +559,13 @@ def _validate_comparison_vector(
     module, graph: dict[str, object], target: dict[str, object], source: dict[str, object]
 ) -> None:
     registry = load_json(REGISTRY)
-    artifacts = {
-        (artifact["source_id"], artifact["artifact_id"]): artifact
-        for artifact in source["artifacts"]
-    }
-    module._check_sample_provenance(target, artifacts)
+    module.check_provenance(
+        graph,
+        registry,
+        source,
+        load_json(SOURCE_REPLAY),
+    )
+    module.check_identities(graph, source)
     module.check_states(graph, registry)
     module.check_comparators(graph, registry, source)
 
@@ -731,6 +774,32 @@ def test_evaluator_derives_missing_and_excludes_it_from_minimum_samples() -> Non
     parameters["maximum_missing_samples"] = 1
     missing = _sample(left, right, state="MISSING")
     assert _evaluate(parameters, [missing], [left, right]) == "INDETERMINATE"
+
+
+def test_failed_availability_bounds_precede_conflict_classification() -> None:
+    left = _artifact("EBUS", "a", "1", "10", "degC")
+    unavailable_left = _artifact("EBUS", "c", "3", None, None)
+    right = _artifact("EEBUS", "b", "2", "11", "degC")
+    parameters = _parameters()
+    parameters["minimum_samples"] = 1
+    parameters["maximum_missing_samples"] = 0
+    parameters["conflict_threshold"] = {
+        "absolute_decimal": "1",
+        "consecutive_samples": 1,
+    }
+    samples = [
+        _sample(left, right, offset_ns=4_000_000_000),
+        _sample(
+            unavailable_left,
+            right,
+            offset_ns=5_000_000_000,
+            state="MISSING",
+        ),
+    ]
+    assert (
+        _evaluate(parameters, samples, [left, unavailable_left, right])
+        == "INDETERMINATE"
+    )
 
 
 def test_evaluator_resets_conflict_run_on_below_threshold_sample() -> None:

--- a/tests/test_candidate_fact_graph_executable_contract.py
+++ b/tests/test_candidate_fact_graph_executable_contract.py
@@ -469,6 +469,196 @@ def _evaluate(
     return module._evaluate_numeric_window(parameters, samples, index)
 
 
+def _comparison_vector(
+    *,
+    status: str,
+    terminal: str | None,
+    outcome: str,
+    left_value: str | None,
+    right_value: str | None,
+    sample_state: str,
+    sample_count: int,
+    draft_value: str | None = None,
+    draft_unit: str | None = None,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    graph = deepcopy(load_json(POSITIVE))
+    left = _artifact("EBUS", "a", "1", left_value, "degC" if left_value else None)
+    right = _artifact("EEBUS", "b", "2", right_value, "degC" if right_value else None)
+    target = graph["facts"][0]
+    target["status"] = status
+    target["terminal_negative_state"] = terminal
+    target["draft_value"] = draft_value
+    target["draft_unit"] = draft_unit
+    target["provenance"]["native_evidence_refs"] = [
+        deepcopy(left["evidence_refs"][0]),
+        deepcopy(right["evidence_refs"][0]),
+    ]
+    target["provenance"]["ebus_source_id"] = left["source_id"]
+    target["provenance"]["ebus_artifact_id"] = left["artifact_id"]
+    target["provenance"]["eebus_source_id"] = right["source_id"]
+    target["provenance"]["eebus_artifact_id"] = right["artifact_id"]
+    target["comparator"] = {
+        "draft_id": "NUMERIC_WINDOW_V1_DRAFT",
+        "samples": [
+            _sample(
+                left,
+                right,
+                offset_ns=3_000_000_000 + index,
+                state=sample_state,
+            )
+            for index in range(sample_count)
+        ],
+        "outcome": outcome,
+    }
+    source = {"artifacts": [left, right]}
+    return graph, target, source
+
+
+def _validate_comparison_vector(
+    module, graph: dict[str, object], target: dict[str, object], source: dict[str, object]
+) -> None:
+    registry = load_json(REGISTRY)
+    artifacts = {
+        (artifact["source_id"], artifact["artifact_id"]): artifact
+        for artifact in source["artifacts"]
+    }
+    module._check_sample_provenance(target, artifacts)
+    module.check_states(graph, registry)
+    module.check_comparators(graph, registry, source)
+
+
+@pytest.mark.parametrize(
+    (
+        "status",
+        "terminal",
+        "outcome",
+        "left_value",
+        "right_value",
+        "sample_state",
+        "sample_count",
+        "draft_value",
+        "draft_unit",
+    ),
+    (
+        ("CANDIDATE", None, "MATCH", "10", "10", "PRESENT", 2, "10.0", "degC"),
+        ("CONFLICTED", None, "MISMATCH", "10", "10.5", "PRESENT", 2, None, None),
+        ("CONFLICTED", None, "CONFLICT", "10", "11", "PRESENT", 2, None, None),
+        ("WITHHELD", "CONFLICT", "CONFLICT", "10", "11", "PRESENT", 2, None, None),
+        (
+            "WITHHELD",
+            "NOT_TESTED",
+            "INDETERMINATE",
+            None,
+            "10",
+            "MISSING",
+            2,
+            None,
+            None,
+        ),
+        ("WITHHELD", "NOT_TESTED", "NOT_EVALUATED", "10", "10", "PRESENT", 0, None, None),
+    ),
+)
+def test_integrated_fully_bound_vectors_accept_exact_outcome_state_matrix(
+    status: str,
+    terminal: str | None,
+    outcome: str,
+    left_value: str | None,
+    right_value: str | None,
+    sample_state: str,
+    sample_count: int,
+    draft_value: str | None,
+    draft_unit: str | None,
+) -> None:
+    module = load_validator_module()
+    graph, target, source = _comparison_vector(
+        status=status,
+        terminal=terminal,
+        outcome=outcome,
+        left_value=left_value,
+        right_value=right_value,
+        sample_state=sample_state,
+        sample_count=sample_count,
+        draft_value=draft_value,
+        draft_unit=draft_unit,
+    )
+    _validate_comparison_vector(module, graph, target, source)
+
+
+@pytest.mark.parametrize(
+    ("status", "terminal", "outcome", "left_value", "right_value", "state"),
+    (
+        ("WITHHELD", "CONFLICT", "MISMATCH", "10", "10.5", "PRESENT"),
+        ("CONFLICTED", None, "INDETERMINATE", None, "10", "MISSING"),
+    ),
+)
+def test_swapped_sampled_outcome_mappings_are_rejected(
+    status: str,
+    terminal: str | None,
+    outcome: str,
+    left_value: str | None,
+    right_value: str | None,
+    state: str,
+) -> None:
+    module = load_validator_module()
+    graph, target, source = _comparison_vector(
+        status=status,
+        terminal=terminal,
+        outcome=outcome,
+        left_value=left_value,
+        right_value=right_value,
+        sample_state=state,
+        sample_count=2,
+    )
+    with pytest.raises(module.Failure):
+        _validate_comparison_vector(module, graph, target, source)
+
+
+def test_sampled_outcomes_reject_empty_samples_and_non_null_draft() -> None:
+    module = load_validator_module()
+    empty_graph, empty_target, empty_source = _comparison_vector(
+        status="CONFLICTED",
+        terminal=None,
+        outcome="MISMATCH",
+        left_value="10",
+        right_value="10.5",
+        sample_state="PRESENT",
+        sample_count=0,
+    )
+    with pytest.raises(module.Failure):
+        _validate_comparison_vector(module, empty_graph, empty_target, empty_source)
+
+    draft_graph, draft_target, draft_source = _comparison_vector(
+        status="CONFLICTED",
+        terminal=None,
+        outcome="MISMATCH",
+        left_value="10",
+        right_value="10.5",
+        sample_state="PRESENT",
+        sample_count=2,
+        draft_value="10.5",
+        draft_unit="degC",
+    )
+    with pytest.raises(module.Failure):
+        _validate_comparison_vector(module, draft_graph, draft_target, draft_source)
+
+
+def test_sampled_outcome_rejects_incomplete_direct_provenance() -> None:
+    module = load_validator_module()
+    graph, target, source = _comparison_vector(
+        status="CONFLICTED",
+        terminal=None,
+        outcome="MISMATCH",
+        left_value="10",
+        right_value="10.5",
+        sample_state="PRESENT",
+        sample_count=2,
+    )
+    target["provenance"]["native_evidence_refs"].pop()
+    with pytest.raises(module.Failure) as error:
+        _validate_comparison_vector(module, graph, target, source)
+    assert str(error.value) == "provenance.binding"
+
+
 def test_evaluator_uses_exact_absolute_plus_relative_tolerance_boundary() -> None:
     left = _artifact("EBUS", "a", "1", "10", "degC")
     right = _artifact("EEBUS", "b", "2", "10.3", "degC")


### PR DESCRIPTION
## Summary
- define and enforce the exact candidate-only mapping for sampled comparator outcomes
- require complete direct cross-runtime provenance for every sampled comparison
- classify failed availability/minimum bounds as INDETERMINATE before conflict or mismatch
- keep the terminal vocabulary, schema, registry, canonical positive graph, and replay hashes unchanged

Closes #363

## Strict TDD evidence
- RED commit: `8f07ff8b41655bede107af02cfb68696bc940b16` (tests only)
- Local focused RED: `61 passed, 3 failed`
- External RED: Actions run `29705232660`; combined-ref passed and Docs Checks failed only at the new missing matrix contract test
- GREEN validated head: `c427a0b09ed89ed4361c1ae38725ab28b49063de`
- Squash merge: `ea88fef23ecb154b08f70e7f94b36e1738ed08bf`

## Verification
- Focused: `PATH=/tmp/helianthus-msp07-bin:$PATH python3 -m pytest -q tests/test_candidate_fact_graph_contract.py tests/test_candidate_fact_graph_executable_contract.py` -> `65 passed`
- Full: `PATH=/tmp/helianthus-msp07-bin:$PATH ./scripts/ci_local.sh` -> pass; candidate groups `6 passed` and `59 passed`, platform suite `385 passed, 10 deselected`
- `git diff --check` -> pass
- Exact-head Actions run `29705497996`: 2/2 passed
- Post-main Actions run `29705558831`: 2/2 passed
- Validated-head tree equals merge tree: `7a22395b5d894de00db0cae167c45d475e31a103`

## Boundaries
Candidate/raw-debug documentation only. No promotion, stable semantics, GraphQL, MCP stable output, Portal, Home Assistant, command exposure, or protocol translation.