### PR TITLE
MSP-08: make the evidence scope call boundary read-only

### DIFF
--- a/docs/platform/multi-runtime-coexistence-no-drift-v1.md
+++ b/docs/platform/multi-runtime-coexistence-no-drift-v1.md
@@ -150,15 +150,22 @@ Each source manifest has contract
 `projection_policy=M8_PROTECTED_VIEWS_SINGLE_WINDOW_V1`, and binds the
 effective auth-scope hash, PRE/POST phase, process instance, distinct window ID,
 capture interval, and source timestamp. Its sixteen ordered inputs cover the
-complete tool inventory visible at the effective read-only M8 test scope,
+complete stable tool inventory visible at the effective read-only M8 test scope,
 complete single-window eBUS responses, the eBUS debug view, owner-UNIX eeBUS
 state inputs, GraphQL, Portal, command routing, semantic registry, container
 identity, and capture timestamp with the exact auth boundary, byte length, and
 SHA-256 of each source. The tool inventory must equal the frozen two `ebus.v1`
-plus nine `eebus.v1` read-only tools in canonical order; an extra write tool,
+plus nine stable `eebus.v1` tools in canonical order; an extra write tool,
 experimental tool, V2 tool, duplicate, omission, reordering, or paginated
 continuation fails closed. The capture is valid only when `tools/list` proves
 the complete effective-scope inventory in one terminal response.
+Inventory visibility does not grant call authority. The M8 scope may call only
+the two eBUS observation tools and the seven eeBUS observation tools. The
+stable lifecycle tools `eebus.v1.snapshot.capture` and
+`eebus.v1.snapshot.drop` remain visible so contract drift is detectable, but a
+`tools/call` request for either must fail before snapshot-store creation,
+lookup, or deletion. In particular, `snapshot.drop` cannot destroy evidence
+through the read-only scope.
 Private verification opens every source as a bounded regular file from a
 fixed-name, no-symlink root, rejects devices such as FIFOs, recomputes every
 binding, derives all eleven protected views with the closed reference projector,

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -180,6 +180,19 @@ def test_msp08_inventory_matches_the_complete_stable_v1_contract() -> None:
     ]
 
 
+def test_msp08_read_only_scope_separates_inventory_from_call_authority() -> None:
+    page = " ".join(PAGE.read_text(encoding="utf-8").split())
+
+    for phrase in (
+        "Inventory visibility does not grant call authority.",
+        "seven eeBUS observation tools",
+        "`eebus.v1.snapshot.capture`",
+        "`eebus.v1.snapshot.drop`",
+        "must fail before snapshot-store creation, lookup, or deletion",
+    ):
+        assert phrase in page
+
+
 def test_msp08_machine_contract_matches_verifier_precedence_and_limits() -> None:
     validator = validator_module()
     registry = load(REGISTRY)


### PR DESCRIPTION
## Summary
- preserve the complete stable 2+9 MCP inventory for drift detection
- define only 2 eBUS + 7 eeBUS observational tools as callable in M8
- require eeBUS snapshot capture/drop to fail before store mutation
- add a focused contract regression

## Validation
- `python3 -m pytest -q tests/test_multi_runtime_live_coexistence_contract.py` (188 passed)
- `git diff --check`

Refs #409

This is the documentation gate for gateway PR #789; it does not publish the final live campaign or close #409.