### PR TITLE
MSP-08: project confirmed eBUS source identities

### DIFF
--- a/docs/platform/multi-runtime-coexistence-no-drift-v1.md
+++ b/docs/platform/multi-runtime-coexistence-no-drift-v1.md
@@ -183,11 +183,16 @@ evaluated. The protected payloads must be produced independently before
 equality is tested.
 
 PRE and POST source windows require different manifest digests regardless of
-their claimed byte lengths. Source device rows are all-or-reject: a malformed
-address or missing identity cannot be omitted from the projection. Household
-zone labels are deterministic public pseudonyms, never copied from the private
-MCP or GraphQL source; source device IDs and model labels are separately
-pseudonymized. Before return, the complete projected view tree is checked for
+their claimed byte lengths. Every source device row remains bound in the raw
+private root and manifest. The stable identity projection selects only rows
+whose runtime state is `identity_confirmed` and whose manufacturer and device
+ID are complete. Incomplete passive observations such as
+`corroborated_pending` addresses are retained as raw evidence but are not
+promoted into a stable device identity. A malformed address, a confirmed row
+with missing identity, or a window with no complete confirmed identity fails
+closed. Household zone labels are deterministic public pseudonyms, never
+copied from the private MCP or GraphQL source; source device IDs and model
+labels are separately pseudonymized. Before return, the complete projected view tree is checked for
 unconsumed decimals, so a fractional pass-through field fails with
 `provenance.source_capture` rather than reaching canonical serialization.
 Capture timestamps are derived exactly from the UTC wall anchor plus the

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1531,12 +1531,21 @@ def _source_reject_unprojected_decimals(value: Any) -> None:
             _source_reject_unprojected_decimals(item)
 
 
+SOURCE_DISCOVERY_STATES = frozenset(
+    {"passive_observed", "static_seed", "active_confirmed"}
+)
+SOURCE_VERIFICATION_STATES = frozenset(
+    {"candidate", "corroborated_pending", "identity_confirmed"}
+)
+
+
 def _source_device_projection(item: dict[str, Any]) -> dict[str, Any] | None:
     if not isinstance(item, dict):
         fail("provenance.source_capture")
     address = item.get("address")
     device_id = item.get("device_id")
     manufacturer = item.get("manufacturer")
+    discovery_source = item.get("discovery_source")
     verification_state = item.get("verification_state")
     if (
         not isinstance(address, int)
@@ -1544,7 +1553,13 @@ def _source_device_projection(item: dict[str, Any]) -> dict[str, Any] | None:
         or not 0 <= address <= 255
         or not isinstance(device_id, str)
         or not isinstance(manufacturer, str)
-        or not isinstance(verification_state, str)
+    ):
+        fail("provenance.source_capture")
+    if discovery_source is None and verification_state is None:
+        return None
+    if (
+        discovery_source not in SOURCE_DISCOVERY_STATES
+        or verification_state not in SOURCE_VERIFICATION_STATES
     ):
         fail("provenance.source_capture")
     if verification_state != "identity_confirmed":
@@ -1556,7 +1571,7 @@ def _source_device_projection(item: dict[str, Any]) -> dict[str, Any] | None:
         "device_id": _source_redacted(f"ebus-device:{address}:{device_id}"),
         "manufacturer": manufacturer,
         "model": _source_redacted(f"ebus-model:{device_id}"),
-        "discovery_source": item.get("discovery_source") or "unknown",
+        "discovery_source": discovery_source,
         "verification_state": verification_state,
     }
 
@@ -1630,6 +1645,25 @@ def _source_graphql_values(raw: dict[str, Any]) -> dict[str, Any]:
             "source": "ebus",
             "operating_mode": data["dhw"]["config"]["operatingMode"],
         },
+    }
+
+
+def _source_portal(raw: dict[str, Any]) -> dict[str, Any]:
+    capabilities = raw.get("capabilities")
+    ui_version = raw.get("ui_version")
+    if (
+        not isinstance(capabilities, dict)
+        or not capabilities
+        or any(not isinstance(value, bool) for value in capabilities.values())
+        or not isinstance(ui_version, str)
+        or not ui_version
+    ):
+        fail("provenance.source_capture")
+    return {
+        "default_protocol": "ebus",
+        "sections": ["devices", "zones", "dhw", "energy"],
+        "enabled_capability_count": sum(capabilities.values()),
+        "ui_version": ui_version,
     }
 
 
@@ -1748,7 +1782,7 @@ def _source_project_views(inputs: dict[str, bytes]) -> dict[str, Any]:
             "ha.graphql.values": ha_values,
             "ha.identity": ha_identity,
             "debug.ebus": debug_raw,
