### PR TITLE
MSP-08: project stable semantic registry scope

### DIFF
--- a/docs/platform/multi-runtime-coexistence-no-drift-v1.md
+++ b/docs/platform/multi-runtime-coexistence-no-drift-v1.md
@@ -177,7 +177,10 @@ G18 view contains every promoted eBUS leaf except the exact indexed
 program/day/slot fields `StartHour`, `StartMinute`, `EndHour`, `EndMinute`,
 `TemperatureC`, and `TemperatureRaw`, whose materialization is transient cache
 state rather than a stable consumer contract. Other `/schedules/` leaves remain
-protected. Every raw leaf is validated before that deterministic projection,
+protected. Array indices use canonical decimal spelling (`0` or a non-zero
+digit followed by decimal digits); leading-zero forms fail closed. Raw leaf
+paths must arrive in strictly increasing bytewise order, so the projection
+cannot normalize an ordering regression. Every raw leaf is validated before that deterministic projection,
 and any non-excluded drift remains a
 terminal consumer-drift failure. The complete protected
 payload is source-bound: `data` comes from the projector, `meta.captured_at`

--- a/docs/platform/multi-runtime-coexistence-no-drift-v1.md
+++ b/docs/platform/multi-runtime-coexistence-no-drift-v1.md
@@ -173,10 +173,12 @@ and compares each derived payload byte-for-byte with the corresponding evidence
 payload. Debug, Portal, routing, and semantic-registry inputs are captured
 directly; they are not inferred from neighboring views. The complete raw
 semantic registry remains bound in the private source manifest. Its protected
-G18 view contains every promoted eBUS leaf except the explicitly declared
-`/schedules/` prefix, whose program/day slot materialization is transient cache
-state rather than a stable consumer contract. Every raw leaf is validated
-before that deterministic projection, and any non-schedule drift remains a
+G18 view contains every promoted eBUS leaf except the exact indexed
+program/day/slot fields `StartHour`, `StartMinute`, `EndHour`, `EndMinute`,
+`TemperatureC`, and `TemperatureRaw`, whose materialization is transient cache
+state rather than a stable consumer contract. Other `/schedules/` leaves remain
+protected. Every raw leaf is validated before that deterministic projection,
+and any non-excluded drift remains a
 terminal consumer-drift failure. The complete protected
 payload is source-bound: `data` comes from the projector, `meta.captured_at`
 comes from the manifest window, and `meta.auth_subject` is the deterministic
@@ -258,7 +260,7 @@ order. A caller cannot select a subset.
 | `debug.ebus` | Existing eBUS debug output |
 | `portal.ebus.bootstrap` | Portal bootstrap and eBUS projection |
 | `command.routing` | Existing command routing |
-| `semantic.registry` | Existing promoted eBUS registry outside explicitly declared volatile `/schedules/` cache materialization |
+| `semantic.registry` | Existing promoted eBUS registry outside the exact declared volatile program/day/slot field grammar |
 | `mcp.eebus.v1.contract` | Stable `eebus.v1` V1 contract |
 
 Every view binds its exact capture path, JSON media type, unmodified payload,

--- a/docs/platform/multi-runtime-coexistence-no-drift-v1.md
+++ b/docs/platform/multi-runtime-coexistence-no-drift-v1.md
@@ -170,8 +170,14 @@ Private verification opens every source as a bounded regular file from a
 fixed-name, no-symlink root, rejects devices such as FIFOs, recomputes every
 binding, derives all eleven protected views with the closed reference projector,
 and compares each derived payload byte-for-byte with the corresponding evidence
-payload. Debug, Portal, routing, and semantic-registry payloads are captured
-directly; they are not inferred from neighboring views. The complete protected
+payload. Debug, Portal, routing, and semantic-registry inputs are captured
+directly; they are not inferred from neighboring views. The complete raw
+semantic registry remains bound in the private source manifest. Its protected
+G18 view contains every promoted eBUS leaf except the explicitly declared
+`/schedules/` prefix, whose program/day slot materialization is transient cache
+state rather than a stable consumer contract. Every raw leaf is validated
+before that deterministic projection, and any non-schedule drift remains a
+terminal consumer-drift failure. The complete protected
 payload is source-bound: `data` comes from the projector, `meta.captured_at`
 comes from the manifest window, and `meta.auth_subject` is the deterministic
 public-redacted identifier of the manifest-bound effective auth scope. A
