### PR TITLE
FMV3-M3-01: align unknown skip with deferred ranges

### DIFF
--- a/docs/platform/fixtures/fronius-sunspec-phase1/v1/positive/inverter-103-unknown-skip.json
+++ b/docs/platform/fixtures/fronius-sunspec-phase1/v1/positive/inverter-103-unknown-skip.json
@@ -3,13 +3,13 @@
   "kind": "positive",
   "provenance": {"synthetic": true, "license": "AGPL-3.0", "capture": "not_a_live_capture", "identity": "fixture-placeholder"},
   "model": {"model_id": 103, "length_words": 50},
-  "logical_words": [21365,28243,103,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,777,3,0,0,0,65535,0],
+  "logical_words": [21365,28243,103,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,666,3,0,0,0,65535,0],
   "logical_word_examples": [
     {"field": "W", "type": "int16", "words": [65526], "expected_raw": -10},
     {"field": "WH", "type": "acc32", "words": [0, 4660], "word_order": "high_word_first", "expected_raw": 4660},
     {"field": "W_SF", "type": "sunssf", "words": [65534], "expected_scale_exponent": -2},
     {"field": "WH_SF", "type": "sunssf", "words": [0], "expected_scale_exponent": 0}
   ],
-  "following_unknown_model": {"model_id": 777, "length_words": 3, "header_offset_words": 54, "expected": "structural_skip_only"},
+  "following_unknown_model": {"model_id": 666, "length_words": 3, "header_offset_words": 54, "expected": "structural_skip_only"},
   "expected": {"scaled_w": -0.1, "scaled_wh": 4660, "unknown_model_has_no_semantic_publication": true}
 }

--- a/tests/test_fronius_sunspec_phase1_contract.py
+++ b/tests/test_fronius_sunspec_phase1_contract.py
@@ -438,7 +438,7 @@ def test_synthetic_values_exercise_standard_decode_rules() -> None:
     assert model_103_chain_error is None
     assert model_103_chain == [
         {"model_id": 103, "length_words": 50, "header_offset_words": 2},
-        {"model_id": 777, "length_words": 3, "header_offset_words": 54},
+        {"model_id": 666, "length_words": 3, "header_offset_words": 54},
         {"model_id": 0xFFFF, "length_words": 0, "header_offset_words": 59},
     ]
     assert model_103_chain[1] == {
@@ -446,6 +446,11 @@ def test_synthetic_values_exercise_standard_decode_rules() -> None:
         for key in ("model_id", "length_words", "header_offset_words")
     }
     assert model_103["following_unknown_model"]["expected"] == "structural_skip_only"
+    unknown_id = model_103["following_unknown_model"]["model_id"]
+    assert unknown_id not in {111, 112, 113, 160}
+    assert not 120 <= unknown_id <= 124
+    assert not 200 <= unknown_id <= 219
+    assert not 700 <= unknown_id <= 799
     context = model_102["observation_context"]
     required_context = {
         "profile_version",


### PR DESCRIPTION
## What

Correct the M3-01 synthetic unknown-model fixture so it no longer contradicts the manifest's deferred 7xx range.

Closes #399.

## Change

- Replace synthetic unknown model 777 with non-deferred model 666 in both raw logical words and fixture metadata.
- Assert the unknown-skip model stays outside every explicit deferred range: 111-113, 120-124, 160, 200-219, and 700-799.
- Preserve model lengths, offsets, end sentinel, supported-model set, and all provenance/licensing facts.

## Validation

- Focused contract: 6 passed.
- JSON parse: PASS.
- git diff --check: PASS.
- Full hosted docs gates and fresh exact-HEAD review pending.

## Scope

Synthetic fixture consistency only. No product/vendor qualification, transport, gateway, live-device, write/control, or M4 changes.