### PR TITLE
docs: verify Modbus trusted revision gate

### DIFF
--- a/docs/platform/modbus-multivendor-boundaries.md
+++ b/docs/platform/modbus-multivendor-boundaries.md
@@ -237,5 +237,12 @@ Each implementation PR must:
 - pass the repository CI and all applicable doc, protocol-interoperability,
   licensing, security, and adversarial review gates.
 
+Changes in the Modbus companion surface are additionally checked by the
+required `Modbus Trusted Revision` status. That check executes the base-owned
+workflow under `pull_request_target`, checks out the proposed head only as
+untrusted data, and validates the transition with the immutable external anchor
+recorded in the companion manifest. The protected workflow and validators must
+not be executed from the proposed head.
+
 Any proposed gateway composition or private binding change is outside this
 pre-gateway contract and requires its own execution authorization.


### PR DESCRIPTION
## What
Document the base-owned execution boundary of the required `Modbus Trusted Revision` check.

## Why
This post-bootstrap PR provides immutable hosted evidence that the required check installed by #376 executes successfully from the protected base workflow and external anchor.

## Acceptance Criteria
- [x] Exact external anchor validation passes locally: `modbus_docs_trust_ok`
- [x] Full local docs CI passes
- [ ] Required hosted `Modbus Trusted Revision` check succeeds on the exact PR head
- [ ] Independent hosted Docs checks succeed
- [ ] Fresh adversarial review returns `NO_FINDINGS`
- [ ] PR is merged before M1 admission opens

## Dependencies
- Depends on #376 merged as `711a556fee344c6fe7f1ecf3253fcdb3f5f22d06`