### PR TITLE
Document HA zone-parent continuity during sparse inventory

### DIFF
--- a/docs/platform/promoted-semantic-consumers-v1.md
+++ b/docs/platform/promoted-semantic-consumers-v1.md
@@ -109,16 +109,16 @@ eBUS radio inventory. A live radio match is authoritative. If no live match is
 available for a zone whose mapping selects a radio controller, Home Assistant
 may retain only a persisted binding for that same config entry, climate unique
 id, Helianthus radio identifier, and validating radio mapping. The unreleased
-pre-V1 migration may seed this binding once from an existing association because
-the prior implementation could attach a climate to a radio device only after a
-live match. Later reloads must use the persisted mapping rather than infer a new
-one from registry attachment. Retention is allowed only when the coordinator
-explicitly marks the current inventory snapshot incomplete; a complete snapshot
-with no match leaves the zone unresolved. The fallback cannot create a parent
-for a new unresolved zone, use a non-radio device, or override a changed mapping.
-When a later live radio match resolves a different physical parent, the live
-mapping replaces and persists over the retained one before the config entry
-reloads for re-parenting.
+pre-V1 registry attachment is not sufficient provenance and must not bootstrap
+the binding automatically. A lab or operator migration must write a binding only
+from separately archived live evidence. Later reloads use the persisted mapping
+rather than infer a new one from registry attachment. Retention is allowed only
+when the coordinator explicitly marks the current inventory snapshot incomplete;
+a complete snapshot with no match leaves the zone unresolved. The fallback
+cannot create a parent for a new unresolved zone, use a non-radio device, or
+override a changed mapping. When a later live radio match resolves a different
+physical parent, the live mapping replaces and persists over the retained one
+before the config entry reloads for re-parenting.
 
 ## Acceptance
 

--- a/docs/platform/promoted-semantic-consumers-v1.md
+++ b/docs/platform/promoted-semantic-consumers-v1.md
@@ -104,6 +104,15 @@ remain unchanged. Capability booleans are diagnostic attributes until a separate
 approved command contract exists. `overrun_active` may be a read-only binary
 sensor because it is an observed state, not a command.
 
+Zone-parent resolution preserves device continuity across a temporarily sparse
+eBUS radio inventory. A live radio match is authoritative. If no live match is
+available for a zone whose mapping selects a radio controller, Home Assistant
+may retain the Helianthus radio parent already attached to that climate entity.
+This fallback cannot create a parent for a new unresolved zone, use a non-radio
+device, or override a mapping that no longer selects radio control. When a
+complete live inventory later resolves a different physical parent, the live
+mapping replaces the retained one and the config entry reloads for re-parenting.
+
 ## Acceptance
 
 M9 is complete only when:

--- a/docs/platform/promoted-semantic-consumers-v1.md
+++ b/docs/platform/promoted-semantic-consumers-v1.md
@@ -107,12 +107,18 @@ sensor because it is an observed state, not a command.
 Zone-parent resolution preserves device continuity across a temporarily sparse
 eBUS radio inventory. A live radio match is authoritative. If no live match is
 available for a zone whose mapping selects a radio controller, Home Assistant
-may retain only that same config entry and climate entity's previously
-live-validated Helianthus radio parent, and only while the radio mapping remains
-the startup-validated value. This fallback cannot create a parent for a new
-unresolved zone, use a non-radio device, or override a changed mapping. When a
-later live radio match resolves a different physical parent, the live mapping
-replaces the retained one and the config entry reloads for re-parenting.
+may retain only a persisted binding for that same config entry, climate unique
+id, Helianthus radio identifier, and validating radio mapping. The unreleased
+pre-V1 migration may seed this binding once from an existing association because
+the prior implementation could attach a climate to a radio device only after a
+live match. Later reloads must use the persisted mapping rather than infer a new
+one from registry attachment. Retention is allowed only when the coordinator
+explicitly marks the current inventory snapshot incomplete; a complete snapshot
+with no match leaves the zone unresolved. The fallback cannot create a parent
+for a new unresolved zone, use a non-radio device, or override a changed mapping.
+When a later live radio match resolves a different physical parent, the live
+mapping replaces and persists over the retained one before the config entry
+reloads for re-parenting.
 
 ## Acceptance
 

--- a/docs/platform/promoted-semantic-consumers-v1.md
+++ b/docs/platform/promoted-semantic-consumers-v1.md
@@ -107,11 +107,12 @@ sensor because it is an observed state, not a command.
 Zone-parent resolution preserves device continuity across a temporarily sparse
 eBUS radio inventory. A live radio match is authoritative. If no live match is
 available for a zone whose mapping selects a radio controller, Home Assistant
-may retain the Helianthus radio parent already attached to that climate entity.
-This fallback cannot create a parent for a new unresolved zone, use a non-radio
-device, or override a mapping that no longer selects radio control. When a
-complete live inventory later resolves a different physical parent, the live
-mapping replaces the retained one and the config entry reloads for re-parenting.
+may retain only that same config entry and climate entity's previously
+live-validated Helianthus radio parent, and only while the radio mapping remains
+the startup-validated value. This fallback cannot create a parent for a new
+unresolved zone, use a non-radio device, or override a changed mapping. When a
+later live radio match resolves a different physical parent, the live mapping
+replaces the retained one and the config entry reloads for re-parenting.
 
 ## Acceptance
 


### PR DESCRIPTION
Closes #424

Companion doc gate for Project-Helianthus/helianthus-ha-integration#225.

Documents live-authoritative zone-parent resolution, validated-parent continuity under sparse radio inventory, fail-closed behavior for new zones, and re-parenting when complete live inventory returns.

Validation: full `scripts/ci_local.sh` passed with M6.25 external inputs pinned to their declared commits.