@@ -252,7 +258,7 @@ order. A caller cannot select a subset.
 | `debug.ebus` | Existing eBUS debug output |
 | `portal.ebus.bootstrap` | Portal bootstrap and eBUS projection |
 | `command.routing` | Existing command routing |
-| `semantic.registry` | Existing promoted semantic registry |
+| `semantic.registry` | Existing promoted eBUS registry outside explicitly declared volatile `/schedules/` cache materialization |
 | `mcp.eebus.v1.contract` | Stable `eebus.v1` V1 contract |
 
 Every view binds its exact capture path, JSON media type, unmodified payload,

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1666,6 +1666,12 @@ def _source_portal(raw: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+VOLATILE_SCHEDULE_LEAF = re.compile(
+    r"^/schedules/Programs/[0-9]+/Days/[0-9]+/Slots/[0-9]+/"
+    r"(?:StartHour|StartMinute|EndHour|EndMinute|TemperatureC|TemperatureRaw)$"
+)
+
+
 def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
     if raw.get("authority") != "ebus.promoted" or set(raw) != {
         "authority",
@@ -1694,7 +1700,7 @@ def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
         ):
             fail("provenance.source_capture")
         seen.add(path)
-        if not path.startswith("/schedules/"):
+        if VOLATILE_SCHEDULE_LEAF.fullmatch(path) is None:
             projected.append(copy.deepcopy(item))
     projected.sort(key=lambda item: item["path"])
     if not projected:
@@ -1702,8 +1708,11 @@ def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
     return {
         "authority": "ebus.promoted",
         "selection": {
-            "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_materialization",
-            "excluded_prefixes": ["/schedules/"],
+            "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_slot_materialization",
+            "excluded_path_pattern": (
+                "/schedules/Programs/<index>/Days/<index>/Slots/<index>/"
+                "<StartHour|StartMinute|EndHour|EndMinute|TemperatureC|TemperatureRaw>"
+            ),
             "selected_count": len(projected),
         },
         "leaves": projected,

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1666,6 +1666,50 @@ def _source_portal(raw: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
+    if raw.get("authority") != "ebus.promoted" or set(raw) != {
+        "authority",
+        "leaves",
+    }:
+        fail("provenance.source_capture")
+    leaves = raw["leaves"]
+    if not isinstance(leaves, list) or not leaves:
+        fail("provenance.source_capture")
+    projected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in leaves:
+        if not isinstance(item, dict) or set(item) != {
+            "path",
+            "promotion_state",
+            "source",
+        }:
+            fail("provenance.source_capture")
+        path = item["path"]
+        if (
+            not isinstance(path, str)
+            or not path.startswith("/")
+            or path in seen
+            or item["promotion_state"] != "PROMOTED"
+            or item["source"] != "ebus"
+        ):
+            fail("provenance.source_capture")
+        seen.add(path)
+        if not path.startswith("/schedules/"):
+            projected.append(copy.deepcopy(item))
+    projected.sort(key=lambda item: item["path"])
+    if not projected:
+        fail("provenance.source_capture")
+    return {
+        "authority": "ebus.promoted",
+        "selection": {
+            "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_materialization",
+            "excluded_prefixes": ["/schedules/"],
+            "selected_count": len(projected),
+        },
+        "leaves": projected,
+    }
+
+
 def _source_project_views(inputs: dict[str, bytes]) -> dict[str, Any]:
     tools = _decode_source_json(inputs["tools.list"])
     devices_response = _source_inner_mcp(inputs["ebus.devices"])
@@ -1783,7 +1827,7 @@ def _source_project_views(inputs: dict[str, bytes]) -> dict[str, Any]:
             "debug.ebus": debug_raw,
             "portal.ebus.bootstrap": _source_portal(portal_raw),
             "command.routing": routes_raw,
-            "semantic.registry": semantic_registry_raw,
+            "semantic.registry": _source_semantic_registry(semantic_registry_raw),
             "mcp.eebus.v1.contract": {
                 "namespace": "eebus.v1",
                 "public_v2": False,

--- a/scripts/validate_multi_runtime_coexistence.py
+++ b/scripts/validate_multi_runtime_coexistence.py
@@ -1666,7 +1666,13 @@ def _source_portal(raw: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+SCHEDULE_INDEX = r"(?:0|[1-9][0-9]*)"
 VOLATILE_SCHEDULE_LEAF = re.compile(
+    rf"^/schedules/Programs/{SCHEDULE_INDEX}/Days/{SCHEDULE_INDEX}/"
+    rf"Slots/{SCHEDULE_INDEX}/"
+    r"(?:StartHour|StartMinute|EndHour|EndMinute|TemperatureC|TemperatureRaw)$"
+)
+NONCANONICAL_VOLATILE_SCHEDULE_LEAF = re.compile(
     r"^/schedules/Programs/[0-9]+/Days/[0-9]+/Slots/[0-9]+/"
     r"(?:StartHour|StartMinute|EndHour|EndMinute|TemperatureC|TemperatureRaw)$"
 )
@@ -1683,6 +1689,7 @@ def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
         fail("provenance.source_capture")
     projected: list[dict[str, Any]] = []
     seen: set[str] = set()
+    previous_path: str | None = None
     for item in leaves:
         if not isinstance(item, dict) or set(item) != {
             "path",
@@ -1699,10 +1706,17 @@ def _source_semantic_registry(raw: dict[str, Any]) -> dict[str, Any]:
             or item["source"] != "ebus"
         ):
             fail("provenance.source_capture")
+        if previous_path is not None and path <= previous_path:
+            fail("provenance.source_capture")
+        if (
+            NONCANONICAL_VOLATILE_SCHEDULE_LEAF.fullmatch(path) is not None
+            and VOLATILE_SCHEDULE_LEAF.fullmatch(path) is None
+        ):
+            fail("provenance.source_capture")
         seen.add(path)
+        previous_path = path
         if VOLATILE_SCHEDULE_LEAF.fullmatch(path) is None:
             projected.append(copy.deepcopy(item))
-    projected.sort(key=lambda item: item["path"])
     if not projected:
         fail("provenance.source_capture")
     return {

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1242,6 +1242,7 @@ def test_msp08_source_projection_declares_and_excludes_volatile_schedule_leaves(
             },
         ]
     )
+    registry["leaves"].sort(key=lambda item: item["path"])
     payloads["semantic.registry"] = validator.canonical(registry)
 
     projected = validator._source_project_views(payloads)["views"][
@@ -1314,12 +1315,73 @@ def test_msp08_source_projection_preserves_stable_schedule_leaf_drift() -> None:
     after_registry["leaves"].append(
         {"path": "/schedules/disabled", "promotion_state": "PROMOTED", "source": "ebus"}
     )
+    before_registry["leaves"].sort(key=lambda item: item["path"])
+    after_registry["leaves"].sort(key=lambda item: item["path"])
     before["semantic.registry"] = validator.canonical(before_registry)
     after["semantic.registry"] = validator.canonical(after_registry)
 
     before_view = validator._source_project_views(before)["views"]["semantic.registry"]
     after_view = validator._source_project_views(after)["views"]["semantic.registry"]
     assert validator.canonical(before_view) != validator.canonical(after_view)
+
+
+def test_msp08_source_projection_rejects_reordered_semantic_leaves() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"].reverse()
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
+
+
+@pytest.mark.parametrize(
+    "terminal",
+    [
+        "StartHour",
+        "StartMinute",
+        "EndHour",
+        "EndMinute",
+        "TemperatureC",
+        "TemperatureRaw",
+    ],
+)
+def test_msp08_source_projection_excludes_each_canonical_volatile_terminal(
+    terminal: str,
+) -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    path = f"/schedules/Programs/1/Days/0/Slots/2/{terminal}"
+    registry["leaves"].append(
+        {"path": path, "promotion_state": "PROMOTED", "source": "ebus"}
+    )
+    registry["leaves"].sort(key=lambda item: item["path"])
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    projected = validator._source_project_views(payloads)["views"]["semantic.registry"]
+    assert path not in {item["path"] for item in projected["leaves"]}
+
+
+def test_msp08_source_projection_rejects_noncanonical_schedule_index() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"].append(
+        {
+            "path": "/schedules/Programs/01/Days/0/Slots/0/StartHour",
+            "promotion_state": "PROMOTED",
+            "source": "ebus",
+        }
+    )
+    registry["leaves"].sort(key=lambda item: item["path"])
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
 
 
 def test_msp08_source_projection_rejects_duplicate_semantic_leaf() -> None:

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1249,13 +1249,17 @@ def test_msp08_source_projection_declares_and_excludes_volatile_schedule_leaves(
     ]
     assert projected["authority"] == "ebus.promoted"
     assert projected["selection"] == {
-        "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_materialization",
-        "excluded_prefixes": ["/schedules/"],
+        "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_slot_materialization",
+        "excluded_path_pattern": (
+            "/schedules/Programs/<index>/Days/<index>/Slots/<index>/"
+            "<StartHour|StartMinute|EndHour|EndMinute|TemperatureC|TemperatureRaw>"
+        ),
         "selected_count": 2,
     }
     assert len(projected["leaves"]) == 2
     assert all(
-        not item["path"].startswith("/schedules/") for item in projected["leaves"]
+        not item["path"].startswith("/schedules/Programs/")
+        for item in projected["leaves"]
     )
 
 
@@ -1296,6 +1300,56 @@ def test_msp08_source_projection_preserves_non_schedule_leaf_drift() -> None:
         "semantic.registry"
     ]
     assert validator.canonical(before_view) != validator.canonical(after_view)
+
+
+def test_msp08_source_projection_preserves_stable_schedule_leaf_drift() -> None:
+    validator = validator_module()
+    before = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    after = source_payloads(validator, "after", "2026-08-12T08:05:00Z")
+    before_registry = json.loads(before["semantic.registry"])
+    after_registry = json.loads(after["semantic.registry"])
+    before_registry["leaves"].append(
+        {"path": "/schedules/enabled", "promotion_state": "PROMOTED", "source": "ebus"}
+    )
+    after_registry["leaves"].append(
+        {"path": "/schedules/disabled", "promotion_state": "PROMOTED", "source": "ebus"}
+    )
+    before["semantic.registry"] = validator.canonical(before_registry)
+    after["semantic.registry"] = validator.canonical(after_registry)
+
+    before_view = validator._source_project_views(before)["views"]["semantic.registry"]
+    after_view = validator._source_project_views(after)["views"]["semantic.registry"]
+    assert validator.canonical(before_view) != validator.canonical(after_view)
+
+
+def test_msp08_source_projection_rejects_duplicate_semantic_leaf() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"].append(dict(registry["leaves"][0]))
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
+
+
+def test_msp08_source_projection_rejects_schedule_only_registry() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"] = [
+        {
+            "path": "/schedules/Programs/1/Days/0/Slots/0/StartHour",
+            "promotion_state": "PROMOTED",
+            "source": "ebus",
+        }
+    ]
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1224,6 +1224,41 @@ def test_msp08_source_projection_rejects_uncontracted_portal_version() -> None:
     assert str(error.value) == "provenance.source_capture"
 
 
+def test_msp08_source_projection_declares_and_excludes_volatile_schedule_leaves() -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"].extend(
+        [
+            {
+                "path": "/schedules/Programs/1/Days/0/Slots/0/StartHour",
+                "promotion_state": "PROMOTED",
+                "source": "ebus",
+            },
+            {
+                "path": "/schedules/Programs/2/Days/4/Slots/0/EndMinute",
+                "promotion_state": "PROMOTED",
+                "source": "ebus",
+            },
+        ]
+    )
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    projected = validator._source_project_views(payloads)["views"][
+        "semantic.registry"
+    ]
+    assert projected["authority"] == "ebus.promoted"
+    assert projected["selection"] == {
+        "criteria": "all_promoted_ebus_leaves_outside_volatile_schedule_materialization",
+        "excluded_prefixes": ["/schedules/"],
+        "selected_count": 2,
+    }
+    assert len(projected["leaves"]) == 2
+    assert all(
+        not item["path"].startswith("/schedules/") for item in projected["leaves"]
+    )
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/test_multi_runtime_live_coexistence_contract.py
+++ b/tests/test_multi_runtime_live_coexistence_contract.py
@@ -1260,6 +1260,45 @@ def test_msp08_source_projection_declares_and_excludes_volatile_schedule_leaves(
 
 
 @pytest.mark.parametrize(
+    "mutation",
+    [
+        {"source": "eebus"},
+        {"promotion_state": "CANDIDATE"},
+        {"path": "relative/path"},
+    ],
+)
+def test_msp08_source_projection_rejects_malformed_semantic_leaf(
+    mutation: dict[str, str],
+) -> None:
+    validator = validator_module()
+    payloads = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    registry = json.loads(payloads["semantic.registry"])
+    registry["leaves"][0].update(mutation)
+    payloads["semantic.registry"] = validator.canonical(registry)
+
+    with pytest.raises(Exception) as error:
+        validator._source_project_views(payloads)
+    assert str(error.value) == "provenance.source_capture"
+
+
+def test_msp08_source_projection_preserves_non_schedule_leaf_drift() -> None:
+    validator = validator_module()
+    before = source_payloads(validator, "before", "2026-08-12T08:00:00Z")
+    after = source_payloads(validator, "after", "2026-08-12T08:05:00Z")
+    registry = json.loads(after["semantic.registry"])
+    registry["leaves"][0]["path"] = "/dhw/non_schedule_drift"
+    after["semantic.registry"] = validator.canonical(registry)
+
+    before_view = validator._source_project_views(before)["views"][
+        "semantic.registry"
+    ]
+    after_view = validator._source_project_views(after)["views"][
+        "semantic.registry"
+    ]
+    assert validator.canonical(before_view) != validator.canonical(after_view)
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     [
         ("discovery_source", "unexpected_source"),


### PR DESCRIPTION
Closes #414.

## RED/GREEN
- RED `1f75d93`: exposed `/schedules/*` cache materialization entering the G18 protected registry.
- GREEN: validates every raw leaf, retains complete registry bytes in the private manifest, and projects all 405 promoted eBUS leaves outside the declared volatile `/schedules/` prefix.

## Exact 0.6.38 evidence
- PRE manifest: `sha256:4a2af0a5ef482555629fc65aabfc79e06ba376ce0a0b30fe15bff61cc19841b9`, 3235 bytes, 16 bound files.
- POST manifest: `sha256:0c46a8d49c1a4003ef09e778801393e75aaa37d53d7d2ab643cab58dc810d2ff`, 3253 bytes, 16 bound files.
- Restart changed process identity; eeBUS stayed connected; eBUS returned to 4 confirmed identities, `LIVE_READY`, active admission, non-degraded, and 630 raw promoted leaves.
- All eleven projected `data` payloads are byte-identical PRE/POST; semantic.registry selects 405 stable leaves in both windows.

## Validation
- `python3 -m pytest -q tests/test_multi_runtime_live_coexistence_contract.py` -> 201 passed
- adjacent captured-promotion/dossier suites -> 112 passed
- `git diff --check`

No raw evidence edits, cross-window intersection, protocol-neutral freshness policy, consumer promotion, Fronius/SunSpec, or M9 scope.
