### PR TITLE
ci: repin Modbus trust workflow

### DIFF
--- a/.github/workflows/modbus-trusted-revision.yml
+++ b/.github/workflows/modbus-trusted-revision.yml
@@ -11,7 +11,7 @@
             "clean": true,
             "path": "anchor",
             "persist-credentials": false,
-            "ref": "5e0674e7514b038418eae6a10beca4632751860b",
+            "ref": "af75995c1587589906213eebc732f9fa317f6787",
             "repository": "Project-Helianthus/helianthus-execution-plans"
           }
         },
@@ -43,12 +43,12 @@
             "UNTRUSTED_HEAD_SHA": "${{ github.event.pull_request.head.sha }}"
           },
           "name": "Verify immutable checkout identities",
-          "run": "set -euo pipefail\ntest \"$(git -C anchor rev-parse HEAD)\" = \"5e0674e7514b038418eae6a10beca4632751860b\"\ntest \"$(git -C prior rev-parse HEAD)\" = \"${TRUSTED_BASE_SHA}\"\ntest \"$(git -C current rev-parse HEAD)\" = \"${UNTRUSTED_HEAD_SHA}\"",
+          "run": "set -euo pipefail\ntest \"$(git -C anchor rev-parse HEAD)\" = \"af75995c1587589906213eebc732f9fa317f6787\"\ntest \"$(git -C prior rev-parse HEAD)\" = \"${TRUSTED_BASE_SHA}\"\ntest \"$(git -C current rev-parse HEAD)\" = \"${UNTRUSTED_HEAD_SHA}\"",
           "shell": "bash"
         },
         {
           "name": "Validate Modbus revision transition with immutable anchor",
-          "run": "python3 anchor/scripts/validate_modbus_docs_trust.py --prior-root prior --current-root current --trust-anchor-sha 5e0674e7514b038418eae6a10beca4632751860b",
+          "run": "python3 anchor/scripts/validate_modbus_docs_trust.py --prior-root prior --current-root current --trust-anchor-sha af75995c1587589906213eebc732f9fa317f6787",
           "shell": "bash"
         }
       ]


### PR DESCRIPTION
## What
Repin the base-owned `Modbus Trusted Revision` workflow to immutable execution-plans trust anchor `af75995c1587589906213eebc732f9fa317f6787`.

## Why
The anchor now validates consumer-lock worktrees against the actual HEAD tree, closing local Git metadata bypasses before docs contract PR #376 is reopened.

## Acceptance Criteria
- [x] Workflow equals the anchor validator generated workflow byte-for-byte after parsing
- [x] `actionlint` passes
- [x] Full local docs CI passes: 385 primary tests plus all focused suites
- [ ] Hosted Docs checks green except the deliberately stale prior-anchor required check
- [ ] Fresh adversarial review returns `NO_FINDINGS`

## Dependencies
- Depends on Project-Helianthus/helianthus-execution-plans#79 (merged as `af75995c1587589906213eebc732f9fa317f6787`)
- Blocks reopening Project-Helianthus/helianthus-docs-ebus#376

This is an audited workflow-only anchor migration. The currently required old-anchor check is expected to reject the SHA change; merge therefore requires the repository-admin bypass after all independent checks and review pass.