### PR TITLE
ci: repin Modbus trust workflow

### DIFF
--- a/.github/workflows/modbus-trusted-revision.yml
+++ b/.github/workflows/modbus-trusted-revision.yml
@@ -11,7 +11,7 @@
             "clean": true,
             "path": "anchor",
             "persist-credentials": false,
-            "ref": "d6cfed15e75482fb75e630d38b664fdf0e1f8a43",
+            "ref": "5e0674e7514b038418eae6a10beca4632751860b",
             "repository": "Project-Helianthus/helianthus-execution-plans"
           }
         },
@@ -43,12 +43,12 @@
             "UNTRUSTED_HEAD_SHA": "${{ github.event.pull_request.head.sha }}"
           },
           "name": "Verify immutable checkout identities",
-          "run": "set -euo pipefail\ntest \"$(git -C anchor rev-parse HEAD)\" = \"d6cfed15e75482fb75e630d38b664fdf0e1f8a43\"\ntest \"$(git -C prior rev-parse HEAD)\" = \"${TRUSTED_BASE_SHA}\"\ntest \"$(git -C current rev-parse HEAD)\" = \"${UNTRUSTED_HEAD_SHA}\"",
+          "run": "set -euo pipefail\ntest \"$(git -C anchor rev-parse HEAD)\" = \"5e0674e7514b038418eae6a10beca4632751860b\"\ntest \"$(git -C prior rev-parse HEAD)\" = \"${TRUSTED_BASE_SHA}\"\ntest \"$(git -C current rev-parse HEAD)\" = \"${UNTRUSTED_HEAD_SHA}\"",
           "shell": "bash"
         },
         {
           "name": "Validate Modbus revision transition with immutable anchor",
-          "run": "python3 anchor/scripts/validate_modbus_docs_trust.py --prior-root prior --current-root current --trust-anchor-sha d6cfed15e75482fb75e630d38b664fdf0e1f8a43",
+          "run": "python3 anchor/scripts/validate_modbus_docs_trust.py --prior-root prior --current-root current --trust-anchor-sha 5e0674e7514b038418eae6a10beca4632751860b",
           "shell": "bash"
         }
       ]


### PR DESCRIPTION
## What
Repin the base-owned `Modbus Trusted Revision` workflow from anchor `d6cfed15…` to independently reviewed anchor `5e0674e7514b038418eae6a10beca4632751860b`.

## Why
The new anchor freezes the sanitized consumer-lock Git identity checks and updates M1 evidence to replacement docs PR #376. The old required check must reject this workflow mutation by design; migration therefore requires an audited administrator merge after all non-old-anchor checks and fresh adversarial review pass.

## Acceptance Criteria
- [x] Workflow-only diff
- [x] Canonical JSON exactly equals `expected_workflow(5e0674e...)`
- [x] Anchor is execution-plans main and validator digest is `3e3bdb689971688702014839cf96f907f1b8fbf591bda1a36fcfe0d2265e9cbb`
- [x] Full local Docs CI green
- [x] `actionlint` green
- [ ] Hosted Docs CI green
- [ ] Old Modbus required check fails closed as expected
- [ ] Fresh adversarial review returns NO_FINDINGS

## Dependencies
- execution-plans #78 merged
- docs #376 temporarily closed without force-push

After merge, #376 will be reopened and updated by normal merge from main.