-            "portal.ebus.bootstrap": portal_raw,
+            "portal.ebus.bootstrap": _source_portal(portal_raw),
             "command.routing": routes_raw,
             "semantic.registry": semantic_registry_raw,
             "mcp.eebus.v1.contract": {

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1655,15 +1655,14 @@ def _source_portal(raw: dict[str, Any]) -> dict[str, Any]:
         not isinstance(capabilities, dict)
         or not capabilities
         or any(not isinstance(value, bool) for value in capabilities.values())
-        or not isinstance(ui_version, str)
-        or not ui_version
+        or ui_version != "m0"
     ):
         fail("provenance.source_capture")
     return {
         "default_protocol": "ebus",
         "sections": ["devices", "zones", "dhw", "energy"],
         "enabled_capability_count": sum(capabilities.values()),
-        "ui_version": ui_version,
+        "ui_version": "m0",
     }
 
 

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1531,21 +1531,25 @@ def _source_reject_unprojected_decimals(value: Any) -> None:
             _source_reject_unprojected_decimals(item)
 
 
-def _source_device_projection(item: dict[str, Any]) -> dict[str, Any]:
+def _source_device_projection(item: dict[str, Any]) -> dict[str, Any] | None:
     if not isinstance(item, dict):
         fail("provenance.source_capture")
     address = item.get("address")
     device_id = item.get("device_id")
     manufacturer = item.get("manufacturer")
+    verification_state = item.get("verification_state")
     if (
         not isinstance(address, int)
         or isinstance(address, bool)
         or not 0 <= address <= 255
         or not isinstance(device_id, str)
-        or not device_id
         or not isinstance(manufacturer, str)
-        or not manufacturer
+        or not isinstance(verification_state, str)
     ):
+        fail("provenance.source_capture")
+    if verification_state != "identity_confirmed":
+        return None
+    if not device_id or not manufacturer:
         fail("provenance.source_capture")
     return {
         "address": _source_redacted(f"ebus-address:{address}"),
@@ -1553,7 +1557,7 @@ def _source_device_projection(item: dict[str, Any]) -> dict[str, Any]:
         "manufacturer": manufacturer,
         "model": _source_redacted(f"ebus-model:{device_id}"),
         "discovery_source": item.get("discovery_source") or "unknown",
-        "verification_state": item.get("verification_state") or "unknown",
+        "verification_state": verification_state,
     }
 
 
@@ -1666,9 +1670,11 @@ def _source_project_views(inputs: dict[str, bytes]) -> dict[str, Any]:
         source_devices = devices_response["data"]
         if not isinstance(source_devices, list):
             fail("provenance.source_capture")
-        devices = [_source_device_projection(item) for item in source_devices]
-        if len(devices) != len(source_devices):
-            fail("provenance.source_capture")
+        devices = [
+            projected
+            for item in source_devices
+            if (projected := _source_device_projection(item)) is not None
+        ]
         devices.sort(key=lambda item: item["address"])
         if not devices:
             fail("provenance.source_capture")
@@ -1724,7 +1730,7 @@ def _source_project_views(inputs: dict[str, bytes]) -> dict[str, Any]:
                         "operation": "ebus.v1.registry.devices.list",
                         "result": {
                             "selection": {
-                                "criteria": "all_structurally_identified_devices_in_single_window",
+                                "criteria": "complete_identity_confirmed_devices_in_single_window",
                                 "selected_count": len(devices),
                             },
                             "devices": devices,

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -695,7 +695,7 @@ def source_payloads(
         ),
         "graphql.values": validator.canonical(graph_values),
         "portal.bootstrap": validator.canonical(
-            {"capabilities": {"devices": True, "zones": True}, "ui_version": "test-v1"}
+            {"capabilities": {"devices": True, "zones": True}, "ui_version": "m0"}
         ),
         "command.routing": validator.canonical(routes),
         "semantic.registry": validator.canonical(semantic_registry),
@@ -1208,10 +1208,20 @@ def test_msp08_source_projection_reduces_portal_bootstrap_to_public_summary() ->
         "default_protocol": "ebus",
         "sections": ["devices", "zones", "dhw", "energy"],
         "enabled_capability_count": 2,
-        "ui_version": "test-v1",
+        "ui_version": "m0",
     }
     assert "endpoints" not in portal
     assert not validator._contains_public_secret(portal)
+
+
+def test_msp08_source_projection_rejects_uncontracted_portal_version() -> None:
+    validator = validator_module()
+
+    with pytest.raises(Exception) as error:
+        validator._source_portal(
+            {"capabilities": {"devices": True}, "ui_version": "resident-name"}
+        )
+    assert str(error.value) == "provenance.source_capture"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1147,6 +1147,64 @@ def test_msp08_private_window_rejects_unprojectable_source_device(
     assert str(error.value) == "provenance.source_capture"
 
 
+def test_msp08_source_projection_retains_passive_incomplete_devices_only_in_raw_input() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    envelope = json.loads(payloads["ebus.devices"])
+    inner = json.loads(envelope["result"]["content"][0]["text"])
+    inner["data"].append(
+        {
+            "address": 3,
+            "manufacturer": "",
+            "device_id": "",
+            "discovery_source": "passive_observed",
+            "verification_state": "corroborated_pending",
+        }
+    )
+    envelope["result"]["content"][0]["text"] = validator.canonical(inner).decode(
+        "utf-8"
+    )
+    payloads["ebus.devices"] = validator.canonical(envelope)
+
+    projected = validator._source_project_views(payloads)
+    devices = projected["views"]["mcp.ebus.v1.responses"]["responses"][0][
+        "result"
+    ]
+    assert devices["selection"] == {
+        "criteria": "complete_identity_confirmed_devices_in_single_window",
+        "selected_count": 2,
+    }
+    assert len(devices["devices"]) == 2
+
+
+@pytest.mark.parametrize("confirmed_count", [0, 1])
+def test_msp08_source_projection_rejects_missing_confirmed_identity(
+    confirmed_count: int,
+) -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    envelope = json.loads(payloads["ebus.devices"])
+    inner = json.loads(envelope["result"]["content"][0]["text"])
+    if confirmed_count == 0:
+        for item in inner["data"]:
+            item.update(
+                manufacturer="",
+                device_id="",
+                discovery_source="passive_observed",
+                verification_state="corroborated_pending",
+            )
+    else:
+        inner["data"][0]["device_id"] = ""
+    envelope["result"]["content"][0]["text"] = validator.canonical(inner).decode(
+        "utf-8"
+    )
+    payloads["ebus.devices"] = validator.canonical(envelope)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
+
+
 def test_msp08_private_runtime_accepts_nanosecond_window_offset(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1175,6 +1175,69 @@ def test_msp08_source_projection_retains_passive_incomplete_devices_only_in_raw_
         "selected_count": 2,
     }
     assert len(devices["devices"]) == 2
+    assert len(projected["views"]["ha.identity"]["devices"]) == 2
+
+
+def test_msp08_source_projection_retains_unlabelled_no_slot_device_only_in_raw_input() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    envelope = json.loads(payloads["ebus.devices"])
+    inner = json.loads(envelope["result"]["content"][0]["text"])
+    inner["data"].append({"address": 3, "manufacturer": "", "device_id": ""})
+    envelope["result"]["content"][0]["text"] = validator.canonical(inner).decode(
+        "utf-8"
+    )
+    payloads["ebus.devices"] = validator.canonical(envelope)
+
+    projected = validator._source_project_views(payloads)
+    mcp_devices = projected["views"]["mcp.ebus.v1.responses"]["responses"][0][
+        "result"
+    ]["devices"]
+    ha_devices = projected["views"]["ha.identity"]["devices"]
+    assert len(mcp_devices) == 2
+    assert len(ha_devices) == 2
+
+
+def test_msp08_source_projection_reduces_portal_bootstrap_to_public_summary() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    projected = validator._source_project_views(payloads)
+    portal = projected["views"]["portal.ebus.bootstrap"]
+
+    assert portal == {
+        "default_protocol": "ebus",
+        "sections": ["devices", "zones", "dhw", "energy"],
+        "enabled_capability_count": 2,
+        "ui_version": "test-v1",
+    }
+    assert "endpoints" not in portal
+    assert not validator._contains_public_secret(portal)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("discovery_source", "unexpected_source"),
+        ("verification_state", "unexpected_state"),
+    ],
+)
+def test_msp08_source_projection_rejects_unknown_device_state(
+    field: str,
+    value: str,
+) -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    envelope = json.loads(payloads["ebus.devices"])
+    inner = json.loads(envelope["result"]["content"][0]["text"])
+    inner["data"][0][field] = value
+    envelope["result"]["content"][0]["text"] = validator.canonical(inner).decode(
+        "utf-8"
+    )
+    payloads["ebus.devices"] = validator.canonical(envelope)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
 
 
 @pytest.mark.parametrize("confirmed_count", [0, 1])


### PR DESCRIPTION
Closes #412.

## RED/GREEN
- RED `559a3e6d813ed86ac91e42c3adf569b69b852764`: focused falsifiers expose rejection of normal `corroborated_pending` passive addresses.
- GREEN `f7197a1`: project only complete `identity_confirmed` rows while retaining every raw row in the immutable source root.

## Validation
- `python3 -m pytest -q tests/test_multi_runtime_live_coexistence_contract.py` -> 191 passed
- `python3 -m pytest -q tests/test_captured_multi_leaf_promotion_contract.py tests/test_leaf_promotion_dossier_contract.py` -> 112 passed
- `git diff --check`
- exact private 0.6.38 PRE/POST assembly advances through source capture and now stops only at the separately serialized runtime-provenance gate.

## Boundaries
No evidence bytes, Fronius/SunSpec files, GraphQL/Portal/HA consumer surface, or M9 scope changed.
